### PR TITLE
Update CI: add go 1.18 and 1.19

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -6,10 +6,10 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.20.5' ]
+        go-version: ['1.18', '1.19', '1.20.5' ]
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/analysis/backtrace/backtrace_test.go
+++ b/analysis/backtrace/backtrace_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build go1.20
+
 package backtrace_test
 
 import (


### PR DESCRIPTION
*Description of changes:*
Small changes to the CI to test on different Go versions.
