### PR TITLE
Fix handling closures in loops

### DIFF
--- a/analysis/backtrace/backtrace.go
+++ b/analysis/backtrace/backtrace.go
@@ -596,7 +596,7 @@ func addNext(s *df.AnalyzerState,
 	s.Logger.Tracef("\tdepth: %v\n", cur.depth)
 
 	// Stop conditions
-	if seen[newNode.Key()] || trace.GetLassoHandle() != nil || s.Config.ExceedsMaxDepth(cur.depth) {
+	if seen[newNode.Key()] || trace.GetLassoHandle() != nil || closureTrace.GetLassoHandle() != nil || s.Config.ExceedsMaxDepth(cur.depth) {
 		s.Logger.Tracef("\tstopping...")
 		return stack
 	}

--- a/analysis/taint/dataflow_visitor.go
+++ b/analysis/taint/dataflow_visitor.go
@@ -586,7 +586,7 @@ func (v *Visitor) addNext(s *df.AnalyzerState,
 	}
 
 	// Second set of stopping conditions: the escape context is unchanged on a loop path
-	if nextTrace.GetLassoHandle() != nil && !escapeContextUpdated {
+	if (nextTrace.GetLassoHandle() != nil || nextClosureTrace.GetLassoHandle() != nil) && !escapeContextUpdated {
 		return que
 	}
 

--- a/testdata/src/taint/closures/main.go
+++ b/testdata/src/taint/closures/main.go
@@ -362,6 +362,17 @@ func example16pre(x *string) func(string) string {
 	return parenthesize
 }
 
+func example17() {
+	data := "ok"
+	a := func() { data = "ok" }
+	b := func() { data = source() } // @Source(example17)
+	for _, f := range []func(){b, a} {
+		f()
+	}
+
+	sink(data) // @Sink(example17)
+}
+
 func taintPre(pre *string) {
 	*pre = source() // @Source(example16)
 }
@@ -386,4 +397,5 @@ func main() {
 	example14()
 	example15()
 	example16()
+	example17()
 }


### PR DESCRIPTION
Fixes a small bug where the taint analysis wasn't terminating when visiting bound and free variables inside of a loop
