### PR TITLE
Fix escape test (iterating over changing map)

### DIFF
--- a/analysis/escape/escape.go
+++ b/analysis/escape/escape.go
@@ -621,7 +621,7 @@ func (ea *functionAnalysisState) transferCallStaticCallee(instrType *ssa.Call, g
 				freeVars = append(freeVars, ea.nodes.ValueNode(fv))
 			}
 		}
-		g.Call(g, nil, args, freeVars, rets, summary.finalGraph)
+		g.Call(g.Clone(), nil, args, freeVars, rets, summary.finalGraph)
 	} else {
 		// If we didn't find a summary or didn't know the callee, use the arbitrary function assumption.
 		// Crucially, this is different from a function that will have a summary but we just haven't


### PR DESCRIPTION
Fixes nondeterminism in escape analysis caused by iterating over map while updating it, which results in some edges being included/excluded based on the specific order.

The flaky test was `TestInterproceduralEscape/testAbstractFunction`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
