### PR TITLE
Update build-analyze-test workflow with new actions + go versions

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -17,13 +17,13 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: ['1.20.12', '1.21.5' ]
+        go-version: ['1.20', '1.21' ]
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Setup dependencies


### PR DESCRIPTION
- Bump the checkout and setup-go version, older version is not supported anymore.
- Remove patch version in Go versions.

