### PR TITLE
Fix Calling Context Computation

### DIFF
--- a/analysis/dataflow/callctx.go
+++ b/analysis/dataflow/callctx.go
@@ -24,7 +24,8 @@ import (
 	cg "golang.org/x/tools/go/callgraph"
 )
 
-type ReversedCallStack = CallStack
+// reversedCallStack is a unary tree that roots at a particular call and stores the next call in the call stack as its child
+type reversedCallStack = CallStack
 
 // GetAllCallingContexts returns all the possible loop-free calling contexts of a CallNode in the state
 func GetAllCallingContexts(s *AnalyzerState, n *CallNode) []*CallStack {
@@ -46,14 +47,14 @@ func GetAllCallingContexts(s *AnalyzerState, n *CallNode) []*CallStack {
 	}
 
 	// backward analysis from n to an entry point
-	type ReversedCallStackKey = string
-	var que []*ReversedCallStack
+	type reversedCallStackKey = string
+	var que []*reversedCallStack
 	/** keeps track of which reverse call stacks we have already inserted into the queue at some point */
-	queInserted := map[ReversedCallStackKey]bool{}
+	queInserted := map[reversedCallStackKey]bool{}
 	initElem := NewNodeTree(n)
 	que = append(que, initElem)
 	queInserted[initElem.key] = true
-	var reversedResults []*ReversedCallStack
+	var reversedResults []*reversedCallStack
 
 	for len(que) > 0 {
 		elt := que[0]
@@ -116,7 +117,7 @@ func hasReachedContextLimit(stack *CallStack, limit int) bool {
 	return false
 }
 
-func reverseCallStack(s *ReversedCallStack) *CallStack {
+func reverseCallStack(s *reversedCallStack) *CallStack {
 	if s == nil {
 		return nil
 	}

--- a/analysis/dataflow/inter_procedural_test.go
+++ b/analysis/dataflow/inter_procedural_test.go
@@ -38,6 +38,7 @@ func TestCrossFunctionFlowGraph(t *testing.T) {
 	// Loading the program for testdata/src/dataflow/summaries/main.go
 	program, _ := analysistest.LoadTest(t, dir, []string{})
 	cfg := config.NewDefault()
+	cfg.MaxDepth = 1 // limit context of each source to avoid timeouts
 	state, err := dataflow.NewInitializedAnalyzerState(config.NewLogGroup(cfg), cfg, program)
 	if err != nil {
 		t.Fatalf("failed to build program analysis state: %v", err)


### PR DESCRIPTION
Depending on the traversal order, the computation of calling contexts might get stopped early on as a call node is not considered if it has already been visited. However, the same call node might occur in different calling contexts. Thus, this PR adapts the computation of calling contexts, to ignore a call node for a particular calling context only if this call node already occurs in this calling context, i.e., is a recursive call.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
