### PR TITLE
Changing ExplicitFlowsOnly to FailOnImplicitFlow

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: ['1.20', '1.21', '1.22' ]
+        go-version: ['1.20', '1.21' ]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: ['1.20', '1.21' ]
+        go-version: ['1.20', '1.21', '1.22' ]
     runs-on: ubuntu-latest
 
     steps:

--- a/analysis/config/config.go
+++ b/analysis/config/config.go
@@ -144,9 +144,10 @@ type TaintSpec struct {
 	// Filters contains a list of filters that can be used by analyses
 	Filters []CodeIdentifier
 
-	// ExplicitFlowOnly indicates whether the taint analysis should only consider explicit data flows.
-	// This should be set to true when proving a data flow property instead of an information flow property.
-	ExplicitFlowOnly bool `yaml:"explicit-flow-only" json:"explicit-flow-only"`
+	// FailOnImplicitFlow indicates whether the taint analysis should fail when tainted data implicitly changes
+	// the control flow of a program. This should be set to false when proving a data flow property,
+	// and set to true when proving an information flow property.
+	FailOnImplicitFlow bool `yaml:"fail-on-implicit-flow" json:"fail-on-implicit-flow"`
 }
 
 // SlicingSpec contains code identifiers that identify a specific program slicing / backwards dataflow analysis spec.
@@ -346,7 +347,8 @@ func Load(filename string) (*Config, error) {
 	}
 
 	for funcName, summaryType := range cfg.EscapeConfig.Functions {
-		if !(summaryType == EscapeBehaviorUnknown || summaryType == EscapeBehaviorNoop || summaryType == EscapeBehaviorSummarize || strings.HasPrefix(summaryType, "reflect:")) {
+		if !(summaryType == EscapeBehaviorUnknown || summaryType == EscapeBehaviorNoop ||
+			summaryType == EscapeBehaviorSummarize || strings.HasPrefix(summaryType, "reflect:")) {
 			return nil, fmt.Errorf("escape summary type for function %s is not recognized: %s", funcName, summaryType)
 		}
 	}

--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -304,7 +304,7 @@ func TestLoadMisc(t *testing.T) {
 						{"", "some/other/package", "", "", "", "OneField", "ThatStruct", "", "", nil},
 						{"", "some/other/package", "Interface", "", "", "", "", "", "", nil},
 					},
-					ExplicitFlowOnly: true,
+					FailOnImplicitFlow: false,
 				},
 			},
 			Options: Options{

--- a/analysis/taint/dataflow_visitor.go
+++ b/analysis/taint/dataflow_visitor.go
@@ -643,7 +643,7 @@ func (v *Visitor) Visit(s *df.AnalyzerState, source df.NodeWithTrace) {
 		case *df.IfNode:
 			// If only explicit taint flows should be tracked,
 			// then don't track flow inside of conditionals (information flow)
-			if v.taintSpec.ExplicitFlowOnly {
+			if !v.taintSpec.FailOnImplicitFlow {
 				break
 			}
 

--- a/doc/01_taint.md
+++ b/doc/01_taint.md
@@ -122,12 +122,12 @@ The configuration contains some specific fields that allow users to tune how the
 
 #### Implicit flows
 Some flows can be implicit: for example, branching on tainted data. See the `implicit-flow` test for an example.
-By default, the taint analysis will produce an error if tainted data is branched on.
-If the tool should only track explicit taint flows, set the `explicit-flow-only` option to `true`:
+By default, the taint analysis will not produce an error if tainted data is branched on.
+If the tool should fail when control flow depends on tainted data, set the `explicit-flow-only` option to `true`:
 ```yaml
 taint-tracking-problems:
     -
-      fail-on-implicit-flow: false
+      fail-on-implicit-flow: true
 ```
 
 #### Filters

--- a/doc/01_taint.md
+++ b/doc/01_taint.md
@@ -127,7 +127,7 @@ If the tool should only track explicit taint flows, set the `explicit-flow-only`
 ```yaml
 taint-tracking-problems:
     -
-      explicit-flow-only: true
+      fail-on-implicit-flow: false
 ```
 
 #### Filters

--- a/doc/01_taint.md
+++ b/doc/01_taint.md
@@ -123,7 +123,7 @@ The configuration contains some specific fields that allow users to tune how the
 #### Implicit flows
 Some flows can be implicit: for example, branching on tainted data. See the `implicit-flow` test for an example.
 By default, the taint analysis will not produce an error if tainted data is branched on.
-If the tool should fail when control flow depends on tainted data, set the `explicit-flow-only` option to `true`:
+If the tool should fail when control flow depends on tainted data, set the `fail-on-implicit-flow` option to `true`:
 ```yaml
 taint-tracking-problems:
     -
@@ -291,7 +291,7 @@ func main() {
 }
 ```
 
-There is an "information leak" from `source` to `sink` because the individual bytes from `data` are copied over to `newData` without explicitly assigning any data from `data` to `newData`. To detect such implicit information flows, the taint analysis logs a warning when tainted data flows to a branch statement (`if`, `switch`, `select`, etc.) or loop (which involves a branch in SSA form). The analysis also returns an error.
+There is an "information leak" from `source` to `sink` because the individual bytes from `data` are copied over to `newData` without explicitly assigning any data from `data` to `newData`. When the `fail-on-implicit-flow` option of an analysis problem is set to true, the taint analysis logs a warning when tainted data flows to a branch statement (`if`, `switch`, `select`, etc.) or loop (which involves a branch in SSA form). The analysis also returns an error.
 
 > 📝 The taint analysis is unsound in the presence of other types of implicit data flows called [side channels](https://en.wikipedia.org/wiki/Side-channel_attack).
 

--- a/testdata/config-examples/config3.yaml
+++ b/testdata/config-examples/config3.yaml
@@ -23,4 +23,4 @@ taint-tracking-problems:
         - package: some/other/package
           interface: Interface
 
-      explicit-flow-only: true
+      fail-on-implicit-flow: false

--- a/testdata/src/taint/agent-example/config.yaml
+++ b/testdata/src/taint/agent-example/config.yaml
@@ -7,7 +7,6 @@ taint-tracking-problems:
       interface: "Logger"
     - method: "sink"
       package: "((main)|(command-line-arguments)|(agent-example))"
-   explicit-flow-only: true
 
 options:
     log-level: 4

--- a/testdata/src/taint/basic/config.yaml
+++ b/testdata/src/taint/basic/config.yaml
@@ -16,7 +16,6 @@ taint-tracking-problems:
   sanitizers:
     - package: "(main)|(command-line-arguments)"
       method: ".*(s|S)anitize[1-9]?"
-  explicit-flow-only: true
 
 options:
     verbose: true

--- a/testdata/src/taint/benchmark/config.yaml
+++ b/testdata/src/taint/benchmark/config.yaml
@@ -11,7 +11,6 @@ taint-tracking-problems:
       - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
-    explicit-flow-only: true
 
 options:
     report-paths: true

--- a/testdata/src/taint/builtins/config.yaml
+++ b/testdata/src/taint/builtins/config.yaml
@@ -7,6 +7,7 @@ taint-tracking-problems:
         method: "source[1-9]?"
     sinks:
       - method: "sink[1-9]?"
+    fail-on-implicit-flow: true
 
 options:
     report-summaries: true

--- a/testdata/src/taint/builtins_121/config.yaml
+++ b/testdata/src/taint/builtins_121/config.yaml
@@ -7,6 +7,7 @@ taint-tracking-problems:
         method: "source[1-9]?"
     sinks:
       - method: "sink[1-9]?"
+    fail-on-implicit-flow: true
 
 options:
     report-summaries: true

--- a/testdata/src/taint/closures/config.yaml
+++ b/testdata/src/taint/closures/config.yaml
@@ -9,7 +9,6 @@ taint-tracking-problems:
       - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
-    explicit-flow-only: true
 
 
 # Same as sinks

--- a/testdata/src/taint/closures_flowprecise/config.yaml
+++ b/testdata/src/taint/closures_flowprecise/config.yaml
@@ -9,7 +9,6 @@ taint-tracking-problems:
       - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
-    explicit-flow-only: true
 
 # Same as sinks
 slicing-problems:

--- a/testdata/src/taint/closures_paper/config.yaml
+++ b/testdata/src/taint/closures_paper/config.yaml
@@ -9,6 +9,7 @@ taint-tracking-problems:
       - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
+    fail-on-implicit-flow: true
 
 # Same as sinks
 slicing-problems:

--- a/testdata/src/taint/defers/config.yaml
+++ b/testdata/src/taint/defers/config.yaml
@@ -9,3 +9,4 @@ taint-tracking-problems:
       - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
+    fail-on-implicit-flow: true

--- a/testdata/src/taint/escape-integration/config.yaml
+++ b/testdata/src/taint/escape-integration/config.yaml
@@ -9,7 +9,6 @@ taint-tracking-problems:
       - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
-    explicit-flow-only: true
 
 options:
     report-paths: true

--- a/testdata/src/taint/example0/config.yaml
+++ b/testdata/src/taint/example0/config.yaml
@@ -11,6 +11,7 @@ taint-tracking-problems:
       - package: "(example0)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
+    fail-on-implicit-flow: true
 
 options:
     report-paths: true

--- a/testdata/src/taint/example1/config.yaml
+++ b/testdata/src/taint/example1/config.yaml
@@ -9,3 +9,4 @@ taint-tracking-problems:
       - package: "(main)|(command-line-arguments)|(example1)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
+    fail-on-implicit-flow: true

--- a/testdata/src/taint/example2/config.yaml
+++ b/testdata/src/taint/example2/config.yaml
@@ -4,7 +4,6 @@ options:
 # The package regex matches all possible ways the package name might appear depending on how the program is loaded
 taint-tracking-problems:
   -
-    explicit-flow-only: true
     sources:
       - package: "(example2)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Sources can be source1, source2, etc.

--- a/testdata/src/taint/fields/config.yaml
+++ b/testdata/src/taint/fields/config.yaml
@@ -11,7 +11,6 @@ taint-tracking-problems:
       - package: "(main)|(command-line-arguments)"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
-    explicit-flow-only: true
 
 options:
    report-paths: true

--- a/testdata/src/taint/globals/config.yaml
+++ b/testdata/src/taint/globals/config.yaml
@@ -7,7 +7,7 @@ taint-tracking-problems:
         method: "source[1-9]?"
     sinks:
       - method: "sink[1-9]?"
-    explicit-flow-only: true
+    fail-on-implicit-flow: false
 
 options:
     report-summaries: true

--- a/testdata/src/taint/implicit-flow/config.yaml
+++ b/testdata/src/taint/implicit-flow/config.yaml
@@ -8,6 +8,7 @@ taint-tracking-problems:
       - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
+    fail-on-implicit-flow: true
 
 options:
     # report-paths: true

--- a/testdata/src/taint/interface-summaries/config.yaml
+++ b/testdata/src/taint/interface-summaries/config.yaml
@@ -13,7 +13,6 @@ taint-tracking-problems:
       - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
-    explicit-flow-only: true
 
 dataflow-specs:
   - "dataflows.json"

--- a/testdata/src/taint/interfaces/config.yaml
+++ b/testdata/src/taint/interfaces/config.yaml
@@ -9,6 +9,7 @@ taint-tracking-problems:
       - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
+    fail-on-implicit-flow: true
 
 options:
     verbose: true

--- a/testdata/src/taint/intra-procedural/config.yaml
+++ b/testdata/src/taint/intra-procedural/config.yaml
@@ -8,7 +8,6 @@ taint-tracking-problems:
     sinks:
       - package: "((main)|(command-line-arguments))"
         method: sink[1-9]
-    explicit-flow-only: true
 
 options:
     skip-interprocedural: false

--- a/testdata/src/taint/panics/config.yaml
+++ b/testdata/src/taint/panics/config.yaml
@@ -6,3 +6,4 @@ taint-tracking-problems:
     sinks:
       - package: "(main|command-line-arguments)"
         method: "sink"
+    fail-on-implicit-flow: true

--- a/testdata/src/taint/parameters/config.yaml
+++ b/testdata/src/taint/parameters/config.yaml
@@ -10,7 +10,6 @@ taint-tracking-problems:
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
       - method: "Start"
-    explicit-flow-only: true
 
 options:
     verbose: true

--- a/testdata/src/taint/playground/config.yaml
+++ b/testdata/src/taint/playground/config.yaml
@@ -9,6 +9,7 @@ taint-tracking-problems:
       - package: "(main)|(command-line-arguments)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
+    fail-on-implicit-flow: true
 
 options:
     report-paths: true

--- a/testdata/src/taint/sample-escape/config.yaml
+++ b/testdata/src/taint/sample-escape/config.yaml
@@ -9,6 +9,7 @@ taint-tracking-problems:
       - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
+    fail-on-implicit-flow: true
 options:
     report-paths: true
     use-escape-analysis: true

--- a/testdata/src/taint/selects/config.yaml
+++ b/testdata/src/taint/selects/config.yaml
@@ -7,7 +7,6 @@ taint-tracking-problems:
         method: "source[1-9]?"
     sinks:
       - method: "sink[1-9]?"
-    explicit-flow-only: true
 
 options:
     report-summaries: true

--- a/testdata/src/taint/stdlib/config.yaml
+++ b/testdata/src/taint/stdlib/config.yaml
@@ -12,6 +12,7 @@ taint-tracking-problems:
     sanitizers:
       - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         method: ".*(s|S)anitize[1-9]?"
+    fail-on-implicit-flow: true
 
 options:
     report-paths: true

--- a/testdata/src/taint/stdlib_121/config.yaml
+++ b/testdata/src/taint/stdlib_121/config.yaml
@@ -12,7 +12,6 @@ taint-tracking-problems:
     sanitizers:
       - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         method: ".*(s|S)anitize[1-9]?"
-    explicit-flow-only: true
 
 options:
     verbose: true

--- a/testdata/src/taint/tuples/config.yaml
+++ b/testdata/src/taint/tuples/config.yaml
@@ -9,3 +9,4 @@ taint-tracking-problems:
       - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
+    fail-on-implicit-flow: true

--- a/testdata/src/taint/validators/config.yaml
+++ b/testdata/src/taint/validators/config.yaml
@@ -14,6 +14,7 @@ taint-tracking-problems:
     validators:
       - package: "(main)|(command-line-arguments)$"
         method: ".*Validate[1-9]?"
+    fail-on-implicit-flow: true
 
 options:
     verbose: true

--- a/testdata/src/taint/with-context/config.yaml
+++ b/testdata/src/taint/with-context/config.yaml
@@ -10,4 +10,3 @@ taint-tracking-problems:
       - package: "(main)|(command-line-arguments)|(example1)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
-    explicit-flow-only: true


### PR DESCRIPTION
This changes the configuration option from ExplicitFlowsOnly to FailOnImplicitFlow which reflects better what the analysis does (fails on implicit flows when on) and by default does expliticit flows only, which is what taint analyzers usually do. 
Also makes previous applications using the .drawio config file format backwards compatible.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
