### PR TITLE
Fixes in tuple handling + output format improvements

### DIFF
--- a/analysis/dataflow/function_summary_graph_nodes.go
+++ b/analysis/dataflow/function_summary_graph_nodes.go
@@ -151,13 +151,13 @@ func NodeKind(g GraphNode) string {
 func NodeSummary(g GraphNode) string {
 	switch x := g.(type) {
 	case *ParamNode:
-		return fmt.Sprintf("Parameter %q of %q", x.ssaNode.Name(), x.parent.Parent.Name())
+		return fmt.Sprintf("Parameter %q:%q of %q", x.ssaNode.Name(), x.Type().String(), x.parent.Parent.Name())
 	case *CallNode:
-		return fmt.Sprintf("Result of call to %q", x.Callee().Name())
+		return fmt.Sprintf("Result of call to %q:%q", x.Callee().Name(), x.Type().String())
 	case *CallNodeArg:
-		return fmt.Sprintf("Argument %v in call to %q", x.Index(), x.ParentNode().Callee().Name())
+		return fmt.Sprintf("Argument %v:%q in call to %q", x.Index(), x.Type().String(), x.ParentNode().Callee().Name())
 	case *ReturnValNode:
-		return fmt.Sprintf("Return value %d of %q", x.Index(), x.ParentName())
+		return fmt.Sprintf("Return value %d:%q of %q", x.Index(), x.Type().String(), x.ParentName())
 	case *ClosureNode:
 		return fmt.Sprintf("Closure")
 	case *BoundLabelNode:
@@ -580,7 +580,9 @@ func (a *ReturnValNode) SetLocs(_ LocSet) {}
 func (a *ReturnValNode) Index() int { return a.index }
 
 // Type returns the return type of the parent function
-func (a *ReturnValNode) Type() types.Type { return a.parent.ReturnType() }
+func (a *ReturnValNode) Type() types.Type {
+	return lang.TryTupleIndexType(a.parent.ReturnType(), a.index)
+}
 
 // Position returns the estimated position of the node in the source
 func (a *ReturnValNode) Position(c *AnalyzerState) token.Position {

--- a/analysis/dataflow/function_summary_graph_nodes.go
+++ b/analysis/dataflow/function_summary_graph_nodes.go
@@ -151,25 +151,27 @@ func NodeKind(g GraphNode) string {
 func NodeSummary(g GraphNode) string {
 	switch x := g.(type) {
 	case *ParamNode:
-		return fmt.Sprintf("Parameter %q:%q of %q", x.ssaNode.Name(), x.Type().String(), x.parent.Parent.Name())
+		return fmt.Sprintf("Parameter %q (type %q) of %q",
+			x.ssaNode.Name(), x.Type().String(), x.parent.Parent.Name())
 	case *CallNode:
-		return fmt.Sprintf("Result of call to %q:%q", x.Callee().Name(), x.Type().String())
+		return fmt.Sprintf("Result of call to %q (type %q)", x.Callee().Name(), x.Type().String())
 	case *CallNodeArg:
-		return fmt.Sprintf("Argument %v:%q in call to %q", x.Index(), x.Type().String(), x.ParentNode().Callee().Name())
+		return fmt.Sprintf("Argument %v (type %q) in call to %q",
+			x.Index(), x.Type().String(), x.ParentNode().Callee().Name())
 	case *ReturnValNode:
-		return fmt.Sprintf("Return value %d:%q of %q", x.Index(), x.Type().String(), x.ParentName())
+		return fmt.Sprintf("Return value %d (type %q) of %q", x.Index(), x.Type().String(), x.ParentName())
 	case *ClosureNode:
 		return fmt.Sprintf("Closure")
 	case *BoundLabelNode:
-		return fmt.Sprintf("Bound label")
+		return fmt.Sprintf("Bound label of type %q", x.targetInfo.Type().String())
 	case *SyntheticNode:
 		return fmt.Sprintf("Synthetic node")
 	case *BoundVarNode:
 		return "Bound variable"
 	case *FreeVarNode:
-		return "Free variable"
+		return fmt.Sprintf("Free variable %d of %q", x.fvPos, x.ssaNode.Parent().String())
 	case *AccessGlobalNode:
-		return "Global "
+		return fmt.Sprintf("Global variable %q", x.Global.String())
 	}
 	return ""
 }

--- a/analysis/dataflow/intra_procedural.go
+++ b/analysis/dataflow/intra_procedural.go
@@ -167,7 +167,6 @@ func (state *IntraAnalysisState) makeEdgesAtCallSite(callInstr ssa.CallInstructi
 	}
 	// add call node edges for call instructions whose Value corresponds to a function (i.e. the Method is nil)
 	if callInstr.Common().Method == nil {
-		// TODO: ignore path until we have field sensitivity in inter-procedural analysis
 		for _, mark := range state.getMarks(callInstr, callInstr.Common().Value, "", true) {
 			state.summary.addCallEdge(mark, nil, callInstr)
 			if closure, isMakeClosure := mark.Mark.Node.(*ssa.MakeClosure); isMakeClosure {
@@ -182,7 +181,7 @@ func (state *IntraAnalysisState) makeEdgesAtCallSite(callInstr ssa.CallInstructi
 		// Special case: a global is received directly as an argument
 		switch argInstr := arg.(type) {
 		case *ssa.Global:
-			tmpSrc := state.flowInfo.GetNewMark(callInstr.(ssa.Node), Global, argInstr, -1)
+			tmpSrc := state.flowInfo.GetNewMark(callInstr.(ssa.Node), Global, argInstr, NonIndexMark)
 			state.summary.addCallArgEdge(MarkWithAccessPath{tmpSrc, ""}, nil, callInstr, argInstr)
 		case *ssa.MakeClosure:
 			state.updateBoundVarEdges(callInstr, argInstr)

--- a/analysis/dataflow/mark.go
+++ b/analysis/dataflow/mark.go
@@ -54,10 +54,10 @@ const (
 type IndexKind int
 
 const (
-	// ReturnedTupleIndex is  index on a tuple returned by a functoin
-	ReturnedTupleIndex IndexKind = iota
-	// NonIndex is a non-index
-	NonIndex
+	// NonIndex is the kind of non-indices
+	NonIndex IndexKind = iota
+	// ReturnedTupleIndex is the kind of indices on tuples returned by functions
+	ReturnedTupleIndex
 )
 
 func (m MarkType) String() string {

--- a/analysis/dataflow/pointer.go
+++ b/analysis/dataflow/pointer.go
@@ -42,7 +42,7 @@ func DoPointerAnalysis(c *config.Config, p *ssa.Program,
 	functionFilter func(*ssa.Function) bool,
 	functionSet map[*ssa.Function]bool) (*pointer.Result, error) {
 	doReflection := false
-	if c != nil {
+	if c != nil && c.PointerConfig != nil {
 		doReflection = c.PointerConfig.Reflection
 	}
 	pCfg := &pointer.Config{
@@ -73,7 +73,7 @@ func DoPointerAnalysis(c *config.Config, p *ssa.Program,
 		}
 	}
 
-	if c != nil {
+	if c != nil && c.PointerConfig != nil {
 		for _, functionName := range c.PointerConfig.UnsafeNoEffectFunctions {
 			pCfg.AddNoEffectFunction(functionName)
 		}

--- a/analysis/lang/values.go
+++ b/analysis/lang/values.go
@@ -16,6 +16,7 @@ package lang
 
 import (
 	"go/token"
+	"go/types"
 
 	"golang.org/x/tools/go/ssa"
 )
@@ -225,4 +226,13 @@ func MatchNegation(x ssa.Value) ssa.Value {
 		return v.X
 	}
 	return nil
+}
+
+// TryTupleIndexType extract the type of element i in tuple type, or returns the type if it's not a tuple type
+func TryTupleIndexType(v types.Type, i int) types.Type {
+	tupleType, ok := v.(*types.Tuple)
+	if !ok {
+		return v
+	}
+	return tupleType.At(i).Type()
 }

--- a/analysis/taint/report.go
+++ b/analysis/taint/report.go
@@ -120,6 +120,6 @@ func reportTaintFlow(c *dataflow.AnalyzerState, source dataflow.NodeWithTrace, s
 				dataflow.FuncNames(nodes[i].Trace),
 				nodes[i].Node.Position(c).String())
 		}
-		c.Logger.Infof("-- SINK: %s\n", sinkPos.String())
+		c.Logger.Infof("-- ENDS WITH SINK: %s\n", sinkPos.String())
 	}
 }

--- a/analysis/taint/report.go
+++ b/analysis/taint/report.go
@@ -114,10 +114,11 @@ func reportTaintFlow(c *dataflow.AnalyzerState, source dataflow.NodeWithTrace, s
 			c.Logger.Infof("%s - %s",
 				formatutil.Purple("TRACE"),
 				dataflow.NodeSummary(nodes[i].Node))
-			c.Logger.Infof("%s - %s [%s] %s\n",
+			// - Context [<calling context string>] Pos: <position in source code>
+			c.Logger.Infof("%s - Context [%s] %s %s\n",
 				"     ",
-				dataflow.NodeKind(nodes[i].Node),
 				dataflow.FuncNames(nodes[i].Trace),
+				formatutil.Yellow("Pos:"),
 				nodes[i].Node.Position(c).String())
 		}
 		c.Logger.Infof("-- ENDS WITH SINK: %s\n", sinkPos.String())

--- a/analysis/taint/testdata/playground/config.yaml
+++ b/analysis/taint/testdata/playground/config.yaml
@@ -14,3 +14,4 @@ taint-tracking-problems:
 options:
     use-escape-analysis: false
     field-sensitive: true
+    summarize-on-demand: true

--- a/analysis/version.go
+++ b/analysis/version.go
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+// Version is the last tagged version of the analysis tool
+const Version = "v0.1.0-alpha"

--- a/cmd/taint/main.go
+++ b/cmd/taint/main.go
@@ -36,7 +36,6 @@ var (
 	maxDepth   = flag.Int("max-depth", -1, "Override max depth in config")
 	// Other constants
 	buildmode = ssa.InstantiateGenerics // necessary for reachability
-	version   = "unknown"
 )
 
 func init() {
@@ -81,7 +80,7 @@ func main() {
 		taintConfig.UnsafeMaxDepth = *maxDepth
 	}
 
-	logger.Printf(formatutil.Faint("Argot taint tool - build " + version))
+	logger.Printf(formatutil.Faint("Argot taint tool - " + analysis.Version))
 	logger.Printf(formatutil.Faint("Reading sources") + "\n")
 
 	program, err := analysis.LoadProgram(nil, "", buildmode, flag.Args())
@@ -133,13 +132,13 @@ func Report(program *ssa.Program, result taint.AnalysisResult) {
 			sourcePos := program.Fset.File(sourceInstr.Pos()).Position(sourceInstr.Pos())
 			sinkPos := program.Fset.File(sinkInstr.Pos()).Position(sinkInstr.Pos())
 			result.State.Logger.Warnf(
-				"%s in function %s:\n\tS: [SSA] %s\n\t\t%s\n\tSource: [SSA] %s\n\t\t%s\n",
-				formatutil.Red("A source has reached a sink"),
-				sinkInstr.Parent().Name(),
-				formatutil.SanitizeRepr(sinkInstr),
-				sinkPos.String(), // safe %s (position string)
+				"%s in function %s:\n\tSource: [SSA] %s\n\t\t%s\n\tSink: [SSA] %s\n\t\t%s\n",
+				formatutil.Red("Data from a source has reached a sink"),
+				sourceInstr.Parent().Name(),
 				formatutil.SanitizeRepr(sourceInstr),
 				sourcePos.String(), // safe %s (position string)
+				formatutil.SanitizeRepr(sinkInstr),
+				sinkPos.String(), // safe %s (position string)
 			)
 		}
 	}

--- a/doc/01_taint.md
+++ b/doc/01_taint.md
@@ -185,12 +185,12 @@ Indicating the source location. If any flow of tainted data from that source loc
 And if the option to print paths is set (`report-paths: true` in configuration file options), a trace is printed:
 ```
 [INFO] Report in taint-report/flow-2507865943.out
-[INFO] TRACE - Result of call to "GetSensitiveData"
-[INFO]       - Call  [(#13432.8)GetSensitiveData] /somedir/example.go:50:17
-[INFO] TRACE - Parameter "name" of "process" 
-[INFO]       - Param [(#23242.3)process] /somedir/processing.go:120:3
-[INFO] TRACE - Argument 0 in call to "processData"
-[INFO]       - CallArg [] /somedir/processing.go:180:23
+[INFO] TRACE - Result of call to "GetSensitiveData" (type *DataStorage)
+[INFO]       - Context [(#13432.8)GetSensitiveData] Pos: /somedir/example.go:50:17
+[INFO] TRACE - Parameter "name" (type string) of "process" 
+[INFO]       - Context [(#23242.3)process] Pos: /somedir/processing.go:120:3
+[INFO] TRACE - Argument 0 (type string) in call to "processData"
+[INFO]       - Context [] Pos: /somedir/processing.go:180:23
 ...
 ```
 The first line shows where the report is stored.
@@ -203,11 +203,11 @@ Once the analysis has terminated, the tool will print a final message followed b
 ```
 [ERROR] RESULT:
      Taint flows detected!
-[WARN]  A source has reached a sink in function test2:
-        Sink: [SSA] sink(t6)
-                /somedir/main.go:68:6
+[WARN]  Data from a source has reached a sink
         Source: [SSA] (fooProducer).source(t3)
                 /somedir/main.go:66:15     
+        Sink: [SSA] sink(t6)
+                /somedir/main.go:68:6
 ```
 If there are no taint flows detected, then the success message will be printed:
 ```
@@ -488,7 +488,7 @@ you should see some output similar to:
 [ERROR] ESCAPE ANALYSIS RESULT:
                 Tainted data escapes origin thread!
 [WARN]  Data escapes thread in function main:
-        S: [SSA] *t18 = t0
+        Sink: [SSA] *t18 = t0
                 argot/testdata/src/taint/sample-escape/main.go:45:15
         Source: [SSA] source1()
                 argot/testdata/src/taint/sample-escape/main.go:41:14


### PR DESCRIPTION
This PR improves tuple handling in the dataflow analysis:
- encoding of "non-tuples" explicit instead of through negative integers.
- tuple-manipulating instructions that are not at the boundary of function calls (returns, calls) now ignore tuple indices.
- analysis panics explicitly if indices don't match.
- some changes in the output format of the taint analysis to display type of nodes and make position more visually obvious.