### PR TITLE
De-duplicate backtrace traces

### DIFF
--- a/analysis/backtrace/backtrace_test.go
+++ b/analysis/backtrace/backtrace_test.go
@@ -335,7 +335,7 @@ func testAnalyze(t *testing.T, lp analysistest.LoadedTestProgram) {
 
 	t.Run(`trace to bar("x") should not exist`, func(t *testing.T) {
 		if funcutil.Exists(traces, func(trace backtrace.Trace) bool {
-			arg, ok := trace[0].Node.(*dataflow.CallNodeArg)
+			arg, ok := trace[0].GraphNode.(*dataflow.CallNodeArg)
 			if !ok {
 				return false
 			}
@@ -567,7 +567,7 @@ func matchTrace(trace backtrace.Trace, matches []match) (bool, error) {
 
 //gocyclo:ignore
 func matchNode(tnode backtrace.TraceNode, m match) (bool, error) {
-	switch node := tnode.Node.(type) {
+	switch node := tnode.GraphNode.(type) {
 	case *dataflow.CallNodeArg:
 		mval := m.val.(argval)
 		val := mval.val == node.Value().Name() || (mval.val == nil && !backtrace.IsStatic(node))

--- a/cmd/backtrace/main.go
+++ b/cmd/backtrace/main.go
@@ -87,11 +87,11 @@ func main() {
 
 	start := time.Now()
 	result, err := backtrace.Analyze(config.NewLogGroup(cfg), cfg, program, pkgs)
-	duration := time.Since(start)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "analysis failed: %v\n", err)
-		return
+		os.Exit(1)
 	}
+	duration := time.Since(start)
 	logger.Printf("")
 	logger.Printf("-%s", strings.Repeat("*", 80))
 	logger.Printf("Analysis took %3.4f s\n", duration.Seconds())


### PR DESCRIPTION
*Description of changes:*
- Remove duplicate traces
- Improve error reporting in backtrace by showing the trace and use `os.Exit` to properly set the exit code
- Make (Trace).String faster by using a buffer to reduce allocations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
