### PR TITLE
Dependency analysis improvements

### DIFF
--- a/analysis/dependencies/dependency_analysis.go
+++ b/analysis/dependencies/dependency_analysis.go
@@ -252,7 +252,7 @@ func DependencyAnalysis(state *dataflow.AnalyzerState, dc DependencyConfigs) rea
 
 		if dc.CsvFile != nil {
 			dc.CsvFile.Write([]byte(fmt.Sprintf("%s,%v,%d,%d,%3.2f\n",
-				dependencyName, entry.isIndirect, entry.reachableLocs, total, percentage)))
+				dependencyName, !entry.isIndirect, entry.reachableLocs, total, percentage)))
 		}
 	}
 

--- a/analysis/dependencies/dependency_analysis.go
+++ b/analysis/dependencies/dependency_analysis.go
@@ -283,7 +283,7 @@ func DependencyAnalysis(state *dataflow.AnalyzerState, dc DependencyConfigs) rea
 		}
 
 		if dc.CsvFile != nil {
-			dc.CsvFile.Write([]byte(fmt.Sprintf("%s,%v, %d,%d,%3.2f\n",
+			dc.CsvFile.Write([]byte(fmt.Sprintf("%s,%v,%d,%d,%3.2f\n",
 				dependencyName, entry.isIndirect, entry.reachableLocs, total, percentage)))
 		}
 	}

--- a/analysis/dependencies/dependency_test.go
+++ b/analysis/dependencies/dependency_test.go
@@ -66,7 +66,7 @@ func TestSamplePackageWorkerDependencies(t *testing.T) {
 	files := []string{"samplePackage/samplePackage.go",
 		"samplePackage/samplePackage_parser.go",
 		"samplePackage/samplePackage_unix.go"}
-	program, pkgs, err := analysis.LoadProgram(nil, "", ssa.BuilderMode(0), files)
+	program, pkgs, err := analysis.LoadProgram(nil, "", ssa.BuilderMode(0), false, files)
 	if err != nil {
 		t.Fatalf("error loading packages: %s", err)
 	}

--- a/analysis/load_program.go
+++ b/analysis/load_program.go
@@ -44,12 +44,13 @@ const PkgLoadMode = packages.NeedName |
 func LoadProgram(config *packages.Config,
 	platform string,
 	buildmode ssa.BuilderMode,
+	loadTests bool,
 	args []string) (*ssa.Program, []*packages.Package, error) {
 
 	if config == nil {
 		config = &packages.Config{
 			Mode:  PkgLoadMode,
-			Tests: false,
+			Tests: loadTests,
 		}
 	}
 
@@ -91,8 +92,9 @@ func LoadProgram(config *packages.Config,
 func LoadAnalyzerState(pkgConfig *packages.Config,
 	platform string,
 	buildmode ssa.BuilderMode,
+	loadTests bool,
 	args []string, cfg *config.Config) (*dataflow.AnalyzerState, error) {
-	program, pkgs, err := LoadProgram(pkgConfig, platform, buildmode, args)
+	program, pkgs, err := LoadProgram(pkgConfig, platform, buildmode, loadTests, args)
 	if err != nil {
 		return nil, fmt.Errorf("could not load program: %v", err)
 	}
@@ -112,12 +114,12 @@ func AllPackages(funcs map[*ssa.Function]bool) []*ssa.Package {
 			pkgs[f.Package()] = true
 		}
 	}
-	pkglist := make([]*ssa.Package, 0, len(pkgs))
+	pkgList := make([]*ssa.Package, 0, len(pkgs))
 	for p := range pkgs {
-		pkglist = append(pkglist, p)
+		pkgList = append(pkgList, p)
 	}
-	sort.Slice(pkglist, func(i, j int) bool {
-		return pkglist[i].Pkg.Path() < pkglist[j].Pkg.Path()
+	sort.Slice(pkgList, func(i, j int) bool {
+		return pkgList[i].Pkg.Path() < pkgList[j].Pkg.Path()
 	})
-	return pkglist
+	return pkgList
 }

--- a/analysis/load_program_test.go
+++ b/analysis/load_program_test.go
@@ -33,7 +33,7 @@ func programLoadTest(t *testing.T, files []string) {
 		return
 	}
 
-	pkgs, _, err := LoadProgram(nil, "", ssa.BuilderMode(0), files)
+	pkgs, _, err := LoadProgram(nil, "", ssa.BuilderMode(0), false, files)
 	if err != nil {
 		t.Fatalf("error loading packages: %s", err)
 	}

--- a/analysis/reachability/reachable_functions.go
+++ b/analysis/reachability/reachable_functions.go
@@ -161,14 +161,14 @@ func findCallees(program *ssa.Program, f *ssa.Function, action func(*ssa.Functio
 func FindReachable(state *dataflow.AnalyzerState, excludeMain bool, excludeInit bool, graph DependencyGraph) map[*ssa.Function]bool {
 
 	allFunctions := ssautil.AllFunctions(state.Program)
-	state.Logger.Infof("allFunctions contains %d total\n", len(allFunctions))
+	state.Logger.Infof("%d SSA functions\n", len(allFunctions))
 
 	reachable := make(map[*ssa.Function]bool, len(allFunctions))
 
 	frontier := make([]*ssa.Function, 0)
 
 	entryPoints := findEntryPoints(allFunctions, excludeMain, excludeInit)
-	state.Logger.Infof("findEntryPoints found %d entry points\n", len(entryPoints))
+	state.Logger.Infof("%d entrypoints\n", len(entryPoints))
 	for _, f := range entryPoints {
 		reachable[f] = true
 		frontier = append(frontier, f)
@@ -193,7 +193,7 @@ func FindReachable(state *dataflow.AnalyzerState, excludeMain bool, excludeInit 
 			}
 		})
 	}
-	state.Logger.Infof("FindReachable reports %d reachable functions\n", len(reachable))
+	state.Logger.Infof("%d reachable functions\n", len(reachable))
 
 	return reachable
 }
@@ -202,7 +202,6 @@ func FindReachable(state *dataflow.AnalyzerState, excludeMain bool, excludeInit 
 // boolean flags. The analysis prints the reachable functions on standard output.
 func ReachableFunctionsAnalysis(state *dataflow.AnalyzerState, excludeMain bool, excludeInit bool, jsonFlag bool) {
 	reachable := FindReachable(state, excludeMain, excludeInit, nil)
-	state.Logger.Infof("%d rechable functions", len(reachable))
 
 	functionNames := make([]string, 0, len(reachable))
 

--- a/cmd/argot-cli/main.go
+++ b/cmd/argot-cli/main.go
@@ -35,6 +35,7 @@ import (
 var (
 	configPath = flag.String("config", "", "Config file path for  analysis")
 	verbose    = flag.Bool("verbose", false, "Verbose printing on standard output")
+	withTest   = flag.Bool("with-test", false, "load test when loading program in cli")
 )
 
 func init() {
@@ -118,7 +119,7 @@ func main() {
 	logger.Printf(formatutil.Faint("Reading sources") + "\n")
 	state.Args = flag.Args()
 	// Load the program
-	program, pkgs, err := analysis.LoadProgram(nil, "", buildmode, flag.Args())
+	program, pkgs, err := analysis.LoadProgram(nil, "", buildmode, *withTest, flag.Args())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not load program: %v\n", err)
 		return

--- a/cmd/argot-cli/program.go
+++ b/cmd/argot-cli/program.go
@@ -51,7 +51,7 @@ func cmdRebuild(tt *term.Terminal, c *dataflow.AnalyzerState, _ Command) bool {
 
 	writeFmt(tt, "Reading sources\n")
 	// Load the program
-	program, pkgs, err := analysis.LoadProgram(nil, "", buildmode, state.Args)
+	program, pkgs, err := analysis.LoadProgram(nil, "", buildmode, *withTest, state.Args)
 	if err != nil {
 		WriteErr(tt, "could not load program:\n%s\n", err)
 		return false

--- a/cmd/backtrace/main.go
+++ b/cmd/backtrace/main.go
@@ -32,6 +32,7 @@ import (
 var (
 	configPath = flag.String("config", "", "Config file path for backtrace analysis")
 	verbose    = flag.Bool("verbose", false, "Verbose printing on standard output")
+	withTest   = flag.Bool("with-test", false, "load tests during backtrace analysis")
 )
 
 func init() {
@@ -79,7 +80,7 @@ func main() {
 
 	logger.Printf(formatutil.Faint("Reading backtrace entrypoints") + "\n")
 
-	program, pkgs, err := analysis.LoadProgram(nil, "", buildmode, flag.Args())
+	program, pkgs, err := analysis.LoadProgram(nil, "", buildmode, *withTest, flag.Args())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not load program: %v\n", err)
 		return

--- a/cmd/compare/main.go
+++ b/cmd/compare/main.go
@@ -46,6 +46,7 @@ var (
 	dynBinary       = flag.String("dynbinary", "", "Load dynamic callgraph corresponding to the given binary")
 	dynCallgraphDir = flag.String("callgraphs", "", "Directory to get dynamic callgraph from")
 	configFilename  = flag.String("config", "", "Configuration file.")
+	withTest        = flag.Bool("with-test", false, "load test for comparison")
 )
 
 func init() {
@@ -98,7 +99,7 @@ func main() {
 		return
 	}
 	fmt.Fprintf(os.Stderr, formatutil.Faint("Reading sources")+"\n")
-	state, loadingErr := analysis.LoadAnalyzerState(nil, "", buildmode, flag.Args(), cfg)
+	state, loadingErr := analysis.LoadAnalyzerState(nil, "", buildmode, *withTest, flag.Args(), cfg)
 	if loadingErr != nil {
 		fmt.Fprintf(os.Stderr, "failed to load program: %s", loadingErr)
 		return

--- a/cmd/defer/main.go
+++ b/cmd/defer/main.go
@@ -76,7 +76,7 @@ func doMain() error {
 
 	fmt.Fprintf(os.Stderr, formatutil.Faint("Reading sources")+"\n")
 
-	program, _, err := analysis.LoadProgram(nil, "", mode, flag.Args())
+	program, _, err := analysis.LoadProgram(nil, "", mode, false, flag.Args())
 	if err != nil {
 		return err
 	}

--- a/cmd/dependencies/main.go
+++ b/cmd/dependencies/main.go
@@ -42,16 +42,20 @@ var (
 	configFilename = ""
 	csvFilename    = ""
 	usageThreshold = 10.0
+	locThreshold   = 100
+	withTest       = false
 )
 
 func init() {
 	flag.StringVar(&configFilename, "config", "", "configuration file")
 	flag.StringVar(&covFilename, "cover", "", "output coverage file")
 	flag.StringVar(&graphFilename, "graph", "", "output graphviz file")
+	flag.BoolVar(&withTest, "with-test", false, "also include tests in dependency analysis")
 	flag.StringVar(&csvFilename, "csv", "", "output results in csv")
 	flag.BoolVar(&jsonFlag, "json", false, "output results as JSON")
 	flag.BoolVar(&stdlib, "stdlib", false, "include standard library packages")
 	flag.Float64Var(&usageThreshold, "usage", 10.0, "usage threshold below which warning produced")
+	flag.IntVar(&locThreshold, "loc", 100, "loc threshold under which a warning is produced if usage is also below percentage")
 	flag.Var(&mode, "build", ssa.BuilderModeDoc)
 	flag.Var((*buildutil.TagsFlag)(&build.Default.BuildTags), "tags", buildutil.TagsFlagDoc)
 }
@@ -86,7 +90,7 @@ func doMain() error {
 
 	fmt.Fprintf(os.Stderr, formatutil.Faint("Reading sources")+"\n")
 
-	program, pkgs, err := analysis.LoadProgram(nil, "", mode, flag.Args())
+	program, pkgs, err := analysis.LoadProgram(nil, "", mode, withTest, flag.Args())
 	if err != nil {
 		return err
 	}
@@ -136,6 +140,7 @@ func doMain() error {
 		CoverageFile:   coverageWriter,
 		CsvFile:        csvWriter,
 		UsageThreshold: usageThreshold,
+		LocThreshold:   locThreshold,
 		ComputeGraph:   true,
 	})
 

--- a/cmd/dependencies/main.go
+++ b/cmd/dependencies/main.go
@@ -136,7 +136,7 @@ func doMain() error {
 		CoverageFile:   coverageWriter,
 		CsvFile:        csvWriter,
 		UsageThreshold: usageThreshold,
-		ComputeGraph:   false,
+		ComputeGraph:   true,
 	})
 
 	if covFilename != "" {

--- a/cmd/dependencies/main.go
+++ b/cmd/dependencies/main.go
@@ -131,7 +131,7 @@ func doMain() error {
 			log.Fatal(err)
 		}
 		defer csvWriter.Close()
-		csvWriter.Write([]byte("dependency,is direct, loc used,loc total,% used\n"))
+		csvWriter.Write([]byte("dependency,direct?, loc used,loc total,% used\n"))
 	}
 
 	dependencyGraph := dependencies.DependencyAnalysis(state, dependencies.DependencyConfigs{

--- a/cmd/dependencies/main.go
+++ b/cmd/dependencies/main.go
@@ -131,7 +131,7 @@ func doMain() error {
 			log.Fatal(err)
 		}
 		defer csvWriter.Close()
-		csvWriter.Write([]byte("dependency,loc used,loc total,% used\n"))
+		csvWriter.Write([]byte("dependency,is direct, loc used,loc total,% used\n"))
 	}
 
 	dependencyGraph := dependencies.DependencyAnalysis(state, dependencies.DependencyConfigs{

--- a/cmd/maypanic/main.go
+++ b/cmd/maypanic/main.go
@@ -92,7 +92,8 @@ func doMain() error {
 
 	fmt.Fprintf(os.Stderr, formatutil.Faint("Reading sources")+"\n")
 
-	program, _, err := analysis.LoadProgram(cfg, "", mode, flag.Args())
+	// never load tests for the may-panic analysis (may change later if there's an ask)
+	program, _, err := analysis.LoadProgram(cfg, "", mode, false, flag.Args())
 	if err != nil {
 		return err
 	}

--- a/cmd/packagescan/main.go
+++ b/cmd/packagescan/main.go
@@ -41,6 +41,7 @@ var (
 	inexact     = false
 	targets     = ""
 	rawFilename = ""
+	withTest    = false
 )
 
 func init() {
@@ -51,6 +52,7 @@ func init() {
 	flag.StringVar(&targets, "target", "windows,linux,darwin", "target platform(s)")
 	flag.StringVar(&rawFilename, "raw", "", "filename for dump of raw symbol usage")
 	flag.Var((*buildutil.TagsFlag)(&build.Default.BuildTags), "tags", buildutil.TagsFlagDoc)
+	flag.BoolVar(&withTest, "with-test", false, "load test when scanning")
 }
 
 const usage = `Analyze your Go packages.
@@ -107,7 +109,7 @@ func doMain() error {
 	// todo -- technically we could run these in parallel...
 	// (though tbf, the LoadProgram does exploit multiple cores already)
 	for _, platform := range platforms {
-		program, pkgs, loadingErr := analysis.LoadProgram(nil, platform, mode, flag.Args())
+		program, pkgs, loadingErr := analysis.LoadProgram(nil, platform, mode, withTest, flag.Args())
 		if loadingErr != nil {
 			return loadingErr
 		}

--- a/cmd/reachability/main.go
+++ b/cmd/reachability/main.go
@@ -37,6 +37,7 @@ var (
 	excludeInit    = false
 	mode           = ssa.InstantiateGenerics
 	configFilename = ""
+	withTests      = false
 )
 
 func init() {
@@ -46,6 +47,7 @@ func init() {
 	flag.BoolVar(&excludeInit, "noinit", false, "exclude init() as a starting point")
 	flag.Var(&mode, "build", ssa.BuilderModeDoc)
 	flag.Var((*buildutil.TagsFlag)(&build.Default.BuildTags), "tags", buildutil.TagsFlagDoc)
+	flag.BoolVar(&withTests, "with-test", false, "include tests in the reachability analysis")
 }
 
 const usage = `Analyze your Go packages.
@@ -91,7 +93,7 @@ func doMain() error {
 		}
 	}
 	fmt.Fprintf(os.Stderr, formatutil.Faint("Reading sources")+"\n")
-	state, err := analysis.LoadAnalyzerState(nil, "", mode, flag.Args(), cfg)
+	state, err := analysis.LoadAnalyzerState(nil, "", mode, withTests, flag.Args(), cfg)
 	if err != nil {
 		return fmt.Errorf("failed to initialize analyzer state: %s", err)
 	}

--- a/cmd/render/main.go
+++ b/cmd/render/main.go
@@ -40,6 +40,7 @@ var (
 	dfOut      = flag.String("dfout", "", "Output file for inter-procedural dataflow graph (no output if not specified)")
 	configPath = flag.String("config", "", "Config file")
 	ssaOutFlag = flag.String("ssaout", "", "Output folder for ssa (no output if not specified)")
+	withTest   = flag.Bool("with-test", false, "Load test for rendering")
 )
 
 func init() {
@@ -103,7 +104,7 @@ func main() {
 
 	fmt.Fprintf(os.Stderr, formatutil.Faint("Reading sources")+"\n")
 
-	program, _, err := analysis.LoadProgram(nil, "", buildmode, flag.Args())
+	program, _, err := analysis.LoadProgram(nil, "", buildmode, *withTest, flag.Args())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not load program: %v", err)
 		return

--- a/cmd/statistics/main.go
+++ b/cmd/statistics/main.go
@@ -35,10 +35,11 @@ import (
 type excludeFlags []string
 
 var (
-	jsonFlag              = false
-	mode                  = ssa.BuilderMode(0)
-	exclude  excludeFlags = []string{}
-	prefix                = ""
+	jsonFlag               = false
+	mode                   = ssa.BuilderMode(0)
+	exclude   excludeFlags = []string{}
+	prefix                 = ""
+	withTests              = false
 )
 
 func (exclude *excludeFlags) String() string {
@@ -55,6 +56,7 @@ func init() {
 	flag.Var((*buildutil.TagsFlag)(&build.Default.BuildTags), "tags", buildutil.TagsFlagDoc)
 	flag.Var(&exclude, "exclude", "path to exclude from analysis")
 	flag.StringVar(&prefix, "prefix", "", "prefix of packages to print statistics for")
+	flag.BoolVar(&withTests, "withTests", false, "also load tests for statistics")
 }
 
 const usage = `Analyze your Go packages.
@@ -88,7 +90,7 @@ func doMain() error {
 
 	fmt.Fprintf(os.Stderr, formatutil.Faint("Reading sources")+"\n")
 
-	program, pkgs, err := analysis.LoadProgram(nil, "", mode, flag.Args())
+	program, pkgs, err := analysis.LoadProgram(nil, "", mode, withTests, flag.Args())
 	if err != nil {
 		return err
 	}

--- a/cmd/taint/main.go
+++ b/cmd/taint/main.go
@@ -34,6 +34,7 @@ var (
 	configPath = flag.String("config", "", "Config file path for taint analysis")
 	verbose    = flag.Bool("verbose", false, "Verbose printing on standard output")
 	maxDepth   = flag.Int("max-depth", -1, "Override max depth in config")
+	withTests  = flag.Bool("with-test", false, "Load tests during analysis")
 	// Other constants
 	buildmode = ssa.InstantiateGenerics // necessary for reachability
 )
@@ -83,7 +84,7 @@ func main() {
 	logger.Printf(formatutil.Faint("Argot taint tool - " + analysis.Version))
 	logger.Printf(formatutil.Faint("Reading sources") + "\n")
 
-	program, pkgs, err := analysis.LoadProgram(nil, "", buildmode, flag.Args())
+	program, pkgs, err := analysis.LoadProgram(nil, "", buildmode, *withTests, flag.Args())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not load program: %v\n", err)
 		return

--- a/doc/06_dependencies.md
+++ b/doc/06_dependencies.md
@@ -3,21 +3,61 @@
 
 The dependency analysis tool ('dependencies') is a whole program analysis tool that performs a conservative reachability analysis to measure what fraction of each imported library is (or at least could be) used by the program.  
 
-The purpose of this tool is to get a sense of how much of each dependency is actually consumed.  So, for example, you might discover that a fairly large package is being imported but only a handful of functions are actually needed.   While importing packages for a single function is considered idiomatic in other languages, Go encourages minimizing the number of dependencies.
+The purpose of this tool is to get a sense of how much of each dependency is actually consumed.  So, for example, you might discover that a fairly large package is being imported but only a handful of functions are actually needed.   While importing packages for a single function is considered idiomatic in other languages, Go encourages minimizing the number of dependencies. With the `-usage` and `-loc` options, you control when a warning appears: if a module is used less than `-usage`% (default 10%) *and* less than `-loc` lines of SSA then a warning is printed on the output.
+
+For example, the tool may print an output as follows:
+```shell
+Reading sources
+[INFO]  Loaded 0 annotations from program
+[INFO]  Analyzing
+[INFO]  allFunctions contains 17911 total
+[INFO]  findEntryPoints found 26 entry points
+[INFO]  FindReachable reports 10991 reachable functions
+[INFO]  Dependencies (direct or indirect, name, reachable LOC, total LOC, % LOC usage):
+[INFO]   direct  github.com/awslabs/ar-go-tools   68954  72438  (95.2 %)
+[INFO]   direct  github.com/dave/dst              101    31016  (0.3 %)
+[INFO]   direct  github.com/google/shlex          296    314    (94.3 %)
+[WARN]   direct  github.com/yourbasic/graph       7      2455   (0.3 %)  <- less than 100 lines used, and below 10.0 % usage
+[INFO]   direct  golang.org/x/exp                 1306   2591   (50.4 %)
+[INFO]   direct  golang.org/x/sys                 1122   6887   (16.3 %)
+[INFO]   direct  golang.org/x/term                1709   2018   (84.7 %)
+[INFO]   direct  golang.org/x/tools               167944 185822 (90.4 %)
+[WARN]   direct  gonum.org/v1/gonum               5      989    (0.5 %)  <- less than 100 lines used, and below 10.0 % usage
+[INFO]  indirect golang.org/x/mod                 6      555    (1.1 %)
+[INFO]  indirect golang.org/x/sync                89     184    (48.4 %)
+
+``` 
+Indicating that the dependencies `gonum.org/v1/gonum` and `github.com/yourbasic/graph` should possibly be eliminated. 
 
 The dependency tool can also be useful in discovering when a dependency is inadvertently being linked into a program where it should not be.  For example, if test libraries are reachable from production code.  In a codebase with multiple executables, the dependency tool can help detect when a change to a shared package results in additional code being imported into executables where it is not required.  
 
 The dependency tool measures the size of functions by counting the SSA instructions in each function.  It presents the results as a ratio of the number of instructions in a package that are reachable within a program to the total number of instructions in the package.  While SSA instructions do not correspond directly to lines of code, they are a reasonable proportional estimate of the size of different dependencies and the fraction of the dependency actually consumed.  The dependency tool does not measure the size of data or constants that might be imported, only functions, and will be less accurate with packages that exist primarily to import data rather than code.
 
-If invoked with the -cover option, the dependency tool will generate an output file using the Go test coverage format to indicate exactly which lines in the codebase are reachable (covered) and which are not (uncovered).  This coverage file can then be interactively browsed using the "go tool cover" command.  It can also be merged with other coverage files using tools such as github.com/wadey/gocovmerge.  So, for example, if your codebase consists of multiple executables, you can run the dependency tool on each binary and then merge the coverage results to see how much each dependency is needed across the set of executables.  Similarly, if you cross-compile your code, you can run the dependency tool with each different platform (e.g. GOOS=windows, GOOS=linux, GOOS=darwin) and merge the coverage results to observe how much each dependency is needed across all target systems.
+### Generate coverage data
+If invoked with the `-cover` option, the dependency tool will generate an output file using the Go test coverage format to indicate exactly which lines in the codebase are reachable (covered) and which are not (uncovered).  This coverage file can then be interactively browsed using the "go tool cover" command.  It can also be merged with other coverage files using tools such as github.com/wadey/gocovmerge.  So, for example, if your codebase consists of multiple executables, you can run the dependency tool on each binary and then merge the coverage results to see how much each dependency is needed across the set of executables.  Similarly, if you cross-compile your code, you can run the dependency tool with each different platform (e.g. GOOS=windows, GOOS=linux, GOOS=darwin) and merge the coverage results to observe how much each dependency is needed across all target systems.
 
-The dependency tool supports a `stdlib` flag to instruct it to suppress output of standard library packages and focus entirely on third-party dependencies.  [todo: should we standardize on these filtering functions, and differentiate between the program itself (identified in go.mod), stdlib, extended stdlib, x/tools, and true third-party?  If so, cf common docs.]
+
+### Build options and including tests
 
 The dependency tool allows the buildmode and tags to be controlled with command line arguments, as per all the other AR-Go-tools.  [cf: common docs].  This may be deprecated.
+The `-with-tests` flags instructs it to include all the test files when computing the dependency usage. By default, tests are excluded.
+The dependency tool supports a `-stdlib` flag to instruct it to suppress output of standard library packages and focus entirely on third-party dependencies.
 
-If invoked with the -graph option, the dependency tool will generate a directed graph of which packages depend on other packages.  It will emit a sorted list of packages as standard output, and emit a graphviz-compatible file format with the complete output.  This can be quite large and too much for graphviz to render, but searching the file for specific package names will provide useful data about how a particular package is being imported.  This is similar to the "go mod why" function, but that will show you every potential dependency of every package, whereas this tool will limit its output to only those dependencies that are actually used in the program being analyzed. 
 
-## Options
+
+### Generate a dependency graph
+
+If invoked with the `-graph` option, the dependency tool will generate a directed graph of which packages depend on other packages.  It will emit a sorted list of packages as standard output, and emit a graphviz-compatible file format with the complete output.  This can be quite large and too much for graphviz to render, but searching the file for specific package names will provide useful data about how a particular package is being imported.  This is similar to the "go mod why" function, but that will show you every potential dependency of every package, whereas this tool will limit its output to only those dependencies that are actually used in the program being analyzed. 
+
+### Generate CSV
+
+The tool can generate a CSV summarizing the results with the `-csv <output-file-name>` option. Each line will be of the form:
+```
+dependency name, is direct dependency?, reachable LoC, total LoC, usage percentage
+```
+Users can consume this information instead of the terminal output.
+
+## All Options
 The `dependency` tool accepts the following options:
 - `-help` prints a list of options.
 - `-config <filename>` allows the user to specify a config file (see [intro doc](./00_intro.md)). The options used are the `log-level` option and the `pkg-filter` option, which in this application controls for which packages some additional debug statements are printed.
@@ -26,3 +66,5 @@ The `dependency` tool accepts the following options:
 - `-csv <filename>` instructs the tool to print a summary of the dependencies and their usage ratio in `<filename>`.
 - `-stdlib` instructs the tool to suppress output of standard library packages (see details above)
 - `-usage` sets a threshold usage percentage under which a dependency's usage is reported with a warning (by default, 10%).
+- `-loc` sets the absolute number lines of code used below which a warning is reported (by default, 100).
+- `-with-test` sets the test inclusion to true. By default, tests are not included when measuring dependency usage. 

--- a/internal/analysistest/analysistest.go
+++ b/internal/analysistest/analysistest.go
@@ -88,7 +88,8 @@ func LoadTest(fsys ReadFileDirFS, dir string, extraFiles []string) (LoadedTestPr
 		patterns = append(patterns, fmt.Sprintf("file=%s", fp))
 	}
 	// Note: adding other package modes like ssa.GlobalDebug breaks the escape analysis tests
-	program, pkgs, err := analysis.LoadProgram(&pcfg, "", ssa.InstantiateGenerics|ssa.BuildSerially, patterns)
+	program, pkgs, err := analysis.LoadProgram(
+		&pcfg, "", ssa.InstantiateGenerics|ssa.BuildSerially, false, patterns)
 	if err != nil {
 		return LoadedTestProgram{}, err
 	}
@@ -127,7 +128,7 @@ func LoadTestFromDisk(dir string, extraFiles []string) (LoadedTestProgram, error
 	}
 	mode := packages.NeedImports | packages.NeedSyntax | packages.NeedTypes | packages.NeedDeps | packages.NeedTypesInfo
 	pcfg := packages.Config{Mode: mode}
-	prog, pkgs, err := analysis.LoadProgram(&pcfg, "", ssa.InstantiateGenerics, files)
+	prog, pkgs, err := analysis.LoadProgram(&pcfg, "", ssa.InstantiateGenerics, false, files)
 	if err != nil {
 		return LoadedTestProgram{Pkgs: pkgs}, fmt.Errorf("error loading packages: %v", err)
 	}


### PR DESCRIPTION
Improvements to the dependency analysis:
- use module names to map dependencies and know whether the dependency is direct or indirect
- add absolute number of lines of code parameter
- some refactoring to make loading the basic analyzer state easier
- add the option to load the program with tests to some tools

Example of the dependency tool running against Argot itself:
<img width="1145" alt="Screenshot 2024-09-04 at 1 01 24 PM" src="https://github.com/user-attachments/assets/57a79053-9c5d-4fc5-9f6c-88815c345672">
