### PR TITLE
Fix summary building logic: all decisions in ShouldBuildSummary.

### DIFF
--- a/analysis/analyzers.go
+++ b/analysis/analyzers.go
@@ -62,7 +62,7 @@ func RunIntraProceduralPass(state *dataflow.AnalyzerState, numRoutines int, args
 			function:      function,
 			analyzerState: state,
 			// Summary is built only when it is not on-demand, and the summary should be built
-			shouldBuildSummary: !state.Config.SummarizeOnDemand && args.ShouldBuildSummary(state, function),
+			shouldBuildSummary: args.ShouldBuildSummary(state, function),
 		})
 	}
 

--- a/analysis/dataflow/inter_procedural.go
+++ b/analysis/dataflow/inter_procedural.go
@@ -585,7 +585,6 @@ func BuildSummary(s *AnalyzerState, function *ssa.Function) *SummaryGraph {
 		summary = NewPredefinedSummary(function, id)
 		s.FlowGraph.Summaries[function] = summary
 	}
-
 	logger := s.Logger
 
 	logger.Debugf("BuildSummary: Constructing summary for %v...\n", function)

--- a/analysis/dataflow/intra_procedural.go
+++ b/analysis/dataflow/intra_procedural.go
@@ -458,6 +458,10 @@ func (state *IntraAnalysisState) isCapturedBy(value ssa.Value) []*pointer.Label 
 //   - the function is not filtered out by the pkg-filter (i.e. the pkg-filter matches the function when present)
 //   - the function is not already summarized by a predefined summary or has an external contract
 func ShouldBuildSummary(state *AnalyzerState, function *ssa.Function) bool {
+	if state.Config != nil && state.Config.SummarizeOnDemand {
+		return false
+	}
+
 	if state == nil || function == nil || summaries.IsSummaryRequired(function) {
 		return true
 	}
@@ -465,10 +469,6 @@ func ShouldBuildSummary(state *AnalyzerState, function *ssa.Function) bool {
 	pkg := function.Package()
 	if pkg == nil {
 		return true
-	}
-
-	if state.Config != nil && state.Config.SummarizeOnDemand {
-		return false
 	}
 
 	// Is PkgPrefix specified?


### PR DESCRIPTION
Moves all the logic deciding when to build summaries in analyzes into the `ShouldBuildSummary` function.
This was causing issues when using the `argot-cli` and the summarization on demand option was on: the `summarize` command would not build the summaries because the summarization on demand option check was outside of the shouldBuildSummary function provided.

Also fixes a bug where some unexpected inter-procedural edges would be visited by the backtrace analysis and cause mismatch in number of arguments in caller and expected callee.
