### PR TITLE
Adding warning for usage of unsound features when a function is being…

### DIFF
--- a/analysis/dataflow/builtins.go
+++ b/analysis/dataflow/builtins.go
@@ -121,8 +121,8 @@ func doBuiltinCall(t *IntraAnalysisState, callValue ssa.Value, callCommon *ssa.C
 
 		// for recover, we will need some form of panic analysis
 		case "recover":
-			t.parentAnalyzerState.Logger.Warnf("Encountered recover at %s, the analysis may be unsound.\n",
-				instruction.Parent().Prog.Fset.Position(instruction.Pos()))
+			// TODO: handler recovers. Analysis is unsound with recovers.
+			// NOTE: Unsoundness is reported by reportUnsoundFeatures
 			return true
 		default:
 			// Special case: the call to Error() of the builtin error interface

--- a/analysis/dataflow/inter_procedural.go
+++ b/analysis/dataflow/inter_procedural.go
@@ -150,7 +150,7 @@ func (g *InterProceduralFlowGraph) BuildGraph() {
 					externalContractSummary := g.AnalyzerState.LoadExternalContractSummary(node)
 					if externalContractSummary != nil {
 						logger.Debugf("Loaded %s from external contracts.\n",
-							formatutil.SanitizeRepr(node.CallSite().Common()))
+							formatutil.SanitizeRepr(node.Callee()))
 						g.Summaries[node.Callee()] = externalContractSummary
 						node.CalleeSummary = externalContractSummary
 						if x := externalContractSummary.Callsites[node.CallSite()]; x == nil {

--- a/analysis/dataflow/intra_procedural.go
+++ b/analysis/dataflow/intra_procedural.go
@@ -106,6 +106,8 @@ func RunIntraProcedural(a *AnalyzerState, sm *SummaryGraph) (time.Duration, erro
 		postBlockCallback:   sm.postBlockCallBack,
 	}
 
+	reportUnsoundFeatures(a, sm.Parent)
+
 	// Output warning if defer stack is unbounded
 	if !state.deferStacks.DeferStackBounded {
 		a.Logger.Warnf("Defer stack unbounded in %s: %s",

--- a/analysis/dataflow/report.go
+++ b/analysis/dataflow/report.go
@@ -110,9 +110,13 @@ func (s *AnalyzerState) ReportSummaryNotConstructed(callSite *CallNode) {
 	}
 }
 
-type unsoundFeaturesMap struct {
-	Recovers      map[token.Position]bool
-	UnsafeUsages  map[token.Position]string
+// UnsoundFeaturesMap maps positions (in a function) to explanations of the unsound features used.
+type UnsoundFeaturesMap struct {
+	// Recovers records the locations where a recover is used.
+	Recovers map[token.Position]bool
+	// UnsafeUsages records the locations where `unsafe` is used, with a short explanation.
+	UnsafeUsages map[token.Position]string
+	// ReflectUsages records the locations where 'reflect' is used, with a short explanation.
 	ReflectUsages map[token.Position]string
 }
 
@@ -159,7 +163,9 @@ func reportUnsoundFeatures(state *AnalyzerState, f *ssa.Function) {
 		state.Logger.Warnf(msg)
 	}
 }
-func FindUnsoundFeatures(f *ssa.Function) unsoundFeaturesMap {
+
+// FindUnsoundFeatures returns a record of the unsound features used by a function, if any.
+func FindUnsoundFeatures(f *ssa.Function) UnsoundFeaturesMap {
 	unsafeUsages := map[token.Position]string{}
 	recovers := map[token.Position]bool{}
 	reflectUsages := map[token.Position]string{}
@@ -206,5 +212,5 @@ func FindUnsoundFeatures(f *ssa.Function) unsoundFeaturesMap {
 			}
 		}
 	})
-	return unsoundFeaturesMap{recovers, unsafeUsages, reflectUsages}
+	return UnsoundFeaturesMap{recovers, unsafeUsages, reflectUsages}
 }

--- a/analysis/dataflow/testdata/unsound-features/config.yaml
+++ b/analysis/dataflow/testdata/unsound-features/config.yaml
@@ -1,0 +1,15 @@
+taint-tracking-problems:
+  - sources:
+      - package: main
+        method: Source
+      - package: command-line-arguments
+        method: Source
+      - package: (main|command-line-arguments)
+        field: Source
+    sinks:
+      - package: command-line-arguments
+        method: Sink
+      - package: main
+        method: Sink
+options:
+  summarize-on-demand: true

--- a/analysis/dataflow/testdata/unsound-features/main.go
+++ b/analysis/dataflow/testdata/unsound-features/main.go
@@ -1,19 +1,16 @@
-/*
- * Copyright (c)
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package main
 

--- a/analysis/dataflow/testdata/unsound-features/main.go
+++ b/analysis/dataflow/testdata/unsound-features/main.go
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c)
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"strconv"
+	"unsafe"
+)
+
+func mayPanic() {
+	panic("a problem")
+}
+
+func Source() string {
+	return "x" + strconv.Itoa(rand.Int())
+}
+
+func Sink(x string) {
+	fmt.Println(x)
+}
+
+type Example struct {
+	x int
+	f string
+}
+
+func (e Example) String() string {
+	return e.f + strconv.Itoa(e.x)
+}
+
+func usingUnsafe() {
+	s := Example{
+		x: 1243,
+		f: Source(),
+	}
+	x := []string{"a", "b", "c"}
+	var i uintptr
+	i = 3
+	// equivalent to f := unsafe.Pointer(&s.f)
+	f := unsafe.Pointer(uintptr(unsafe.Pointer(&s)) + unsafe.Offsetof(s.f))
+	// equivalent to e := unsafe.Pointer(&x[i])
+	e := unsafe.Pointer(uintptr(unsafe.Pointer(&x[0])) + i*unsafe.Sizeof(x[0]))
+
+	fmt.Println(e, f)
+}
+
+func usingReflect() {
+	x := 10
+	name := "Go Lang"
+	example := Example{1, Source()} // @Source(reflect)
+	fmt.Println(reflect.TypeOf(x))
+	fmt.Println(reflect.TypeOf(name))
+	fmt.Println(reflect.TypeOf(example))
+
+	method := reflect.ValueOf(example).MethodByName("String")
+	if !method.IsValid() {
+		fmt.Println("ERROR: String is not implemented")
+		return
+	}
+	e := method.Call(nil) // this call is elided by the pointer analysis and results in false negatives!
+	Sink(e[0].String())   // @Sink(reflect)
+}
+
+func usingRecover() {
+	defer func() {
+		if r := recover(); r != nil {
+
+			fmt.Println("Recovered. Error:\n", r)
+		}
+	}()
+	mayPanic()
+	fmt.Println("After mayPanic()")
+
+}
+
+func main() {
+	usingUnsafe()
+	usingReflect()
+	usingRecover()
+}

--- a/analysis/dataflow/unsound_features_test.go
+++ b/analysis/dataflow/unsound_features_test.go
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dataflow_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/ar-go-tools/analysis/config"
+	"github.com/awslabs/ar-go-tools/analysis/dataflow"
+	"github.com/awslabs/ar-go-tools/internal/analysistest"
+)
+
+func TestUnsoundFeatures(t *testing.T) {
+	dir := filepath.Join("testdata", "unsound-features")
+	lp, err := analysistest.LoadTest(testfsys, dir, []string{},
+		analysistest.LoadTestOptions{ApplyRewrite: true})
+	if err != nil {
+		t.Fatalf("failed to load test: %v", err)
+	}
+	c, err := dataflow.NewInitializedAnalyzerState(lp.Prog, lp.Pkgs, config.NewLogGroup(lp.Config), lp.Config)
+	if err != nil {
+		t.Errorf("error building state: %q", err)
+	}
+	var unsafeChecked, reflectChecked, recoverChecked bool
+	for f := range c.ReachableFunctions() {
+		if strings.Contains(f.Name(), "usingUnsafe") {
+
+			uf := dataflow.FindUnsoundFeatures(f)
+			if len(uf.UnsafeUsages) <= 2 {
+				t.Errorf("Did not detect enough usages of unsage in usingUnsafe")
+			}
+			unsafeChecked = true
+		}
+		if strings.Contains(f.Name(), "usingReflect") {
+			uf := dataflow.FindUnsoundFeatures(f)
+			if len(uf.ReflectUsages) <= 2 {
+				t.Errorf("Did not detect enough usages of unsage in usingReflect")
+			}
+			reflectChecked = true
+		}
+		if strings.Contains(f.Name(), "usingRecover$1") {
+			uf := dataflow.FindUnsoundFeatures(f)
+			if len(uf.Recovers) <= 0 {
+				t.Errorf("Did not detect enough usages of recover in usingRecover")
+			}
+			recoverChecked = true
+		}
+	}
+	if !(recoverChecked && reflectChecked && unsafeChecked) {
+		t.Errorf("Failed to check for recover, reflect and unsafe functions")
+	}
+}

--- a/analysis/summaries/standard_library.go
+++ b/analysis/summaries/standard_library.go
@@ -791,7 +791,12 @@ var summaryReflect = map[string]Summary{
 		[][]int{{0}, {1}},
 		[][]int{{0}, {0}},
 	},
-	"(reflect.Value).Bool":  SingleVarArgPropagation,
+	"(reflect.Value).Bool": SingleVarArgPropagation,
+	// Over-approximation for Call: it is assumed the function being called fully propagates data
+	"(reflect.Value).Call": {
+		[][]int{{0}, {1}},
+		[][]int{{0}, {0}},
+	},
 	"(reflect.Value).Float": SingleVarArgPropagation,
 	"(reflect.Value).Int":   SingleVarArgPropagation,
 	// func (v Value) Elem() Value
@@ -829,6 +834,11 @@ var summaryReflect = map[string]Summary{
 	"(reflect.Value).Kind": SingleVarArgPropagation,
 	// func (v Value) Len() int
 	"(reflect.Value).Len": SingleVarArgPropagation,
+	// func (v Value) MethodByName(name string) Value
+	"(reflect.Value).MethodByName": {
+		[][]int{{0}, {1}},
+		[][]int{{0}, {0}},
+	},
 	// func (v Value) NumField() int
 	"(reflect.Value).NumField": SingleVarArgPropagation,
 	// func (v Value) MapKeys() []Value

--- a/analysis/taint/testdata/basic/config.yaml
+++ b/analysis/taint/testdata/basic/config.yaml
@@ -9,6 +9,9 @@ taint-tracking-problems:
     - package: "(basic)|(main)|(command-line-arguments)"
       type: "(chan \\*_S)|(chan _S)"
       kind: "channel receive"
+    - package: "(basic)|(main)|(command-line-arguments)"
+      type: "\\*Sample"
+      field: "Secret"
   sinks:
     - package: "(basic)|(main)|(command-line-arguments)"
       # Similarly, sinks are sink1 sink2 sink2 ...

--- a/analysis/taint/testdata/basic/main.go
+++ b/analysis/taint/testdata/basic/main.go
@@ -65,6 +65,7 @@ func main() {
 	test5()                   // see example3.go
 	testField()               // see fields.go
 	testFieldEmbedded()       // see fields.go
+	testField2()              // see fields.go
 	runSanitizerExamples()    // see sanitizers.go
 	testAliasingTransitive()  // see memory.go
 	testChannelReadAsSource() // see channels.go

--- a/cmd/argot/cli/defs.go
+++ b/cmd/argot/cli/defs.go
@@ -17,6 +17,7 @@ package cli
 import (
 	"go/token"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/awslabs/ar-go-tools/analysis/dataflow"
@@ -88,7 +89,9 @@ func funcsMatchingCommand(tt *term.Terminal, c *dataflow.AnalyzerState, command 
 		regexErr(tt, rString, err)
 		return []*ssa.Function{}
 	}
-	return findFunc(c, r)
+	s := findFunc(c, r)
+	slices.SortFunc(s, func(a, b *ssa.Function) int { return strings.Compare(a.String(), b.String()) })
+	return s
 }
 
 func findFunc(c *dataflow.AnalyzerState, target *regexp.Regexp) []*ssa.Function {


### PR DESCRIPTION
The tool will now warn when Go features that are a threat to soundness are use in a function being analyzed by the dataflow analyses (see #95 ):

<img width="854" alt="Screenshot 2024-10-04 at 1 52 24 PM" src="https://github.com/user-attachments/assets/b978ac37-0d13-4312-9503-09854f06b73c">
This is in addition to the existing warnings about possibly unbound defer stacks and data flowing through Go calls.
This feature is meant to help users understand what may threaten soundness, but we won't give guarantees about "a warning will be produced iff the analyzer encounters a feature that is a threat to soundness".
