### PR TITLE
Adding error hints to help user

### DIFF
--- a/cmd/argot/main.go
+++ b/cmd/argot/main.go
@@ -164,6 +164,10 @@ func main() {
 }
 
 func errExit(err error) {
-	fmt.Fprintf(os.Stderr, "error: %v", err)
+	fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	hint := tools.HintForErrorMessage(err.Error())
+	if hint != "" {
+		fmt.Fprintf(os.Stderr, "Hint: %s\n", hint)
+	}
 	os.Exit(2)
 }

--- a/cmd/argot/tools/interpret.go
+++ b/cmd/argot/tools/interpret.go
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import "regexp"
+
+// Captures errors happening before any analysis starts (program could not load)
+var regexCouldNotLoad = regexp.MustCompile("could not load program")
+
+// Captures the kind of error that happen when you put a flag at the end instead of go files
+var namedFilesMustBeGoFiles = regexp.MustCompile("-: named files must be .go files: -(\\w)")
+
+// Captures error in the analysis for steps that require a main program
+var missingMainTestPackages = regexp.MustCompile("no main/test packages to analyze")
+
+// HintForErrorMessage looks for specific error message and returns some other message that might help the user
+// resolve the problem.
+func HintForErrorMessage(errMsg string) string {
+	if regexCouldNotLoad.MatchString(errMsg) {
+		if namedFilesMustBeGoFiles.MatchString(errMsg) {
+			return "all command line flags should be before the path to the Go files to analyze"
+		}
+		return "make sure you have provided the right arguments for an analyzer to load a Go program"
+	}
+	if missingMainTestPackages.MatchString(errMsg) {
+		return "this analysis analyzes executables with an entry point; the path should lead to a main package"
+	}
+	return ""
+}

--- a/cmd/argot/tools/interpret_test.go
+++ b/cmd/argot/tools/interpret_test.go
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func validateHint(t *testing.T, errorMsg string, containedHint string) {
+	hint := HintForErrorMessage(errorMsg)
+	if !strings.Contains(hint, containedHint) {
+		t.Fatalf("incorrect hint; check and update error message if necessary")
+	}
+}
+
+func TestHintForFlagAfterFiles(t *testing.T) {
+	errorMsg := "error: could not load program:\n -: named files must be .go files: -v"
+	containedHint := "all command line flags should be before the path"
+	validateHint(t, errorMsg, containedHint)
+}
+
+func TestHintForFailedLoadProgram(t *testing.T) {
+	errorMsg := "error: could not load program:\n errors found, exiting\n"
+	containedHint := "you have provided the right arguments for an analyzer to load a Go program"
+	validateHint(t, errorMsg, containedHint)
+}
+
+func TestHintForMissingMain(t *testing.T) {
+	errorMsg := "error: taint analysis failed: error while running parallel steps:" +
+		" failed to build analyzer state: no main/test packages to analyze (check $GOROOT/$GOPATH)\n"
+	containedHint := "this analysis analyzes executables with an entry point; the path should lead to a main package"
+	validateHint(t, errorMsg, containedHint)
+}


### PR DESCRIPTION
Adds simple hints printed when the program fails to help the user. We will extend the list as more error messages are encountered. Those error messages may come from dependencies (building ssa, pointer analysis) and thus we have no control over the original message.