### PR TITLE
Struct assignment as sink

### DIFF
--- a/analysis/analyzers.go
+++ b/analysis/analyzers.go
@@ -35,7 +35,9 @@ type IntraAnalysisParams struct {
 	ShouldBuildSummary func(*dataflow.AnalyzerState, *ssa.Function) bool
 
 	// ShouldTrack is a function that returns true if the node should be an entrypoint to the analysis.
-	// The entrypoint node is treated as a "source" of data.
+	// The node may be an entrypoint or an endpoint of an analysis.
+	// In particular, ShouldTrack identifies the special nodes that must be tracked but are not callgraph
+	// related nodes.
 	ShouldTrack func(*dataflow.AnalyzerState, ssa.Node) bool
 
 	// PostBlockCallback will be called each time a block is analyzed if the analysis is running on a single core

--- a/analysis/backtrace/backtrace.go
+++ b/analysis/backtrace/backtrace.go
@@ -134,7 +134,7 @@ func Analyze(logger *config.LogGroup, cfg *config.Config, prog *ssa.Program, pkg
 
 	analysis.RunIntraProceduralPass(state, numRoutines, analysis.IntraAnalysisParams{
 		ShouldBuildSummary: df.ShouldBuildSummary,
-		IsEntrypoint:       isSomeIntraProceduralEntryPoint,
+		ShouldTrack:        isSomeIntraProceduralEntryPoint,
 	})
 
 	var errs []error

--- a/analysis/backtrace/backtrace_taint_test.go
+++ b/analysis/backtrace/backtrace_taint_test.go
@@ -252,7 +252,7 @@ func isSourceNode(s *dataflow.AnalyzerState, source ssa.Node) bool {
 		}
 	}
 
-	return taint.IsSomeSourceNode(s, source)
+	return taint.IsSourceNode(s, nil, source)
 }
 
 func sourceNode(source dataflow.GraphNode) ssa.Node {

--- a/analysis/dataflow/function_summary_graph.go
+++ b/analysis/dataflow/function_summary_graph.go
@@ -202,9 +202,9 @@ func (g *SummaryGraph) initializeInnerNodes(s *AnalyzerState,
 			g.addIfNode(x)
 
 		// Other types of sources that may be used in config
-		case *ssa.Alloc, *ssa.FieldAddr, *ssa.Field, *ssa.UnOp:
+		case *ssa.Alloc, *ssa.FieldAddr, *ssa.Field, *ssa.UnOp, *ssa.Store:
 			if shouldTrack != nil && shouldTrack(s, x.(ssa.Node)) {
-				g.addSyntheticNode(x, "source")
+				g.addSyntheticNode(x, "synthetic")
 			}
 		}
 	})
@@ -1014,8 +1014,13 @@ func (a *SyntheticNode) String() string {
 	if a == nil {
 		return ""
 	}
-	return fmt.Sprintf("\"[#%d.%d] synthetic: %s = %s\"",
-		a.parent.ID, a.id, ftu.Sanitize(a.instr.(ssa.Value).Name()), ftu.SanitizeRepr(a.instr))
+	if _, isSsaValue := a.instr.(ssa.Value); isSsaValue {
+		return fmt.Sprintf("\"[#%d.%d] synthetic: %s = %s\"",
+			a.parent.ID, a.id, ftu.Sanitize(a.instr.(ssa.Value).Name()), ftu.SanitizeRepr(a.instr))
+	} else {
+		return fmt.Sprintf("\"[#%d.%d] synthetic: %s\"",
+			a.parent.ID, a.id, ftu.SanitizeRepr(a.instr))
+	}
 }
 
 func (a *FreeVarNode) String() string {

--- a/analysis/dataflow/function_summary_graph.go
+++ b/analysis/dataflow/function_summary_graph.go
@@ -204,6 +204,8 @@ func (g *SummaryGraph) initializeInnerNodes(s *AnalyzerState,
 		// Other types of sources that may be used in config
 		case *ssa.Alloc, *ssa.FieldAddr, *ssa.Field, *ssa.UnOp, *ssa.Store:
 			if shouldTrack != nil && shouldTrack(s, x.(ssa.Node)) {
+				// TODO: for debugging, shouldTrack could return the label to associate to the node
+				// instead of just a boolean.
 				g.addSyntheticNode(x, "synthetic")
 			}
 		}
@@ -1017,10 +1019,9 @@ func (a *SyntheticNode) String() string {
 	if _, isSsaValue := a.instr.(ssa.Value); isSsaValue {
 		return fmt.Sprintf("\"[#%d.%d] synthetic: %s = %s\"",
 			a.parent.ID, a.id, ftu.Sanitize(a.instr.(ssa.Value).Name()), ftu.SanitizeRepr(a.instr))
-	} else {
-		return fmt.Sprintf("\"[#%d.%d] synthetic: %s\"",
-			a.parent.ID, a.id, ftu.SanitizeRepr(a.instr))
 	}
+	return fmt.Sprintf("\"[#%d.%d] synthetic: %s\"",
+		a.parent.ID, a.id, ftu.SanitizeRepr(a.instr))
 }
 
 func (a *FreeVarNode) String() string {

--- a/analysis/dataflow/inter_procedural.go
+++ b/analysis/dataflow/inter_procedural.go
@@ -337,6 +337,7 @@ func scanEntryPoints(isEntryPointGraphNode func(node GraphNode) bool, g *InterPr
 		}
 
 		// special cases for each SSA node type supported
+		// TODO: try to factor out the special cases in the isEntryPointGraphNode functions
 		switch node := n.(type) {
 		case *SyntheticNode:
 			if _, isStore := node.instr.(*ssa.Store); !isStore {

--- a/analysis/dataflow/inter_procedural.go
+++ b/analysis/dataflow/inter_procedural.go
@@ -339,9 +339,12 @@ func scanEntryPoints(isEntryPointGraphNode func(node GraphNode) bool, g *InterPr
 		// special cases for each SSA node type supported
 		switch node := n.(type) {
 		case *SyntheticNode:
-			// all synthetic nodes are entry points
-			entry := NodeWithTrace{Node: node}
-			entryPoints[entry.Key()] = entry
+			if _, isStore := node.instr.(*ssa.Store); !isStore {
+				// all other non-store synthetic nodes are entry points.
+				// WARNING: revise when this changes!
+				entry := NodeWithTrace{Node: node}
+				entryPoints[entry.Key()] = entry
+			}
 		case *CallNodeArg:
 			if g.AnalyzerState.Config.SourceTaintsArgs &&
 				isEntryPointSsa(node.parent.CallSite().Value()) {

--- a/analysis/dataflow/inter_procedural_test.go
+++ b/analysis/dataflow/inter_procedural_test.go
@@ -50,7 +50,7 @@ func TestCrossFunctionFlowGraph(t *testing.T) {
 
 	analysis.RunIntraProceduralPass(state, numRoutines, analysis.IntraAnalysisParams{
 		ShouldBuildSummary: dataflow.ShouldBuildSummary,
-		IsEntrypoint:       func(*dataflow.AnalyzerState, ssa.Node) bool { return true },
+		ShouldTrack:        func(*dataflow.AnalyzerState, ssa.Node) bool { return true },
 	})
 
 	state, err = render.BuildCrossFunctionGraph(state)

--- a/analysis/dataflow/intra_procedural_test.go
+++ b/analysis/dataflow/intra_procedural_test.go
@@ -48,7 +48,7 @@ func TestFunctionSummaries(t *testing.T) {
 
 	analysis.RunIntraProceduralPass(state, numRoutines, analysis.IntraAnalysisParams{
 		ShouldBuildSummary: dataflow.ShouldBuildSummary,
-		IsEntrypoint:       taint.IsSomeSourceNode,
+		ShouldTrack:        taint.IsNodeOfInterest,
 	})
 
 	if len(state.FlowGraph.Summaries) == 0 {

--- a/analysis/taint/code_identifiers_test.go
+++ b/analysis/taint/code_identifiers_test.go
@@ -82,7 +82,7 @@ var taintSourcesAnalyzer = &analysis.Analyzer{
 
 // newSourceMap builds a SourceMap by inspecting the ssa for each function inside each package.
 func newSourceMap(s *dataflow.AnalyzerState) PackageToNodes {
-	return NewPackagesMap(s, taint.IsSomeSourceNode)
+	return NewPackagesMap(s, taint.IsNodeOfInterest)
 }
 
 // newSinkMap builds a SinkMap by inspecting the ssa for each function inside each package.

--- a/analysis/taint/taint.go
+++ b/analysis/taint/taint.go
@@ -92,7 +92,7 @@ func Analyze(cfg *config.Config, prog *ssa.Program, pkgs []*packages.Package) (A
 		analysis.IntraAnalysisParams{
 			ShouldBuildSummary: dataflow.ShouldBuildSummary,
 			// For the intra-procedural pass, all source nodes of all problems are marked
-			IsEntrypoint: IsSomeSourceNode,
+			ShouldTrack: IsNodeOfInterest,
 		})
 
 	// ** Third step **

--- a/analysis/taint/testdata/basic/config.yaml
+++ b/analysis/taint/testdata/basic/config.yaml
@@ -19,6 +19,9 @@ taint-tracking-problems:
     - package: "fmt"
       method: "Printf"
       value-match: ".*%s.*"
+    - type: "ExampleData"
+      field: "SinkField"
+      kind: "store"
   sanitizers:
     - package: "(basic)|(main)|(command-line-arguments)"
       method: ".*(s|S)anitize[1-9]?"

--- a/analysis/taint/testdata/basic/fields.go
+++ b/analysis/taint/testdata/basic/fields.go
@@ -84,3 +84,15 @@ func testFieldEmbedded() {
 	s4 := fmt.Sprintf("%s", s3)
 	sink1(s4) // @Sink(embedded1,embedded2)
 }
+
+type ExampleData struct {
+	SinkField string
+	OtherData string
+}
+
+func testStoreTaintedDataInField() {
+	x := source1() // @Source(storeTaintedData)
+	s := ExampleData{OtherData: "not tainted", SinkField: "not tainted"}
+	s.SinkField = x // @Sink(storeTaintedData)
+	println(s.SinkField)
+}

--- a/analysis/taint/testdata/basic/fields.go
+++ b/analysis/taint/testdata/basic/fields.go
@@ -20,6 +20,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math/rand"
+	"strconv"
 )
 
 type Example struct {
@@ -94,5 +96,21 @@ func testStoreTaintedDataInField() {
 	x := source1() // @Source(storeTaintedData)
 	s := ExampleData{OtherData: "not tainted", SinkField: "not tainted"}
 	s.SinkField = x // @Sink(storeTaintedData)
+	println(s.SinkField)
+}
+
+func genExample() Example {
+	s := "tainted" + strconv.Itoa(rand.Int())
+	o := "ok"
+	return Example{
+		SourceField: s,
+		OtherData:   o,
+	}
+}
+
+func testSourceFieldInSinkField() {
+	x := genExample()
+	s := ExampleData{OtherData: "not tainted", SinkField: "not tainted"}
+	s.SinkField = x.SourceField // @Source(sourceFieldInSinkField) @Sink(sourceFieldInSinkField)
 	println(s.SinkField)
 }

--- a/analysis/taint/testdata/basic/main.go
+++ b/analysis/taint/testdata/basic/main.go
@@ -58,18 +58,19 @@ func source1() string {
 
 func main() {
 	test0()
-	test1()                   // see bar.go
-	test2()                   // see example.go
-	test3(10)                 // see example.go
-	test4()                   // see example2.go
-	test5()                   // see example3.go
-	testField()               // see fields.go
-	testFieldEmbedded()       // see fields.go
-	testField2()              // see fields.go
-	runSanitizerExamples()    // see sanitizers.go
-	testAliasingTransitive()  // see memory.go
-	testChannelReadAsSource() // see channels.go
-	testValueMatch()          // see valuematch.go
+	test1()                       // see bar.go
+	test2()                       // see example.go
+	test3(10)                     // see example.go
+	test4()                       // see example2.go
+	test5()                       // see example3.go
+	testField()                   // see fields.go
+	testFieldEmbedded()           // see fields.go
+	testStoreTaintedDataInField() // see fields.go
+	testField2()                  // see fields.go
+	runSanitizerExamples()        // see sanitizers.go
+	testAliasingTransitive()      // see memory.go
+	testChannelReadAsSource()     // see channels.go
+	testValueMatch()              // see valuematch.go
 }
 
 type Data struct {

--- a/analysis/taint/testdata/basic/main.go
+++ b/analysis/taint/testdata/basic/main.go
@@ -66,6 +66,7 @@ func main() {
 	testField()                   // see fields.go
 	testFieldEmbedded()           // see fields.go
 	testStoreTaintedDataInField() // see fields.go
+	testSourceFieldInSinkField()  // see fields.go
 	testField2()                  // see fields.go
 	runSanitizerExamples()        // see sanitizers.go
 	testAliasingTransitive()      // see memory.go

--- a/cmd/argot/cli/analysis.go
+++ b/cmd/argot/cli/analysis.go
@@ -252,7 +252,7 @@ func cmdSummarize(tt *term.Terminal, c *dataflow.AnalyzerState, command Command,
 		}
 		analysis.RunIntraProceduralPass(c, numRoutines, analysis.IntraAnalysisParams{
 			ShouldBuildSummary: shouldBuildSummary,
-			IsEntrypoint:       taint.IsSomeSourceNode,
+			ShouldTrack:        taint.IsNodeOfInterest,
 		})
 		WriteSuccess(tt, "%d summaries created, %d built", createCounter, buildCounter)
 	} else {
@@ -283,7 +283,7 @@ func cmdSummarize(tt *term.Terminal, c *dataflow.AnalyzerState, command Command,
 		// Run the analysis with the filter.
 		analysis.RunIntraProceduralPass(c, numRoutines, analysis.IntraAnalysisParams{
 			ShouldBuildSummary: shouldBuildSummary,
-			IsEntrypoint:       taint.IsSomeSourceNode,
+			ShouldTrack:        taint.IsNodeOfInterest,
 		})
 		// Insert the summaries, i.e. only updated the summaries that have been computed and do not discard old ones
 

--- a/cmd/argot/cli/function.go
+++ b/cmd/argot/cli/function.go
@@ -340,7 +340,7 @@ func cmdIntra(tt *term.Terminal, c *dataflow.AnalyzerState, command Command, wit
 	}
 
 	_, err := dataflow.IntraProceduralAnalysis(c, state.CurrentFunction, true, 0,
-		taint.IsSomeSourceNode, post)
+		taint.IsNodeOfInterest, post)
 	if err != nil {
 		WriteErr(tt, "Error while analyzing.")
 		return false

--- a/cmd/argot/render/render.go
+++ b/cmd/argot/render/render.go
@@ -94,7 +94,7 @@ func WriteCrossFunctionGraph(cfg *config.Config, logger *config.LogGroup, progra
 
 	analysis.RunIntraProceduralPass(state, numRoutines, analysis.IntraAnalysisParams{
 		ShouldBuildSummary: dataflow.ShouldBuildSummary,
-		IsEntrypoint:       func(*dataflow.AnalyzerState, ssa.Node) bool { return true },
+		ShouldTrack:        func(*dataflow.AnalyzerState, ssa.Node) bool { return true },
 	})
 
 	state, err = render.BuildCrossFunctionGraph(state)

--- a/doc/01_taint.md
+++ b/doc/01_taint.md
@@ -105,6 +105,17 @@ taint-tracking-problems:
 ```
 This implies that any access to the field `taintedMember` of a struct of type `structA` in package `mypackage` will be seen as a source of tainted data.
 
+**Field writes** are of the form:
+```yaml
+taint-tracking-problems:
+    - sinks:
+        - package: "mypackage"
+          type: "structA"
+          field: "sensitiveStore"
+          kind: "store"
+```
+This implies that writing data to the field `sensitiveStore` of a struct of type `structA` defined in package `mypackage` will be seen as a sink for tainted data.
+
 **Interfaces** are of the form:
 ```yaml
 taint-tracking-problems:
@@ -114,7 +125,7 @@ taint-tracking-problems:
 ```
 This implies that any method whose receiver implements the `mypackage.interfaceName` interface will be seen as a sink.
 
-> The specifications for sources can be function calls, types, channel receives or field reads. The specifications for sinks, sanitizers and validators can only be functions (method and package) or interfaces (interface name and package).
+> The specifications for sources can be function calls, types, channel receives or field reads. The specifications sanitizers and validators can only be functions (method and package) or interfaces (interface name and package). The specifications for sinks can be functions calls and field writes.
 
 #### Code locations in a specific context
 

--- a/internal/analysisutil/analysisutil.go
+++ b/internal/analysisutil/analysisutil.go
@@ -204,6 +204,23 @@ func IsEntrypointNode(pointer *pointer.Result, n ssa.Node,
 			Package: packageName,
 			Type:    typeName})
 
+	// Storing into a specific struct field
+	case *ssa.Store:
+		if fieldAddr, isFieldAddr := node.Addr.(*ssa.FieldAddr); isFieldAddr {
+			fieldName, _ := FieldAddrFieldInfo(fieldAddr)
+			packageName, typeName, err := FindEltTypePackage(fieldAddr.X.Type(), "%s")
+			if err != nil {
+				return false
+			}
+			return f(config.CodeIdentifier{
+				Context: node.Parent().String(),
+				Package: packageName,
+				Field:   fieldName,
+				Type:    typeName,
+				Kind:    "store"})
+		}
+		return false
+
 	// Channel receives can be sources
 	case *ssa.UnOp:
 		if node.Op == token.ARROW {


### PR DESCRIPTION
Adds the possibillity of specifying assignment to a specific struct field as a sink for tainted data.
For example:
```yaml
taint-tracking-problems:
  - type: "ExampleData"
     field: "SinkField"
      kind: "store"
```
Means that storing tainted data in the field `SinkField` of a struct of type `ExampleData` should raise an alarm.