### PR TITLE
Using argot:ignore annotations in the taint analysis.

### DIFF
--- a/analysis/annotations/annotations.go
+++ b/analysis/annotations/annotations.go
@@ -211,19 +211,20 @@ func (pa ProgramAnnotations) Iter(fx func(a Annotation)) {
 	for _, cst := range pa.Globals {
 		funcutil.Iter(cst, fx)
 	}
+	for _, cst := range pa.Positional {
+		fx(cst)
+	}
 }
 
 // CompleteFromSyntax takes a set of program annotations and adds additional non-ssa linked annotations
 // to the annotations
-func (pa ProgramAnnotations) CompleteFromSyntax(logger *config.LogGroup, pkgs []*packages.Package) {
-	for _, pkg := range pkgs {
-		for _, astFile := range pkg.Syntax {
-			pa.loadPackageDocAnnotations(astFile.Doc)
-			for _, comments := range astFile.Comments {
-				for _, comment := range comments.List {
-					if annotationContents := extractAnnotation(comment); annotationContents != nil {
-						pa.loadFileAnnotations(logger, annotationContents, pkg.Fset.Position(comment.Pos()))
-					}
+func (pa ProgramAnnotations) CompleteFromSyntax(logger *config.LogGroup, pkg *packages.Package) {
+	for _, astFile := range pkg.Syntax {
+		pa.loadPackageDocAnnotations(astFile.Doc)
+		for _, comments := range astFile.Comments {
+			for _, comment := range comments.List {
+				if annotationContents := extractAnnotation(comment); annotationContents != nil {
+					pa.loadFileAnnotations(logger, annotationContents, pkg.Fset.Position(comment.Pos()))
 				}
 			}
 		}

--- a/analysis/annotations/annotations.go
+++ b/analysis/annotations/annotations.go
@@ -102,6 +102,7 @@ func (a Annotation) IsMatchingAnnotation(kind AnnotationKind, tag string) bool {
 	return a.Kind == kind && (tag == AnyTag || (len(a.Tags) > 0 && a.Tags[0] == AnyTag) || slices.Contains(a.Tags, tag))
 }
 
+// LinePos is a simple line-file position indicator.
 type LinePos struct {
 	Line int
 	File string

--- a/analysis/annotations/annotations_test.go
+++ b/analysis/annotations/annotations_test.go
@@ -36,9 +36,35 @@ func TestLoadAnnotations(t *testing.T) {
 	testProgram.Prog.Build()
 	logger := config.NewLogGroup(testProgram.Config)
 	a, err := annotations.LoadAnnotations(logger, testProgram.Prog.AllPackages())
+	a.CompleteFromSyntax(logger, testProgram.Pkgs)
 	if err != nil {
 		t.Errorf("error loading annotations: %s", err)
 	}
+
+	// Positional annotations like //argot:ignore
+	t.Logf("%d positional annotations", len(a.Positional))
+	if !funcutil.ExistsInMap(a.Positional, func(k annotations.LinePos, _ annotations.Annotation) bool {
+		return k.Line == 43
+	}) {
+		t.Errorf("Expected annotation at line 43.")
+	}
+
+	for pos, annot := range a.Positional {
+		if pos.Line == 43 && (annot.Kind != annotations.Ignore || !funcutil.Contains(annot.Tags, "_")) {
+			t.Errorf("Expected annotation at line 43 to be //argot:ignore _ but its %v", annot)
+		}
+	}
+
+	// Config annotations like //argot:config
+	t.Logf("%d config annotations", len(a.Configs))
+	if _, hasOpt := a.Configs["_"]; !hasOpt {
+		t.Errorf("expected a config option for _")
+	}
+	if a.Configs["_"]["log-level"] != "3" {
+		t.Errorf("Expected config option log-level set to 3 by annotation.")
+	}
+
+	// Function annotations like //argot:function and //argot:param
 	t.Logf("%d functions scanned", len(a.Funcs))
 	for ssaFunc, functionAnnotation := range a.Funcs {
 		switch ssaFunc.Name() {

--- a/analysis/annotations/annotations_test.go
+++ b/analysis/annotations/annotations_test.go
@@ -36,7 +36,7 @@ func TestLoadAnnotations(t *testing.T) {
 	testProgram.Prog.Build()
 	logger := config.NewLogGroup(testProgram.Config)
 	a, err := annotations.LoadAnnotations(logger, testProgram.Prog.AllPackages())
-	a.CompleteFromSyntax(logger, testProgram.Pkgs)
+	a.CompleteFromSyntax(logger, testProgram.Pkgs[0])
 	if err != nil {
 		t.Errorf("error loading annotations: %s", err)
 	}

--- a/analysis/annotations/testdata/main.go
+++ b/analysis/annotations/testdata/main.go
@@ -16,6 +16,8 @@ package main
 
 import "fmt"
 
+//argot:config _ @SetOptions(log-level=3) configures log-level for all problems
+
 // sink and source annotation are relative to data categories (e.g. in this example bar, io and html)
 // Sink(_) means it is always a sink
 
@@ -38,7 +40,7 @@ func foo() string {
 //
 //argot:function Sink(_)
 func superSensitiveFunction(iWillPrintYouUnencrypted string) {
-	fmt.Println(iWillPrintYouUnencrypted)
+	fmt.Println(iWillPrintYouUnencrypted) //argot:ignore _
 }
 
 // sanitizerOfIo

--- a/analysis/dataflow/inter_procedural.go
+++ b/analysis/dataflow/inter_procedural.go
@@ -312,12 +312,15 @@ func (g *InterProceduralFlowGraph) RunVisitorOnEntryPoints(visitor Visitor,
 	// entrypoints at once, but this would require a finer context-tracking mechanism than what the NodeWithCallStack
 	// implements.
 	// If the maximum number of alarms has been reached, stop early.
+	i := 0
 	for _, entry := range entryPoints {
 		if !g.AnalyzerState.TestAlarmCount() {
-			g.AnalyzerState.Logger.Warnf("Some entrypoints are skipped, max number of alarms reached.")
+			g.AnalyzerState.Logger.Warnf("%d entrypoints are skipped, max number of alarms reached.",
+				len(entryPoints)-i)
 			return
 		}
 		visitor.Visit(g.AnalyzerState, entry)
+		i++
 	}
 }
 

--- a/analysis/dataflow/state.go
+++ b/analysis/dataflow/state.go
@@ -38,7 +38,7 @@ type AnalyzerState struct {
 	// Annotations contains all the annotations of the program
 	Annotations annotations.ProgramAnnotations
 
-	// The logger used during the analysis (can be used to control output.
+	// The logger used during the analysis (can be used to control output).
 	Logger *config.LogGroup
 
 	// The configuration file for the analysis
@@ -217,6 +217,7 @@ func NewDefaultAnalyzer(p *ssa.Program, pkgs []*packages.Package) (*AnalyzerStat
 // CopyTo copies pointers in receiver into argument (shallow copy of everything except mutex).
 // Do not use two copies in separate routines.
 func (s *AnalyzerState) CopyTo(b *AnalyzerState) {
+	b.Annotations = s.Annotations
 	b.BoundingInfo = s.BoundingInfo
 	b.Config = s.Config
 	b.EscapeAnalysisState = s.EscapeAnalysisState

--- a/analysis/dataflow/state.go
+++ b/analysis/dataflow/state.go
@@ -25,6 +25,7 @@ import (
 	"github.com/awslabs/ar-go-tools/analysis/config"
 	"github.com/awslabs/ar-go-tools/analysis/lang"
 	"github.com/awslabs/ar-go-tools/analysis/summaries"
+	"github.com/awslabs/ar-go-tools/internal/analysisutil"
 	"github.com/awslabs/ar-go-tools/internal/pointer"
 	"golang.org/x/tools/go/callgraph"
 	"golang.org/x/tools/go/callgraph/cha"
@@ -120,10 +121,23 @@ func NewAnalyzerState(p *ssa.Program, pkgs []*packages.Package, l *config.LogGro
 	steps []func(*AnalyzerState)) (*AnalyzerState, error) {
 	var allContracts []Contract
 
-	// Load annotations
+	// Load annotations by scanning all packages' syntax
 	pa, err := annotations.LoadAnnotations(l, p.AllPackages())
+
 	if pkgs != nil {
-		pa.CompleteFromSyntax(l, pkgs)
+		for _, pkg := range pkgs {
+			analysisutil.VisitPackages(pkg, func(p *packages.Package) bool {
+				// Don't scan stdlib for annotations!
+				if summaries.IsStdPackageName(p.Name) {
+					return false
+				}
+				// TODO: find a way to not scan dependencies if there is demand. Currently, it is unlikely that some
+				// dependencies will contain argot annotations.
+				l.Debugf("Scan %s for annotations.\n", p.PkgPath)
+				pa.CompleteFromSyntax(l, p)
+				return true
+			})
+		}
 	}
 
 	if err != nil {

--- a/analysis/taint/report.go
+++ b/analysis/taint/report.go
@@ -76,7 +76,8 @@ func reportCoverage(coverage map[string]bool, coverageWriter io.StringWriter) {
 }
 
 // reportTaintFlow reports a taint flow by writing to a file if the configuration has the ReportPaths flag set,
-// and writing in the logger
+// and writing in the logger.
+// The function checks the annotations to suppress reports where there are //argot:ignore annotations.
 func reportTaintFlow(c *dataflow.AnalyzerState, source dataflow.NodeWithTrace, sink *dataflow.VisitorNode) {
 	c.Logger.Infof(" !!!! TAINT FLOW !!!!")
 	c.Logger.Infof(" 💀 Sink reached at %s\n", formatutil.Red(sink.Node.Position(c)))

--- a/analysis/taint/taint.go
+++ b/analysis/taint/taint.go
@@ -140,6 +140,7 @@ func Analyze(cfg *config.Config, prog *ssa.Program, pkgs []*packages.Package) (A
 			}
 		}
 		visitor := NewVisitor(&taintSpec)
+		state.Logger.Infof("Analyzing taint-tracking problem %s", taintSpec.Tag)
 		analysis.RunInterProcedural(state, visitor, analysis.InterProceduralParams{
 			// The entry points are specific to each taint tracking problem (unlike in the intra-procedural pass)
 			IsEntrypoint: func(node ssa.Node) bool { return IsSourceNode(state, &taintSpec, node) },

--- a/analysis/taint/testdata/annotations/main.go
+++ b/analysis/taint/testdata/annotations/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Specific problem-level config options can be set in annotations
-//argot:config lim SetOptions(max-alarms=2,unsafe-max-depth=2)
+//argot:config lim SetOptions(max-alarms=12,unsafe-max-depth=2)
 
 // bar
 // It is also a source for the problem hybridDef also defined in the config.json
@@ -79,7 +79,7 @@ func main() {
 	sink(s)                          //  @Sink(ex1)
 	sinkOnSecondArg(s, "ok")         // only second argument of this is a sink
 	sinkOnSecondArg("ok", s)         // @Sink(ex2)
-	sink(sanitizeSecondArg(s, "ok")) // @Sink(ex1)
+	sink(sanitizeSecondArg(s, "ok")) //argot:ignore _ (but should be an ex1 sink)
 	sink(sanitizeSecondArg("ok", s))
 	sink(sanitizer(s))
 	fmt.Println(s)            // @Sink(hybridDef)

--- a/doc/01_taint.md
+++ b/doc/01_taint.md
@@ -202,6 +202,17 @@ options:
     max-alarms: 2
 ```
 
+#### Finding Suppression
+
+You may encounter false positives in the taint analysis, some of which cannot be easily resolved by making the configuration more precise or by changing the code.
+When you are confident the finding is a false positive, you can suppress the findings of the taint analysis on a specific line by using the `//argot:ignore problem-tag` annotation. 
+For example:
+```go
+...
+   callSink(notReaalyTaintedData) //argot:ignore _ 
+```
+Will suppress findings for all taint problems. Taint problems can be associated with a `tag: tagName` in the configuration, and you can suppress findings specifically for `tagName` by using `//argot:ignore tagName`. 
+
 #### Warning Suppression 
 The use can set the setting `warn: false` to suppress warnings during the analysis. This means that if the analysis encounters program constructs that make it unsound, those will not be reported. This setting does not affect the soundness of the analysis, but it will cause the tool to not report when your program falls beyond the soundness guarantees.
 

--- a/internal/analysisutil/iterators.go
+++ b/internal/analysisutil/iterators.go
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysisutil
+
+import (
+	"golang.org/x/tools/go/packages"
+)
+
+// VisitPackages calls f recursively on the root package provided, and then all the imports provided f returns
+// true for that package. If f returns false, the imports will not be visited.
+func VisitPackages(root *packages.Package, f func(p *packages.Package) bool) {
+	seen := map[*packages.Package]bool{}
+	queue := []*packages.Package{root}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		if seen[cur] {
+			continue
+		}
+		if f(cur) {
+			for _, importedPkg := range cur.Imports {
+				queue = append(queue, importedPkg)
+			}
+		}
+		seen[cur] = true
+	}
+}

--- a/internal/funcutil/collections.go
+++ b/internal/funcutil/collections.go
@@ -134,6 +134,16 @@ func Exists[T any](a []T, f func(T) bool) bool {
 	return false
 }
 
+// ExistsInMap returns true when there exists some k,x in map a such that f(k,x), otherwise false.
+func ExistsInMap[K comparable, T any](a map[K]T, f func(K, T) bool) bool {
+	for k, x := range a {
+		if f(k, x) {
+			return true
+		}
+	}
+	return false
+}
+
 // FindMap returns Some(f(x)) when there exists some x in slice a such that p(f(x)), otherwise None.
 func FindMap[T any, R any](a []T, f func(T) R, p func(R) bool) Optional[R] {
 	for _, x := range a {


### PR DESCRIPTION
Annotating a line with `//argot:ignore` supresses findings on that line for the taint analysis. 
See `analysis/taint/testdata/annotations/main.go` for an example.
