### PR TITLE
Problem spec options

### DIFF
--- a/analysis/backtrace/backtrace.go
+++ b/analysis/backtrace/backtrace.go
@@ -342,7 +342,7 @@ func (v *Visitor) visit(s *df.AnalyzerState, entrypoint *df.CallNodeArg) error {
 						panic(fmt.Errorf("[No Context] no arg at call site %v when visiting node %v: %v", callSite, graphNode, err))
 					}
 					callSiteArg := callSite.Args()[graphNode.Index()]
-					if !callSiteArg.Graph().Constructed && !s.Config.UnsafeIgnoreNonSummarized {
+					if !callSiteArg.Graph().Constructed {
 						v.onDemandIntraProcedural(s, callSiteArg.Graph())
 					}
 					nextNodeWithTrace := df.NodeWithTrace{

--- a/analysis/backtrace/testdata/closures/config.yaml
+++ b/analysis/backtrace/testdata/closures/config.yaml
@@ -1,6 +1,6 @@
 # The package regex matches all possible ways the package name might appear depending on how the program is loaded
 taint-tracking-problems:
-  -
+  - tag: "taint"
     sources:
       - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Sources can be source1, source2, etc.

--- a/analysis/backtrace/testdata/closures_flowprecise/config.yaml
+++ b/analysis/backtrace/testdata/closures_flowprecise/config.yaml
@@ -1,6 +1,6 @@
 # The package regex matches all possible ways the package name might appear depending on how the program is loaded
 taint-tracking-problems:
-  -
+  - tag: "taint"
     sources:
       - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Sources can be source1, source2, etc.

--- a/analysis/backtrace/testdata/closures_paper/config.yaml
+++ b/analysis/backtrace/testdata/closures_paper/config.yaml
@@ -1,6 +1,6 @@
 # The package regex matches all possible ways the package name might appear depending on how the program is loaded
 taint-tracking-problems:
-  -
+  - tag: "taint"
     sources:
       - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Sources can be source1, source2, etc.

--- a/analysis/config/config.go
+++ b/analysis/config/config.go
@@ -214,6 +214,9 @@ type SlicingSpec struct {
 	// Filters contains a list of filters that can be used by analyses
 	Filters []CodeIdentifier
 
+	// Tag identifies a group of annotations when used with annotations
+	Tag string
+
 	// SkipBoundLabels indicates whether to skip flows that go through "bound labels", i.e. aliases of the variables
 	// bound by a closure. This can be useful to test data flows because bound labels generate a lot of false positives.
 	SkipBoundLabels bool `yaml:"unsafe-skip-bound-labels" json:"unsafe-skip-bound-labels"`

--- a/analysis/config/config.go
+++ b/analysis/config/config.go
@@ -337,7 +337,7 @@ func NewDefault() *Config {
 }
 
 func unmarshalConfig(b []byte, cfg *Config) error {
-	// Strict decoding for json config files: will warn user of misconfiguration
+	// Strict decoding for yaml config files: will warn user of misconfiguration
 	yamlDecoder := yaml.NewDecoder(bytes.NewReader(b))
 	yamlDecoder.KnownFields(true)
 	errYaml := yamlDecoder.Decode(cfg)
@@ -353,9 +353,30 @@ func unmarshalConfig(b []byte, cfg *Config) error {
 	jsonDecoder.DisallowUnknownFields()
 	errJson := jsonDecoder.Decode(cfg)
 	if errJson == nil {
-		return errJson
+		return nil
 	}
-	return fmt.Errorf("could not unmarshal config file, not as yaml: %w, not as xml: %v, not as json: %v",
+	return errorMisconfigurationGracefully(errYaml, errXML, errJson)
+}
+
+func errorMisconfigurationGracefully(errYaml, errXML, errJson error) error {
+	// A list of messages that is likely to appear if the user is using an old configuration file
+	oldConfigFingerprints := []string{
+		"field unsafe-max-depth not found in type config.Options",
+		"field max-alarms not found in type config.Options",
+		"field max-alarms not found in type config.Options",
+	}
+	msgUpgrade := "your config follows an outdated format. Please consult documentation and update the config file"
+	for _, fingerprint := range oldConfigFingerprints {
+		if strings.Contains(errYaml.Error(), fingerprint) {
+			return fmt.Errorf("could not parse config file:\n%w\n%s", errYaml, msgUpgrade)
+		}
+		if strings.Contains(errJson.Error(), fingerprint) {
+			return fmt.Errorf("could not parse config file:\n%w\n%s", errJson, msgUpgrade)
+		}
+	}
+
+	// default behaviour is just to forward the error messages of all unmarshalling attempts
+	return fmt.Errorf("could not parse config file, not as yaml: %w,\nnot as xml: %v,\nnot as json: %v\n",
 		errYaml, errXML, errJson)
 }
 
@@ -471,7 +492,7 @@ func Load(filename string, configBytes []byte) (*Config, error) {
 		cfg.PointerConfig = NewPointerConfig()
 	}
 
-	return cfg, nil
+	return cfg, cfg.Validate()
 }
 
 // LoadEscape adds the escape configuration settings from escapeConfigBytes into c.
@@ -700,17 +721,20 @@ func SetOption(c *Config, name, value string) (string, error) {
 // problem options. Overwriting is logged at info level.
 func OverrideWithAnalysisOptions(l *LogGroup, c *Config, o *AnalysisProblemOptions) {
 	if o.MaxAlarms != 0 {
-		l.Infof("Overring max-alarms with %d", o.MaxAlarms)
+		l.Infof("max-alarms set to %d (using problem's analysis-options)",
+			o.MaxAlarms)
 		c.MaxAlarms = o.MaxAlarms
 	}
 
 	if o.UnsafeMaxDepth != 0 {
-		l.Infof("Overring unsafe-max-depth with %d", o.UnsafeMaxDepth)
+		l.Infof("unsafe-max-depth set to %d (using problem's analysis-options)",
+			o.UnsafeMaxDepth)
 		c.UnsafeMaxDepth = o.UnsafeMaxDepth
 	}
 
 	if o.MaxEntrypointContextSize != 0 {
-		l.Infof("Overring max-entrypoint-context-size with %d", o.MaxEntrypointContextSize)
+		l.Infof("max-entrypoint-context-size set to %d (using problem's analysis-options)",
+			o.MaxEntrypointContextSize)
 		c.MaxEntrypointContextSize = o.MaxEntrypointContextSize
 	}
 }

--- a/analysis/config/config.go
+++ b/analysis/config/config.go
@@ -134,6 +134,32 @@ type Config struct {
 	StaticCommandsProblems []StaticCommandsSpec `yaml:"static-commands-problems" json:"static-commands-problems"`
 }
 
+// AnalysisProblemOptions are the options that are specific to an analysis problem.
+type AnalysisProblemOptions struct {
+	// MaxAlarms sets a limit for the number of alarms reported by an analysis.  If MaxAlarms > 0, then at most
+	// MaxAlarms will be reported. Otherwise, if MaxAlarms <= 0, it is ignored.
+	//
+	// This setting does not affect soundness, since event with max-alarms:1, at least one path will be reported if
+	// there is some potential alarm-causing result.
+	MaxAlarms int `xml:"max-alarms,attr" yaml:"max-alarms" json:"max-alarms"`
+
+	// UnsafeMaxDepth sets a limit for the number of function call depth explored during the analysis.
+	// The default is -1, and any value less than 0 is safe: the analysis will be sound and explore call depth
+	// without bounds.
+	//
+	// Setting UnsafeMaxDepth to a limit larger than 0 will yield unsound results, but can be useful to use the tool
+	// as a checking mechanism. Limiting the call depth will usually yield fewer false positives.
+	UnsafeMaxDepth int `xml:"unsafe-max-depth,attr" yaml:"unsafe-max-depth" json:"unsafe-max-depth"`
+
+	// MaxEntrypointContextSize sets the maximum context (call stack) size used when searching for entry points with context.
+	// This only impacts precision of the returned results.
+	//
+	// If MaxEntrypointContextSize is < 0, it is ignored.
+	// If MaxEntrypointContextSize is 0 is specified by the user, the value is ignored, and a default internal value is used.
+	// If MaxEntrypointContextSize is > 0, then the limit in the callstack size for the context is used.
+	MaxEntrypointContextSize int `xml:"max-entrypoint-context-size,attr" yaml:"max-entrypoint-context-size" json:"max-entrypoint-context-size"`
+}
+
 // PointerConfig is the pointer analysis specific configuration.
 type PointerConfig struct {
 	// UnsafeNoEffectFunctions is a list of function names that produce no constraints in the pointer analysis.
@@ -149,6 +175,7 @@ type PointerConfig struct {
 // TaintSpec contains code identifiers that identify a specific taint tracking problem, or contains a code that
 // can differentiate groups of annotations
 type TaintSpec struct {
+	*AnalysisProblemOptions `xml:"analysis-options,attr" yaml:"analysis-options" json:"analysis-options"`
 	// Sanitizers is the list of sanitizers for the taint analysis
 	Sanitizers []CodeIdentifier
 
@@ -179,6 +206,7 @@ type TaintSpec struct {
 
 // SlicingSpec contains code identifiers that identify a specific program slicing / backwards dataflow analysis spec.
 type SlicingSpec struct {
+	*AnalysisProblemOptions `xml:"analysis-options,attr" yaml:"analysis-options" json:"analysis-options"`
 	// BacktracePoints is the list of identifiers to be considered as entrypoint functions for the backwards
 	// dataflow analysis.
 	BacktracePoints []CodeIdentifier
@@ -199,7 +227,10 @@ type StaticCommandsSpec struct {
 }
 
 // Options holds the global options for analyses
+// embeds AnalysisProblemOptions
 type Options struct {
+	AnalysisProblemOptions `xml:"analysis-options,attr" yaml:"analysis-options" json:"analysis-options"`
+
 	// Path to a JSON file that has the escape configuration (allow/blocklist)
 	EscapeConfigFile string `xml:"escape-config,attr" yaml:"escape-config" json:"escape-config"`
 
@@ -209,21 +240,6 @@ type Options struct {
 
 	// Loglevel controls the verbosity of the tool
 	LogLevel int `xml:"log-level,attr" yaml:"log-level" json:"log-level"`
-
-	// MaxAlarms sets a limit for the number of alarms reported by an analysis.  If MaxAlarms > 0, then at most
-	// MaxAlarms will be reported. Otherwise, if MaxAlarms <= 0, it is ignored.
-	//
-	// This setting does not affect soundness, since event with max-alarms:1, at least one path will be reported if
-	// there is some potential alarm-causing result.
-	MaxAlarms int `xml:"max-alarms,attr" yaml:"max-alarms" json:"max-alarms"`
-
-	// MaxEntrypointContextSize sets the maximum context (call stack) size used when searching for entry points with context.
-	// This only impacts precision of the returned results.
-	//
-	// If MaxEntrypointContextSize is < 0, it is ignored.
-	// If MaxEntrypointContextSize is 0 is specified by the user, the value is ignored, and a default internal value is used.
-	// If MaxEntrypointContextSize is > 0, then the limit in the callstack size for the context is used.
-	MaxEntrypointContextSize int `xml:"max-entrypoint-context-size,attr" yaml:"max-entrypoint-context-size" json:"max-entrypoint-context-size"`
 
 	// PathSensitive is a boolean indicating whether the analysis should be run with access path sensitivity on
 	// (will change to include more filtering in the future)
@@ -278,19 +294,6 @@ type Options struct {
 	// SummarizeOnDemand specifies whether the graph should build summaries on-demand instead of all at once
 	SummarizeOnDemand bool `xml:"summarize-on-demand,attr" yaml:"summarize-on-demand" json:"summarize-on-demand"`
 
-	// UnsafeMaxDepth sets a limit for the number of function call depth explored during the analysis.
-	// The default is -1, and any value less or equal than 0 is safe: the analysis will be sound and explore call depth
-	// without bounds.
-	//
-	// Setting UnsafeMaxDepth to a limit larger than 0 will yield unsound results, but can be useful to use the tool
-	// as a checking mechanism. Limiting the call depth will usually yield fewer false positives.
-	UnsafeMaxDepth int `xml:"unsafe-max-depth,attr" yaml:"unsafe-max-depth" json:"unsafe-max-depth"`
-
-	// UnsafeIgnoreNonSummarized allows the analysis to ignore when the summary of a function has not been built in
-	// the first analysis phase. This is only for experimentation, since the results may be unsound.
-	// This has no effect when SummarizeOnDemand is true.
-	UnsafeIgnoreNonSummarized bool `xml:"unsafeIgnoreNonSummarized,attr" yaml:"unsafe-ignore-non-summarized" json:"unsafe-ignore-non-summarized"`
-
 	// Run and use the escape analysis for analyses that have the option to use the escape analysis results.
 	UseEscapeAnalysis bool `xml:"use-escape-analysis,attr" yaml:"use-escape-analysis" json:"use-escape-analysis"`
 }
@@ -307,6 +310,11 @@ func NewDefault() *Config {
 		EscapeConfig:           NewEscapeConfig(),
 		PointerConfig:          NewPointerConfig(),
 		Options: Options{
+			AnalysisProblemOptions: AnalysisProblemOptions{
+				UnsafeMaxDepth:           DefaultSafeMaxDepth,
+				MaxAlarms:                0,
+				MaxEntrypointContextSize: DefaultSafeMaxEntrypointContextSize,
+			},
 			ReportsDir:                "",
 			PkgFilter:                 "",
 			SkipInterprocedural:       false,
@@ -315,13 +323,9 @@ func NewDefault() *Config {
 			ReportPaths:               false,
 			ReportCoverage:            false,
 			ReportNoCalleeSites:       false,
-			UnsafeMaxDepth:            DefaultSafeMaxDepth,
-			MaxAlarms:                 0,
-			MaxEntrypointContextSize:  DefaultSafeMaxEntrypointContextSize,
 			LogLevel:                  int(InfoLevel),
 			SilenceWarn:               false,
 			SourceTaintsArgs:          false,
-			UnsafeIgnoreNonSummarized: false,
 			PathSensitive:             false,
 			PathSensitiveFuncs:        []string{},
 			pathSensitiveFuncsRegexes: nil,
@@ -687,4 +691,23 @@ func SetOption(c *Config, name, value string) (string, error) {
 		return prev, nil
 	}
 	return "", fmt.Errorf("%s cannot be set by name", name)
+}
+
+// OverrideWithAnalysisOptions overwrites the options in the config with the non-default options in the analysis
+// problem options. Overwriting is logged at info level.
+func OverrideWithAnalysisOptions(l *LogGroup, c *Config, o *AnalysisProblemOptions) {
+	if o.MaxAlarms != 0 {
+		l.Infof("Overring max-alarms with %d", o.MaxAlarms)
+		c.MaxAlarms = o.MaxAlarms
+	}
+
+	if o.UnsafeMaxDepth != 0 {
+		l.Infof("Overring unsafe-max-depth with %d", o.UnsafeMaxDepth)
+		c.UnsafeMaxDepth = o.UnsafeMaxDepth
+	}
+
+	if o.MaxEntrypointContextSize != 0 {
+		l.Infof("Overring max-entrypoint-context-size with %d", o.MaxEntrypointContextSize)
+		c.MaxEntrypointContextSize = o.MaxEntrypointContextSize
+	}
 }

--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -154,6 +155,25 @@ func TestLoadBadFormatFileReturnsError(t *testing.T) {
 	config, err := Load(name, b)
 	if config != nil || err == nil {
 		t.Errorf("Expected error and nil value when trying to load a badly formatted file.")
+	}
+}
+
+func TestLoadVersionBefore_v0_3_0_Errors(t *testing.T) {
+	_, config, err := loadFromTestDir("config_before_v0_3_0.yaml")
+	if config != nil || err == nil {
+		t.Fatalf("Expected error and nil value when trying to load config with bad format")
+	}
+	msg1 := "Please consult documentation and update the config file"
+	if !strings.Contains(err.Error(), msg1) {
+		t.Errorf("Error message:\n%s\nshould contain %s", err, msg1)
+	}
+
+	_, configJson, errJson := loadFromTestDir("config_before_v0_3_0.json")
+	if configJson != nil || errJson == nil {
+		t.Fatalf("Expected error and nil value when trying to load config with bad format")
+	}
+	if !strings.Contains(errJson.Error(), msg1) {
+		t.Errorf("Error message:\n%s\nshould contain %s", errJson, msg1)
 	}
 }
 

--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -200,7 +200,7 @@ func TestLoadWithNoSpecifiedReportsDir(t *testing.T) {
 func TestLoadFullConfigYaml(t *testing.T) {
 	fileName, config, err := loadFromTestDir("full-config.yaml")
 	if config == nil || err != nil {
-		t.Errorf("Could not load %s", fileName)
+		t.Errorf("Could not load %s: %s", fileName, err)
 		return
 	}
 	if config.LogLevel != int(TraceLevel) {
@@ -246,14 +246,14 @@ func TestLoadFullConfigYaml(t *testing.T) {
 		len(config.TaintTrackingProblems[0].Sources) != 1 {
 		t.Error("full config should have one element in each of sinks, validators, sanitizers and sources")
 	}
+	if config.TaintTrackingProblems[0].UnsafeMaxDepth != 1 {
+		t.Error("analysis option unsafe-max-depth should be 1 for taint-tracking-problem")
+	}
 	if !config.SourceTaintsArgs {
 		t.Error("full config should have source-taints-args set")
 	}
 	if !config.SilenceWarn {
 		t.Error("full config should have silence-warn set to true")
-	}
-	if !config.UnsafeIgnoreNonSummarized {
-		t.Errorf("full config should have set unsafeignorenonsummarized")
 	}
 	if !config.UseEscapeAnalysis {
 		t.Errorf("full config should have set useescapeaanalysis")
@@ -271,17 +271,17 @@ func TestLoadFullConfigYamlEqualsJson(t *testing.T) {
 	_, yamlConfig, yamlErr := loadFromTestDir("full-config.yaml")
 	_, jsonConfig, jsonErr := loadFromTestDir("full-config.json")
 	if jsonErr != nil {
-		t.Errorf("failed to load json config")
+		t.Fatalf("failed to load json config")
 	}
 	if yamlErr != nil {
-		t.Errorf("failed to load yaml config")
+		t.Fatalf("failed to load yaml config")
 	}
 	jsonConfig.sourceFile = ""
 	yamlConfig.sourceFile = ""
 	if jsonConfig.ReportCoverage != yamlConfig.ReportCoverage &&
 		jsonConfig.SilenceWarn != yamlConfig.SilenceWarn &&
 		jsonConfig.LogLevel != yamlConfig.LogLevel &&
-		jsonConfig.UnsafeIgnoreNonSummarized != yamlConfig.Options.UnsafeIgnoreNonSummarized &&
+		jsonConfig.UnsafeMaxDepth != yamlConfig.Options.UnsafeMaxDepth &&
 		jsonConfig.UnsafeMaxDepth != yamlConfig.UnsafeMaxDepth {
 		t.Errorf("config options in json and yaml should be the same")
 	}
@@ -337,10 +337,12 @@ func TestLoadMisc(t *testing.T) {
 				},
 			},
 			Options: Options{
-				PkgFilter:                "a",
-				UnsafeMaxDepth:           DefaultSafeMaxDepth,
-				MaxEntrypointContextSize: DefaultSafeMaxEntrypointContextSize,
-				SilenceWarn:              false,
+				PkgFilter: "a",
+				AnalysisProblemOptions: AnalysisProblemOptions{
+					UnsafeMaxDepth:           DefaultSafeMaxDepth,
+					MaxEntrypointContextSize: DefaultSafeMaxEntrypointContextSize,
+				},
+				SilenceWarn: false,
 			},
 			EscapeConfig:  NewEscapeConfig(),
 			PointerConfig: NewPointerConfig(),

--- a/analysis/config/testdata/config_before_v0_3_0.json
+++ b/analysis/config/testdata/config_before_v0_3_0.json
@@ -1,0 +1,37 @@
+{
+  "options": {
+    "log-level": 5,
+    "reports-dir": "example-dir",
+    "report-coverage": true,
+    "report-paths": true,
+    "report-no-callee-sites": true,
+    "coverage-filter": "argot.*",
+    "report-summaries": true,
+    "pkg-filter": "analysis.*",
+    "silence-warn": true,
+    "source-taints-args": true,
+    "use-escape-analysis": true,
+    "summarize-on-demand": true,
+    "skip-interprocedural": true,
+    "field-sensitive": true,
+    "max-alarms": 16,
+    "unsafe-max-depth": 42,
+    "max-entrypoint-context-size": 20
+  },
+  "pointer-config": {
+    "reflection": true,
+    "unsafe-no-effect-functions": [
+      "fmt.Errorf",
+      "fmt.Printf"
+    ]
+  },
+  "dataflow-specs": ["example.json", "example2.json"],
+  "taint-tracking-problems": [
+    {
+      "validators": [{"method": "Validate", "package": "x"}],
+      "sinks": [{"method": "Sink", "package":  "sensitiveDataManipulation"}],
+      "sources": [{"type": "Data", "field":  "UserProvided"}],
+      "sanitizers": [{"method": "Sanitize"}]
+    }
+  ]
+}

--- a/analysis/config/testdata/config_before_v0_3_0.yaml
+++ b/analysis/config/testdata/config_before_v0_3_0.yaml
@@ -1,0 +1,37 @@
+# This is a complete config file. All fields are mostly optional, unless clearly required by the analysis you
+# are trying to run.
+
+options:
+  log-level: 5
+  field-sensitive: true
+  # Before v0.3.0 below were simple config options
+  unsafe-max-depth: 42
+  max-alarms: 16
+  max-entrypoint-context-size: 20
+
+dataflow-specs:
+  - "example.json"
+  - "example2.json"
+
+pointer-config:
+  reflection: true
+  unsafe-no-effect-functions:
+    - "fmt.Errorf"
+    - "fmt.Printf"
+
+taint-tracking-problems:
+  - validators:
+      - method: "Validate"
+        package: "x"
+
+    sinks:
+      - method: "Sink"
+        package: "sensitiveDataManipulation"
+
+    sources:
+      - type: "Data"
+        field: "UserProvided"
+
+    sanitizers:
+      - method: "Sanitize"
+

--- a/analysis/config/testdata/full-config.json
+++ b/analysis/config/testdata/full-config.json
@@ -8,16 +8,17 @@
     "coverage-filter": "argot.*",
     "report-summaries": true,
     "pkg-filter": "analysis.*",
-    "max-alarms": 16,
-    "max-entrypoint-context-size": 20,
     "silence-warn": true,
     "source-taints-args": true,
-    "unsafe-max-depth": 42,
-    "unsafe-ignore-non-summarized": true,
     "use-escape-analysis": true,
     "summarize-on-demand": true,
     "skip-interprocedural": true,
-    "field-sensitive": true
+    "field-sensitive": true,
+    "analysis-options": {
+      "max-alarms": 16,
+      "unsafe-max-depth": 42,
+      "max-entrypoint-context-size": 20
+    }
   },
   "pointer-config": {
     "reflection": true,
@@ -32,7 +33,10 @@
       "validators": [{"method": "Validate", "package": "x"}],
       "sinks": [{"method": "Sink", "package":  "sensitiveDataManipulation"}],
       "sources": [{"type": "Data", "field":  "UserProvided"}],
-      "sanitizers": [{"method": "Sanitize"}]
+      "sanitizers": [{"method": "Sanitize"}],
+      "analysis-options": {
+        "unsafe-max-depth": 1
+      }
     }
   ]
 }

--- a/analysis/config/testdata/full-config.yaml
+++ b/analysis/config/testdata/full-config.yaml
@@ -37,28 +37,11 @@ options:
   # packages that do not match the regex will not be analyzed
   pkg-filter: "analysis.*"
 
-  # this can be set to limit the number of alarms raised by an analysis if you only care about the truth value of
-  # the output, or only want to analyze a few results
-  max-alarms: 16
-
-  # this can be used to limit the size of the callstack when searching for contexts under which a function can be
-  # called.
-  max-entrypoint-context-size: 20
-
   # this can be set to suppress warnings. Errors (i.e. taint detected will be reported)
   silence-warn: true
 
   # this can be set so that source function are also tainting their arguments
   source-taints-args: true
-
-  # this option makes analyzes unsound, but can be useful in exploration. This ignores when functions have not
-  # been summarized during the inter-procedural step
-  unsafe-ignore-non-summarized: true
-
-  # For context-sensitive graph reachability based analysis this parameter can be used to limit the callstack depth
-  # that can be considered during the analysis. This can be used for debugging, or to artifically only filter
-  # short traces
-  unsafe-max-depth: 42
 
   # this options ensures that the escape analysis is run in parallel with the dataflow analysis
   use-escape-analysis: true
@@ -68,6 +51,20 @@ options:
 
   # This setting sets whether the analysis is field sensitive
   field-sensitive: true
+
+  analysis-options:
+    # For context-sensitive graph reachability based analysis this parameter can be used to limit the callstack depth
+    # that can be considered during the analysis. This can be used for debugging, or to artifically only filter
+    # short traces
+    unsafe-max-depth: 42
+
+    # this can be set to limit the number of alarms raised by an analysis if you only care about the truth value of
+    # the output, or only want to analyze a few results
+    max-alarms: 16
+
+    # this can be used to limit the size of the callstack when searching for contexts under which a function can be
+    # called.
+    max-entrypoint-context-size: 20
 
 # For any dataflow analysis, you can specify summaries for specific functions and interfaces. The analysis will
 # use each of those files as a reference for the functions specified
@@ -97,3 +94,6 @@ taint-tracking-problems:
 
     sanitizers:
       - method: "Sanitize"
+
+    analysis-options:
+      unsafe-max-depth: 1

--- a/analysis/config/validation.go
+++ b/analysis/config/validation.go
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/awslabs/ar-go-tools/internal/funcutil"
+)
+
+// Validate validates the config and returns an error if there is some invalid setting
+func (c Config) Validate() error {
+	if err := c.checkTagsAreUnique(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c Config) checkTagsAreUnique() error {
+	hasUnsetTag := false
+	tags := map[string]bool{}
+	tagsList := funcutil.Map(c.TaintTrackingProblems, func(ts TaintSpec) string { return ts.Tag })
+	tagsList = append(tagsList, funcutil.Map(c.SlicingProblems, func(ts SlicingSpec) string { return ts.Tag })...)
+	for _, tag := range tagsList {
+		if tag == "" {
+			if hasUnsetTag {
+				return fmt.Errorf("there can be only one problem with an unspecified tag")
+			}
+			hasUnsetTag = true
+		} else if tags[tag] {
+			return fmt.Errorf("tag %s is used for multiple problems", tag)
+		}
+		tags[tag] = true
+	}
+	return nil
+}

--- a/analysis/dataflow/state.go
+++ b/analysis/dataflow/state.go
@@ -304,6 +304,11 @@ func (s *AnalyzerState) HasErrors() bool {
 	return false
 }
 
+// ResetAlarms resets the number of alarms to 0
+func (s *AnalyzerState) ResetAlarms() {
+	s.numAlarms.Store(0)
+}
+
 // IncrementAndTestAlarms increments the alarm counter in the state, and returns false if the count is larger
 // than the MaxAlarms setting in the config.
 func (s *AnalyzerState) IncrementAndTestAlarms() bool {

--- a/analysis/dataflow/testdata/bounding-analysis/config.yaml
+++ b/analysis/dataflow/testdata/bounding-analysis/config.yaml
@@ -1,6 +1,6 @@
 # The package regex matches all possible ways the package name might appear depending on how the program is loaded
 taint-tracking-problems:
-  -
+  - tag: "taint1"
     sources:
       - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Sources can be source1, source2, etc.
@@ -18,3 +18,4 @@ slicing-problems:
       - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
+    tag: "slicing1"

--- a/analysis/dataflow/testdata/callctx/config.yaml
+++ b/analysis/dataflow/testdata/callctx/config.yaml
@@ -1,2 +1,3 @@
 options:
-  max-alarms: 1000
+  analysis-options:
+    max-alarms: 1000

--- a/analysis/dataflow/testdata/callgraph/config.yaml
+++ b/analysis/dataflow/testdata/callgraph/config.yaml
@@ -1,2 +1,3 @@
 options:
-  max-alarms: 1000
+  analysis-options:
+    max-alarms: 1000

--- a/analysis/taint/taint.go
+++ b/analysis/taint/taint.go
@@ -128,8 +128,7 @@ func Analyze(cfg *config.Config, prog *ssa.Program, pkgs []*packages.Package) (A
 
 		state.Logger.Infof("Analyzing taint-tracking problem %s", taintSpec.Tag)
 		// Set problem-specific options
-		var prevOptions config.AnalysisProblemOptions
-		prevOptions = state.Config.AnalysisProblemOptions
+		prevOptions := state.Config.AnalysisProblemOptions
 
 		// Overriding options with problem-specific config
 		if taintSpec.AnalysisProblemOptions != nil {

--- a/analysis/taint/testdata/annotations/config.json
+++ b/analysis/taint/testdata/annotations/config.json
@@ -1,12 +1,36 @@
 {
   "options": {
-    "log-level": 4
+    "log-level": 4,
+    "analysis-options": {
+      "unsafe-max-depth": 42
+    }
   },
   "taint-tracking-problems": [
     {
       "tag": "hybridDef",
       "sinks": [
         {"package":  "fmt", "method": "Println"}
+      ]
+    },
+    {
+      "tag": "foo",
+      "sources": [
+        {"method": "sourceFoo"}
+      ],
+      "sinks": [
+        {"method": "sinkFoo"}
+      ],
+      "analysis-options": {
+        "unsafe-max-depth": 1
+      }
+    },
+    {
+      "tag": "bar",
+      "sources": [
+        {"method": "sourceFoo"}
+      ],
+      "sinks": [
+        {"method": "sinkBar"}
       ]
     }
   ]

--- a/analysis/taint/testdata/closures/config.yaml
+++ b/analysis/taint/testdata/closures/config.yaml
@@ -1,6 +1,6 @@
 # The package regex matches all possible ways the package name might appear depending on how the program is loaded
 taint-tracking-problems:
-  -
+  - tag: "taint"
     sources:
       - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Sources can be source1, source2, etc.
@@ -14,7 +14,8 @@ taint-tracking-problems:
 
 # Same as sinks
 slicing-problems:
-  - backtracepoints:
+  - tag: "slicing"
+    backtracepoints:
       - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"

--- a/analysis/taint/testdata/closures_flowprecise/config.yaml
+++ b/analysis/taint/testdata/closures_flowprecise/config.yaml
@@ -1,6 +1,6 @@
 # The package regex matches all possible ways the package name might appear depending on how the program is loaded
 taint-tracking-problems:
-  -
+  - tag: "taint1"
     sources:
       - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Sources can be source1, source2, etc.
@@ -13,7 +13,7 @@ taint-tracking-problems:
 
 # Same as sinks
 slicing-problems:
-  -
+  - tag: "slicing"
     backtracepoints:
       - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...

--- a/analysis/taint/testdata/closures_paper/config.yaml
+++ b/analysis/taint/testdata/closures_paper/config.yaml
@@ -17,3 +17,7 @@ slicing-problems:
       - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
+
+options:
+  analysis-options:
+    max-entrypoint-context-size: 5

--- a/analysis/taint/testdata/closures_paper/config.yaml
+++ b/analysis/taint/testdata/closures_paper/config.yaml
@@ -1,6 +1,6 @@
 # The package regex matches all possible ways the package name might appear depending on how the program is loaded
 taint-tracking-problems:
-  -
+  - tag: "taint1"
     sources:
       - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Sources can be source1, source2, etc.
@@ -12,7 +12,7 @@ taint-tracking-problems:
 
 # Same as sinks
 slicing-problems:
-  -
+  - tag: "slicing1"
     backtracepoints:
       - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...

--- a/analysis/version.go
+++ b/analysis/version.go
@@ -15,4 +15,4 @@
 package analysis
 
 // Version is the last tagged version of the analysis tool
-const Version = "v0.2.2"
+const Version = "v0.3.0"

--- a/payload/selfcheck/config.yaml
+++ b/payload/selfcheck/config.yaml
@@ -1,11 +1,12 @@
 options:
   log-level: 3
-  max-alarms: 10
-  unsafe-max-depth: 6
   reports-dir: "payload/selfcheck/taint-report"
-  max-entrypoint-context-size: 2
   summarize-on-demand: true
   report-paths: true
+  analysis-options:
+    max-alarms: 10
+    unsafe-max-depth: 6
+    max-entrypoint-context-size: 2
   field-sensitive-funcs:
     - "AnalyzerState"
 


### PR DESCRIPTION
This PR:
+ moves the `unsafe-max-depth`, `max-entrypoint-context-size` and `max-alarms` options into a sub-option group `analysis-options` for options that apply individually to each analysis problem.
+ adds the possibility for taint and slicing problems to redefine their own `analysis-options`.
+ adds logging when option values are being overriden by annotations or problem-specific options.
+ adds some errors capturing when an old configuration is being used.
+ adds a check forcing tag to be unique for analysis problems when there are multiple
- deprecates the `unsafe-ignore-non-summarized` option which is useless when using on-demand summarization.

Since the previous configuration files are incompatible, this bumps the version to 0.3.0.

