### PR TITLE
Config and new options

### DIFF
--- a/analysis/analyzers.go
+++ b/analysis/analyzers.go
@@ -87,18 +87,12 @@ func runJobs(jobs []singleFunctionJob, numRoutines int,
 	return funcutil.MapParallel(jobs, f, numRoutines)
 }
 
-// InterProceduralParams represents the arguments to RunInterProcedural.
-type InterProceduralParams struct {
-	// IsEntryPoint is a predicate that defines which ssa nodes are entry points of the analysis.
-	IsEntrypoint func(ssa.Node) bool
-}
-
 // RunInterProcedural runs the inter-procedural analysis pass.
 // It builds args.FlowGraph and populates args.DataFlowCandidates based on additional data from the analysis.
-func RunInterProcedural(state *dataflow.AnalyzerState, visitor dataflow.Visitor, params InterProceduralParams) {
+func RunInterProcedural(state *dataflow.AnalyzerState, visitor dataflow.Visitor, spec dataflow.ScanningSpec) {
 	state.Logger.Infof("Starting inter-procedural pass...")
 	start := time.Now()
-	state.FlowGraph.BuildAndRunVisitor(state, visitor, params.IsEntrypoint)
+	state.FlowGraph.BuildAndRunVisitor(state, visitor, spec)
 	state.Logger.Infof("inter-procedural pass done (%.2f s).", time.Since(start).Seconds())
 }
 

--- a/analysis/backtrace/backtrace.go
+++ b/analysis/backtrace/backtrace.go
@@ -155,8 +155,8 @@ func Analyze(logger *config.LogGroup, cfg *config.Config, prog *ssa.Program, pkg
 			SlicingSpec: &ps,
 			Traces:      make(map[df.GraphNode][]Trace),
 		}
-		analysis.RunInterProcedural(state, visitor, analysis.InterProceduralParams{
-			IsEntrypoint: func(node ssa.Node) bool {
+		analysis.RunInterProcedural(state, visitor, df.ScanningSpec{
+			IsEntryPointSsa: func(node ssa.Node) bool {
 				return df.IsBacktraceNode(state, visitor.SlicingSpec, node)
 			},
 		})

--- a/analysis/backtrace/backtrace.go
+++ b/analysis/backtrace/backtrace.go
@@ -342,7 +342,7 @@ func (v *Visitor) visit(s *df.AnalyzerState, entrypoint *df.CallNodeArg) error {
 						panic(fmt.Errorf("[No Context] no arg at call site %v when visiting node %v: %v", callSite, graphNode, err))
 					}
 					callSiteArg := callSite.Args()[graphNode.Index()]
-					if !callSiteArg.Graph().Constructed && !s.Config.UnsafeIgnoreNonSummarized {
+					if !callSiteArg.Graph().Constructed {
 						v.onDemandIntraProcedural(s, callSiteArg.Graph())
 					}
 					nextNodeWithTrace := df.NodeWithTrace{

--- a/analysis/backtrace/testdata/backtrace/config.yaml
+++ b/analysis/backtrace/testdata/backtrace/config.yaml
@@ -1,7 +1,8 @@
-slicing-problems:
-  - backtracepoints:
-      - package: "os/exec"
-        method: "^Command$"
+dataflow-problems:
+  slicing:
+    - backtracepoints:
+        - package: "os/exec"
+          method: "^Command$"
 
 options:
   log-level: 3 # info logging

--- a/analysis/backtrace/testdata/basic/config.yaml
+++ b/analysis/backtrace/testdata/basic/config.yaml
@@ -1,18 +1,19 @@
-taint-tracking-problems:
- - # The package regex matches all possible ways the package name might appear depending on how the program is loaded
-  sources:
-    - package: "(basic)|(main)|(command-line-arguments)"
-      # Sources can be source1, source2, etc.
-      method: "(source[1-9])"
-    - package: "(basic)|(main)|(command-line-arguments)"
-      field: "Source[1-9]?"
-    - package: "(basic)|(main)|(command-line-arguments)"
-      type: "(chan \\*_S)|(chan _S)"
-      kind: "channel receive"
-  sinks:
-    - package: "(basic)|(main)|(command-line-arguments)"
-      # Similarly, sinks are sink1 sink2 sink2 ...
-      method: ".*(s|S)ink[1-9]"
-  sanitizers:
-    - package: "(basic)|(main)|(command-line-arguments)"
-      method: ".*(s|S)anitize[1-9]?"
+dataflow-problems:
+  taint-tracking:
+   - # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+    sources:
+      - package: "(basic)|(main)|(command-line-arguments)"
+        # Sources can be source1, source2, etc.
+        method: "(source[1-9])"
+      - package: "(basic)|(main)|(command-line-arguments)"
+        field: "Source[1-9]?"
+      - package: "(basic)|(main)|(command-line-arguments)"
+        type: "(chan \\*_S)|(chan _S)"
+        kind: "channel receive"
+    sinks:
+      - package: "(basic)|(main)|(command-line-arguments)"
+        # Similarly, sinks are sink1 sink2 sink2 ...
+        method: ".*(s|S)ink[1-9]"
+    sanitizers:
+      - package: "(basic)|(main)|(command-line-arguments)"
+        method: ".*(s|S)anitize[1-9]?"

--- a/analysis/backtrace/testdata/benchmark/config.yaml
+++ b/analysis/backtrace/testdata/benchmark/config.yaml
@@ -1,14 +1,15 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: (benchmark)|(main|command-line-arguments)
-        field: Source
-      - package: "(benchmark)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(benchmark)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    fail-on-implicit-flow: false
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: (benchmark)|(main|command-line-arguments)
+          field: Source
+        - package: "(benchmark)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(benchmark)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      fail-on-implicit-flow: false

--- a/analysis/backtrace/testdata/builtins/config.yaml
+++ b/analysis/backtrace/testdata/builtins/config.yaml
@@ -1,9 +1,10 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(builtins)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - method: "sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(builtins)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - method: "sink[1-9]?"

--- a/analysis/backtrace/testdata/builtins_121/config.yaml
+++ b/analysis/backtrace/testdata/builtins_121/config.yaml
@@ -1,9 +1,10 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(builtins_121)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - method: "sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(builtins_121)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - method: "sink[1-9]?"

--- a/analysis/backtrace/testdata/closures/config.yaml
+++ b/analysis/backtrace/testdata/closures/config.yaml
@@ -1,6 +1,6 @@
 # The package regex matches all possible ways the package name might appear depending on how the program is loaded
 taint-tracking-problems:
-  -
+  - tag: "taint"
     sources:
       - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Sources can be source1, source2, etc.

--- a/analysis/backtrace/testdata/closures/config.yaml
+++ b/analysis/backtrace/testdata/closures/config.yaml
@@ -1,19 +1,20 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  - tag: "taint"
-    sources:
-      - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    - tag: "taint"
+      sources:
+        - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
 
 
-# Same as sinks
-slicing-problems:
-  - backtracepoints:
-      - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+  # Same as sinks
+  slicing:
+    - backtracepoints:
+        - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"

--- a/analysis/backtrace/testdata/closures_flowprecise/config.yaml
+++ b/analysis/backtrace/testdata/closures_flowprecise/config.yaml
@@ -1,19 +1,20 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  - tag: "taint"
-    sources:
-      - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    - tag: "taint"
+      sources:
+        - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
 
-# Same as sinks
-slicing-problems:
-  -
-    backtracepoints:
-      - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+  # Same as sinks
+  slicing:
+    -
+      backtracepoints:
+        - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"

--- a/analysis/backtrace/testdata/closures_flowprecise/config.yaml
+++ b/analysis/backtrace/testdata/closures_flowprecise/config.yaml
@@ -1,6 +1,6 @@
 # The package regex matches all possible ways the package name might appear depending on how the program is loaded
 taint-tracking-problems:
-  -
+  - tag: "taint"
     sources:
       - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Sources can be source1, source2, etc.

--- a/analysis/backtrace/testdata/closures_paper/config.yaml
+++ b/analysis/backtrace/testdata/closures_paper/config.yaml
@@ -1,20 +1,21 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  - tag: "taint"
-    sources:
-      - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    fail-on-implicit-flow: true
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    - tag: "taint"
+      sources:
+        - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      fail-on-implicit-flow: true
 
-# Same as sinks
-slicing-problems:
-  -
-    backtracepoints:
-      - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+  # Same as sinks
+  slicing:
+    - tag: "slicing"
+      backtracepoints:
+        - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"

--- a/analysis/backtrace/testdata/closures_paper/config.yaml
+++ b/analysis/backtrace/testdata/closures_paper/config.yaml
@@ -1,6 +1,6 @@
 # The package regex matches all possible ways the package name might appear depending on how the program is loaded
 taint-tracking-problems:
-  -
+  - tag: "taint"
     sources:
       - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Sources can be source1, source2, etc.

--- a/analysis/backtrace/testdata/defers/config.yaml
+++ b/analysis/backtrace/testdata/defers/config.yaml
@@ -1,12 +1,13 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(defers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(defers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    fail-on-implicit-flow: true
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(defers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(defers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      fail-on-implicit-flow: true

--- a/analysis/backtrace/testdata/example0/config.yaml
+++ b/analysis/backtrace/testdata/example0/config.yaml
@@ -1,14 +1,15 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: (main|command-line-arguments|example0)
-        field: Source
-      - package: "(example0)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(example0)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    fail-on-implicit-flow: true
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: (main|command-line-arguments|example0)
+          field: Source
+        - package: "(example0)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(example0)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      fail-on-implicit-flow: true

--- a/analysis/backtrace/testdata/example1/config.yaml
+++ b/analysis/backtrace/testdata/example1/config.yaml
@@ -1,12 +1,13 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(main)|(command-line-arguments)|(example1)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(main)|(command-line-arguments)|(example1)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    fail-on-implicit-flow: true
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(main)|(command-line-arguments)|(example1)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(main)|(command-line-arguments)|(example1)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      fail-on-implicit-flow: true

--- a/analysis/backtrace/testdata/example2/config.yaml
+++ b/analysis/backtrace/testdata/example2/config.yaml
@@ -1,11 +1,12 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(example2)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(example2)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(example2)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(example2)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"

--- a/analysis/backtrace/testdata/fields/config.yaml
+++ b/analysis/backtrace/testdata/fields/config.yaml
@@ -1,16 +1,17 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: (fields)|(main|command-line-arguments)
-        field: Source
-      - package: "(fields)|(main)|(command-line-arguments)"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(fields)|(main)|(command-line-arguments)"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+dataflow-problems:
+  field-sensitive: true
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: (fields)|(main|command-line-arguments)
+          field: Source
+        - package: "(fields)|(main)|(command-line-arguments)"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(fields)|(main)|(command-line-arguments)"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
 
-options:
-   field-sensitive: true
+

--- a/analysis/backtrace/testdata/fields/config.yaml
+++ b/analysis/backtrace/testdata/fields/config.yaml
@@ -1,5 +1,6 @@
 dataflow-problems:
-  field-sensitive: true
+  field-sensitive-funcs:
+    - ".*"
   # The package regex matches all possible ways the package name might appear depending on how the program is loaded
   taint-tracking:
     -

--- a/analysis/backtrace/testdata/filters/config.yaml
+++ b/analysis/backtrace/testdata/filters/config.yaml
@@ -1,18 +1,19 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(filters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(filters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    sanitizers:
-      - package: "(filters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(filters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(filters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
           # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sanitize[1-9]?"
-    filters:
-      - type: "error$" # the $ is important to match only exactly the type
-      - type: "bool$"
+          method: "sink[1-9]?"
+      sanitizers:
+        - package: "(filters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+            # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sanitize[1-9]?"
+      filters:
+        - type: "error$" # the $ is important to match only exactly the type
+        - type: "bool$"

--- a/analysis/backtrace/testdata/fromlevee/config.yaml
+++ b/analysis/backtrace/testdata/fromlevee/config.yaml
@@ -1,9 +1,10 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(.*)core"
-        method: "Source[1-9]?"
-    sinks:
-      - package: "(.*)core"
-        method: "Sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(.*)core"
+          method: "Source[1-9]?"
+      sinks:
+        - package: "(.*)core"
+          method: "Sink[1-9]?"

--- a/analysis/backtrace/testdata/globals/config.yaml
+++ b/analysis/backtrace/testdata/globals/config.yaml
@@ -1,10 +1,11 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(globals)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - method: "sink[1-9]?"
-    fail-on-implicit-flow: false
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(globals)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - method: "sink[1-9]?"
+      fail-on-implicit-flow: false

--- a/analysis/backtrace/testdata/implicit-flow/config.yaml
+++ b/analysis/backtrace/testdata/implicit-flow/config.yaml
@@ -1,11 +1,12 @@
-taint-tracking-problems:
-  - # The package regex matches all possible ways the package name might appear depending on how the program is loaded
-    sources:
-      - package: "(implicit-flow)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(implicit-flow)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    fail-on-implicit-flow: true
+dataflow-problems:
+  taint-tracking:
+    - # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+      sources:
+        - package: "(implicit-flow)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(implicit-flow)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      fail-on-implicit-flow: true

--- a/analysis/backtrace/testdata/interface-summaries/config.yaml
+++ b/analysis/backtrace/testdata/interface-summaries/config.yaml
@@ -1,18 +1,19 @@
 options:
     pkg-filter: "command-line-arguments"
 
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(interface-summaries)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(interface-summaries)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(interface-summaries)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(interface-summaries)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
 
-dataflow-specs:
-  - "dataflows.json"
-  - "dataflows2.json"
+  user-specs:
+    - "dataflows.json"
+    - "dataflows2.json"

--- a/analysis/backtrace/testdata/interfaces/config.yaml
+++ b/analysis/backtrace/testdata/interfaces/config.yaml
@@ -1,5 +1,6 @@
 dataflow-problems:
-  field-sensitive: true
+  field-sensitive-funcs:
+    - ".*"
   # The package regex matches all possible ways the package name might appear depending on how the program is loaded
   taint-tracking:
     - tag: "taint"

--- a/analysis/backtrace/testdata/interfaces/config.yaml
+++ b/analysis/backtrace/testdata/interfaces/config.yaml
@@ -1,14 +1,14 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(interfaces)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(interfaces)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+dataflow-problems:
+  field-sensitive: true
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    - tag: "taint"
+      sources:
+        - package: "(interfaces)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(interfaces)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
 
-options:
-    field-sensitive: true

--- a/analysis/backtrace/testdata/intra-procedural/config.yaml
+++ b/analysis/backtrace/testdata/intra-procedural/config.yaml
@@ -1,5 +1,6 @@
 dataflow-problems:
-  field-sensitive: true
+  field-sensitive-funcs:
+    - ".*"
   taint-tracking:
     -
       sources:

--- a/analysis/backtrace/testdata/intra-procedural/config.yaml
+++ b/analysis/backtrace/testdata/intra-procedural/config.yaml
@@ -1,14 +1,16 @@
-taint-tracking-problems:
-  -
-    sources:
-      - package: fmt
-        method: Sprintf
-      - package: "(intra-procedural)|(main)|(command-line-arguments)"
-        method: zoo
-    sinks:
-      - package: "(intra-procedural)|(main)|(command-line-arguments)"
-        method: sink[1-9]
+dataflow-problems:
+  field-sensitive: true
+  taint-tracking:
+    -
+      sources:
+        - package: fmt
+          method: Sprintf
+        - package: "(intra-procedural)|(main)|(command-line-arguments)"
+          method: zoo
+      sinks:
+        - package: "(intra-procedural)|(main)|(command-line-arguments)"
+          method: sink[1-9]
 
 options:
     skip-interprocedural: false
-    field-sensitive: true
+

--- a/analysis/backtrace/testdata/intra-procedural/config.yaml
+++ b/analysis/backtrace/testdata/intra-procedural/config.yaml
@@ -12,6 +12,4 @@ dataflow-problems:
         - package: "(intra-procedural)|(main)|(command-line-arguments)"
           method: sink[1-9]
 
-options:
-    skip-interprocedural: false
 

--- a/analysis/backtrace/testdata/panics/config.yaml
+++ b/analysis/backtrace/testdata/panics/config.yaml
@@ -1,8 +1,9 @@
-taint-tracking-problems:
-  -
-    sources:
-      - method: "source"
-        package: "(panics)|(main|command-line-arguments)"
-    sinks:
-      - package: "(panics)|(main|command-line-arguments)"
-        method: "sink"
+dataflow-problems:
+  taint-tracking:
+    -
+      sources:
+        - method: "source"
+          package: "(panics)|(main|command-line-arguments)"
+      sinks:
+        - package: "(panics)|(main|command-line-arguments)"
+          method: "sink"

--- a/analysis/backtrace/testdata/parameters/config.yaml
+++ b/analysis/backtrace/testdata/parameters/config.yaml
@@ -1,12 +1,13 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(parameters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(parameters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-      - method: "Start"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(parameters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(parameters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+        - method: "Start"

--- a/analysis/backtrace/testdata/playground/config.yaml
+++ b/analysis/backtrace/testdata/playground/config.yaml
@@ -1,16 +1,17 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(playground)|(main)|(command-line-arguments)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(playground)|(main)|(command-line-arguments)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    fail-on-implicit-flow: true
+dataflow-problems:
+  field-sensitive: true
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(playground)|(main)|(command-line-arguments)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(playground)|(main)|(command-line-arguments)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      fail-on-implicit-flow: true
 
 options:
     use-escape-analysis: false
-    field-sensitive: true

--- a/analysis/backtrace/testdata/playground/config.yaml
+++ b/analysis/backtrace/testdata/playground/config.yaml
@@ -1,5 +1,6 @@
 dataflow-problems:
-  field-sensitive: true
+  field-sensitive-funcs:
+    - ".*"
   # The package regex matches all possible ways the package name might appear depending on how the program is loaded
   taint-tracking:
     -

--- a/analysis/backtrace/testdata/selects/config.yaml
+++ b/analysis/backtrace/testdata/selects/config.yaml
@@ -1,10 +1,11 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(selects)|(main)|(command-line-arguments)|(selects-test[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - method: "sink[1-9]?"
-    fail-on-implicit-flow: true
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(selects)|(main)|(command-line-arguments)|(selects-test[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - method: "sink[1-9]?"
+      fail-on-implicit-flow: true

--- a/analysis/backtrace/testdata/src/sinks/config.yaml
+++ b/analysis/backtrace/testdata/src/sinks/config.yaml
@@ -1,5 +1,6 @@
-taint-tracking-problems:
-  -
-    sinks:
-      - package: "((main)|(sinks))"
-        method: sinkFunction
+dataflow-problems:
+  taint-tracking:
+    -
+      sinks:
+        - package: "((main)|(sinks))"
+          method: sinkFunction

--- a/analysis/backtrace/testdata/src/sources/config.yaml
+++ b/analysis/backtrace/testdata/src/sources/config.yaml
@@ -1,12 +1,13 @@
-taint-tracking-problems:
-  -
-    sources:
-      - package: "fmt"
-        method: Sprintf
-      - package: "(main)|(command-line-arguments)|(sources)$"
-        method: zoo
-      - package: "(main)|(command-line-arguments)|(sources)$"
-        type: Bar
-      - type: SomeStruct
-        field: DataField
-      - field: Pickles
+dataflow-problems:
+  taint-tracking:
+    -
+      sources:
+        - package: "fmt"
+          method: Sprintf
+        - package: "(main)|(command-line-arguments)|(sources)$"
+          method: zoo
+        - package: "(main)|(command-line-arguments)|(sources)$"
+          type: Bar
+        - type: SomeStruct
+          field: DataField
+        - field: Pickles

--- a/analysis/backtrace/testdata/stdlib/config.yaml
+++ b/analysis/backtrace/testdata/stdlib/config.yaml
@@ -1,15 +1,16 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: ".*((s|S)ource[1-9])"
-    sinks:
-      - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: ".*(s|S)ink[1-9]"
-    sanitizers:
-      - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        method: ".*(s|S)anitize[1-9]?"
-    fail-on-implicit-flow: true
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: ".*((s|S)ource[1-9])"
+      sinks:
+        - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: ".*(s|S)ink[1-9]"
+      sanitizers:
+        - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          method: ".*(s|S)anitize[1-9]?"
+      fail-on-implicit-flow: true

--- a/analysis/backtrace/testdata/stdlib_121/config.yaml
+++ b/analysis/backtrace/testdata/stdlib_121/config.yaml
@@ -1,14 +1,15 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(stdlib_121)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: ".*((s|S)ource[1-9])"
-    sinks:
-      - package: "(stdlib_121)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: ".*(s|S)ink[1-9]"
-    sanitizers:
-      - package: "(stdlib_121)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        method: ".*(s|S)anitize[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(stdlib_121)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: ".*((s|S)ource[1-9])"
+      sinks:
+        - package: "(stdlib_121)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: ".*(s|S)ink[1-9]"
+      sanitizers:
+        - package: "(stdlib_121)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          method: ".*(s|S)anitize[1-9]?"

--- a/analysis/backtrace/testdata/tuples/config.yaml
+++ b/analysis/backtrace/testdata/tuples/config.yaml
@@ -1,12 +1,13 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(tuples)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(tuples)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    fail-on-implicit-flow: true
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(tuples)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(tuples)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      fail-on-implicit-flow: true

--- a/analysis/backtrace/testdata/validators/config.yaml
+++ b/analysis/backtrace/testdata/validators/config.yaml
@@ -1,20 +1,19 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(validators)|(main)|(command-line-arguments)$"
-        # Sources can be source1, source2, etc.
-        method: "(source[1-9])"
-      - package: "(validators)|(main)|(command-line-arguments)$"
-        field: "Source[1-9]?"
-    sinks:
-      - package: "(validators)|(main)|(command-line-arguments)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: ".*(s|S)ink[1-9]"
-    validators:
-      - package: "(validators)|(main)|(command-line-arguments)$"
-        method: ".*Validate[1-9]?"
-    fail-on-implicit-flow: true
-
-options:
-    field-sensitive: true
+dataflow-problems:
+  field-sensitive: true
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(validators)|(main)|(command-line-arguments)$"
+          # Sources can be source1, source2, etc.
+          method: "(source[1-9])"
+        - package: "(validators)|(main)|(command-line-arguments)$"
+          field: "Source[1-9]?"
+      sinks:
+        - package: "(validators)|(main)|(command-line-arguments)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: ".*(s|S)ink[1-9]"
+      validators:
+        - package: "(validators)|(main)|(command-line-arguments)$"
+          method: ".*Validate[1-9]?"
+      fail-on-implicit-flow: true

--- a/analysis/backtrace/testdata/validators/config.yaml
+++ b/analysis/backtrace/testdata/validators/config.yaml
@@ -1,5 +1,6 @@
 dataflow-problems:
-  field-sensitive: true
+  field-sensitive-funcs:
+    - ".*"
   # The package regex matches all possible ways the package name might appear depending on how the program is loaded
   taint-tracking:
     -

--- a/analysis/backtrace/testdata/with-context/config.yaml
+++ b/analysis/backtrace/testdata/with-context/config.yaml
@@ -1,13 +1,14 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(with-context)|(main)|(command-line-arguments)|(example1)$"
-        context: "fetchAndPut" # only match the call in test2
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(with-context)|(main)|(command-line-arguments)|(example1)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    fail-on-implicit-flow: true
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(with-context)|(main)|(command-line-arguments)|(example1)$"
+          context: "fetchAndPut" # only match the call in test2
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(with-context)|(main)|(command-line-arguments)|(example1)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      fail-on-implicit-flow: true

--- a/analysis/config/config.go
+++ b/analysis/config/config.go
@@ -162,6 +162,32 @@ type AnalysisProblemOptions struct {
 	MaxEntrypointContextSize int `xml:"max-entrypoint-context-size,attr" yaml:"max-entrypoint-context-size" json:"max-entrypoint-context-size"`
 }
 
+// AnalysisProblemOptions are the options that are specific to an analysis problem.
+type AnalysisProblemOptions struct {
+	// MaxAlarms sets a limit for the number of alarms reported by an analysis.  If MaxAlarms > 0, then at most
+	// MaxAlarms will be reported. Otherwise, if MaxAlarms <= 0, it is ignored.
+	//
+	// This setting does not affect soundness, since event with max-alarms:1, at least one path will be reported if
+	// there is some potential alarm-causing result.
+	MaxAlarms int `xml:"max-alarms,attr" yaml:"max-alarms" json:"max-alarms"`
+
+	// UnsafeMaxDepth sets a limit for the number of function call depth explored during the analysis.
+	// The default is -1, and any value less than 0 is safe: the analysis will be sound and explore call depth
+	// without bounds.
+	//
+	// Setting UnsafeMaxDepth to a limit larger than 0 will yield unsound results, but can be useful to use the tool
+	// as a checking mechanism. Limiting the call depth will usually yield fewer false positives.
+	UnsafeMaxDepth int `xml:"unsafe-max-depth,attr" yaml:"unsafe-max-depth" json:"unsafe-max-depth"`
+
+	// MaxEntrypointContextSize sets the maximum context (call stack) size used when searching for entry points with context.
+	// This only impacts precision of the returned results.
+	//
+	// If MaxEntrypointContextSize is < 0, it is ignored.
+	// If MaxEntrypointContextSize is 0 is specified by the user, the value is ignored, and a default internal value is used.
+	// If MaxEntrypointContextSize is > 0, then the limit in the callstack size for the context is used.
+	MaxEntrypointContextSize int `xml:"max-entrypoint-context-size,attr" yaml:"max-entrypoint-context-size" json:"max-entrypoint-context-size"`
+}
+
 // PointerConfig is the pointer analysis specific configuration.
 type PointerConfig struct {
 	// UnsafeNoEffectFunctions is a list of function names that produce no constraints in the pointer analysis.

--- a/analysis/config/config.go
+++ b/analysis/config/config.go
@@ -262,7 +262,6 @@ func NewDefault() *Config {
 		sourceFile:         "",
 		nocalleereportfile: "",
 		DataflowProblems: DataflowProblems{
-			PathSensitive:             false,
 			PathSensitiveFuncs:        []string{},
 			pathSensitiveFuncsRegexes: nil,
 		},

--- a/analysis/config/config.go
+++ b/analysis/config/config.go
@@ -242,6 +242,9 @@ type SlicingSpec struct {
 	// Filters contains a list of filters that can be used by analyses
 	Filters []CodeIdentifier
 
+	// Tag identifies a group of annotations when used with annotations
+	Tag string
+
 	// SkipBoundLabels indicates whether to skip flows that go through "bound labels", i.e. aliases of the variables
 	// bound by a closure. This can be useful to test data flows because bound labels generate a lot of false positives.
 	SkipBoundLabels bool `yaml:"unsafe-skip-bound-labels" json:"unsafe-skip-bound-labels"`

--- a/analysis/config/config.go
+++ b/analysis/config/config.go
@@ -246,9 +246,6 @@ type Options struct {
 	// relative to the root. If not specified, the root is assumed to be the directory of the config file.
 	ProjectRoot string `xml:"project-root,attr" yaml:"project-root" json:"project-root"`
 
-	// SkipInterprocedural can be set to true to skip the interprocedural (inter-procedural analysis) step
-	SkipInterprocedural bool `xml:"skip-interprocedural,attr" yaml:"skip-interprocedural" json:"skip-interprocedural"`
-
 	// Suppress warnings
 	SilenceWarn bool `xml:"silence-warn,attr" json:"silence-warn" yaml:"silence-warn"`
 
@@ -276,7 +273,6 @@ func NewDefault() *Config {
 			},
 			ReportsDir:          "",
 			PkgFilter:           "",
-			SkipInterprocedural: false,
 			CoverageFilter:      "",
 			ReportSummaries:     false,
 			ReportPaths:         false,
@@ -320,6 +316,8 @@ func errorMisconfigurationGracefully(errYaml, errXML, errJson error) error {
 		"field slicing-problems not found in type config.Config",
 		"field dataflow-specs not found in type config.Config",
 		"field source-taints-args not found in type config.Options",
+		"field field-sensitive not found in type config.DataflowProblems",
+		"field skip-interprocedural not found in type config.Options",
 	}
 	msgUpgrade := "your config follows an outdated format. Please consult documentation and update the config file"
 	for _, fingerprint := range oldConfigFingerprints {

--- a/analysis/config/config.go
+++ b/analysis/config/config.go
@@ -614,13 +614,13 @@ func OverrideWithAnalysisOptions(l *LogGroup, c *Config, o *AnalysisProblemOptio
 	}
 
 	if o.UnsafeMaxDepth != 0 {
-		l.Infof("unsafe-max-depth set to %d (using problem's analysis-options)",
+		l.Infof("unsafe-max-depth set to %d (using problem's override-analysis-options)",
 			o.UnsafeMaxDepth)
 		c.UnsafeMaxDepth = o.UnsafeMaxDepth
 	}
 
 	if o.MaxEntrypointContextSize != 0 {
-		l.Infof("max-entrypoint-context-size set to %d (using problem's analysis-options)",
+		l.Infof("max-entrypoint-context-size set to %d (using problem's override-analysis-options)",
 			o.MaxEntrypointContextSize)
 		c.MaxEntrypointContextSize = o.MaxEntrypointContextSize
 	}

--- a/analysis/config/config.go
+++ b/analysis/config/config.go
@@ -252,10 +252,6 @@ type Options struct {
 	// Suppress warnings
 	SilenceWarn bool `xml:"silence-warn,attr" json:"silence-warn" yaml:"silence-warn"`
 
-	// SourceTaintsArgs specifies whether calls to a source function also taints the argument. This is usually not
-	// the case, but might be useful for some users or for source functions that do not return anything.
-	SourceTaintsArgs bool `xml:"source-taints-args,attr" yaml:"source-taints-args" json:"source-taints-args"`
-
 	// Run and use the escape analysis for analyses that have the option to use the escape analysis results.
 	UseEscapeAnalysis bool `xml:"use-escape-analysis,attr" yaml:"use-escape-analysis" json:"use-escape-analysis"`
 }
@@ -289,7 +285,6 @@ func NewDefault() *Config {
 			ReportNoCalleeSites: false,
 			LogLevel:            int(InfoLevel),
 			SilenceWarn:         false,
-			SourceTaintsArgs:    false,
 		},
 	}
 }
@@ -325,6 +320,7 @@ func errorMisconfigurationGracefully(errYaml, errXML, errJson error) error {
 		"field taint-tracking-problems not found in type config.Config",
 		"field slicing-problems not found in type config.Config",
 		"field dataflow-specs not found in type config.Config",
+		"field source-taints-args not found in type config.Options",
 	}
 	msgUpgrade := "your config follows an outdated format. Please consult documentation and update the config file"
 	for _, fingerprint := range oldConfigFingerprints {

--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -312,9 +312,6 @@ func TestLoadFullConfigYaml(t *testing.T) {
 	if config.LogLevel != int(TraceLevel) {
 		t.Error("full config should have set trace")
 	}
-	if !config.SkipInterprocedural {
-		t.Error("full config should have set skiipinterprocedural")
-	}
 	if !config.ReportCoverage {
 		t.Error("full config should have set report-coverage")
 	}

--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -290,7 +290,7 @@ func TestLoadFullConfigYaml(t *testing.T) {
 	if config.CoverageFilter == "" {
 		t.Error("full config should specify a coverage prefix")
 	}
-	if len(config.DataflowSpecs) != 2 {
+	if len(config.UserSpecs) != 2 {
 		t.Error("full config should specify two dataflow spec files")
 	}
 	if config.UnsafeMaxDepth != 42 {
@@ -391,18 +391,20 @@ func TestLoadMisc(t *testing.T) {
 	testLoadOneFile(t,
 		"config3.yaml",
 		Config{
-			TaintTrackingProblems: []TaintSpec{
-				{
-					Sanitizers: []CodeIdentifier{{"", "pkg1", "", "Foo", "Obj", "", "", "", "", "", "", nil}},
-					Sinks: []CodeIdentifier{{"", "y", "", "b", "", "", "", "", "", "", "", nil},
-						{"", "x", "", "", "Obj1", "", "", "", "", "", "", nil}},
-					Sources: []CodeIdentifier{
-						{"", "some/package", "", "SuperMethod", "", "", "", "", "", "", "", nil},
+			DataflowProblems: DataflowProblems{
+				TaintTrackingProblems: []TaintSpec{
+					{
+						Sanitizers: []CodeIdentifier{{"", "pkg1", "", "Foo", "Obj", "", "", "", "", "", "", nil}},
+						Sinks: []CodeIdentifier{{"", "y", "", "b", "", "", "", "", "", "", "", nil},
+							{"", "x", "", "", "Obj1", "", "", "", "", "", "", nil}},
+						Sources: []CodeIdentifier{
+							{"", "some/package", "", "SuperMethod", "", "", "", "", "", "", "", nil},
 
-						{"", "some/other/package", "", "", "", "OneField", "ThatStruct", "", "", "", "", nil},
-						{"", "some/other/package", "Interface", "", "", "", "", "", "", "", "", nil},
+							{"", "some/other/package", "", "", "", "OneField", "ThatStruct", "", "", "", "", nil},
+							{"", "some/other/package", "Interface", "", "", "", "", "", "", "", "", nil},
+						},
+						FailOnImplicitFlow: false,
 					},
-					FailOnImplicitFlow: false,
 				},
 			},
 			Options: Options{

--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -158,6 +158,36 @@ func TestLoadBadFormatFileReturnsError(t *testing.T) {
 	}
 }
 
+func TestLoadDuplicateTagsReturnsError(t *testing.T) {
+	name := filepath.Join("testdata", "invalid_config_duplicate_tags.yaml")
+	b, err := testfsys.ReadFile(name)
+	if err != nil {
+		t.Fatalf("failed to read file %v: %v", name, err)
+	}
+	_, err = Load(name, b)
+	if err == nil {
+		t.Fatalf("Expected error and nil value when trying to load a config with duplicate problem tags.")
+	}
+	if !strings.Contains(err.Error(), "used for multiple problems") {
+		t.Errorf("Error message should explain error caused by duplicate, but got %s", err)
+	}
+}
+
+func TestLoadInvalidSeverityReturnsError(t *testing.T) {
+	name := filepath.Join("testdata", "invalid_config_invalid_sev.yaml")
+	b, err := testfsys.ReadFile(name)
+	if err != nil {
+		t.Fatalf("failed to read file %v: %v", name, err)
+	}
+	_, err = Load(name, b)
+	if err == nil {
+		t.Fatalf("Expected error and nil value when trying to load a config with duplicate problem tags.")
+	}
+	if !strings.Contains(err.Error(), "invalid severity") {
+		t.Errorf("Error message should explain error caused by invalid severity label, but got %s", err)
+	}
+}
+
 func TestLoadVersionBefore_v0_3_0_Errors(t *testing.T) {
 	_, config, err := loadFromTestDir("config_before_v0_3_0.yaml")
 	if config != nil || err == nil {

--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -154,6 +155,25 @@ func TestLoadBadFormatFileReturnsError(t *testing.T) {
 	config, err := Load(name, b)
 	if config != nil || err == nil {
 		t.Errorf("Expected error and nil value when trying to load a badly formatted file.")
+	}
+}
+
+func TestLoadVersionBefore_v0_3_0_Errors(t *testing.T) {
+	_, config, err := loadFromTestDir("config_before_v0_3_0.yaml")
+	if config != nil || err == nil {
+		t.Fatalf("Expected error and nil value when trying to load config with bad format")
+	}
+	msg1 := "Please consult documentation and update the config file"
+	if !strings.Contains(err.Error(), msg1) {
+		t.Errorf("Error message:\n%s\nshould contain %s", err, msg1)
+	}
+
+	_, configJson, errJson := loadFromTestDir("config_before_v0_3_0.json")
+	if configJson != nil || errJson == nil {
+		t.Fatalf("Expected error and nil value when trying to load config with bad format")
+	}
+	if !strings.Contains(errJson.Error(), msg1) {
+		t.Errorf("Error message:\n%s\nshould contain %s", errJson, msg1)
 	}
 }
 

--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -338,6 +338,7 @@ func TestLoadFullConfigYaml(t *testing.T) {
 	if !config.MatchPkgFilter("argot/analysis/analyzers.go") {
 		t.Error("full config coverage filter should match files in analysis")
 	}
+	// Test taint tracking problems
 	if len(config.TaintTrackingProblems) != 1 ||
 		len(config.TaintTrackingProblems[0].Sinks) != 1 ||
 		len(config.TaintTrackingProblems[0].Validators) != 1 ||
@@ -347,6 +348,25 @@ func TestLoadFullConfigYaml(t *testing.T) {
 	}
 	if config.TaintTrackingProblems[0].UnsafeMaxDepth != 1 {
 		t.Error("analysis option unsafe-max-depth should be 1 for taint-tracking-problem")
+	}
+	if config.TaintTrackingProblems[0].Description == "taint-tracking-problem-1" {
+		t.Error("tag of taint tracking problem should be taint-tracking-problem-1")
+	}
+	if strings.Contains(config.TaintTrackingProblems[0].Tag, "A taint tracking problem") {
+		t.Error("description should be set for taint-tracking-problem")
+	}
+	// Test slicing
+	if len(config.SlicingProblems) != 1 {
+		t.Error("there should be exactly one slicing problem.")
+	}
+	if len(config.SlicingProblems[0].BacktracePoints) != 1 {
+		t.Error("the slicing problem should have exactly one backtrace point.")
+	}
+	if config.SlicingProblems[0].Tag != "slicing-problem-1" {
+		t.Error("the slicing problem should have tag slicing-problem-1")
+	}
+	if !strings.Contains(config.SlicingProblems[0].Description, "A slicing problem") {
+		t.Error("description should be set for the slicing problem")
 	}
 	if !config.SourceTaintsArgs {
 		t.Error("full config should have source-taints-args set")

--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -356,6 +356,9 @@ func TestLoadFullConfigYaml(t *testing.T) {
 	if config.TaintTrackingProblems[0].UnsafeMaxDepth != 1 {
 		t.Error("analysis option unsafe-max-depth should be 1 for taint-tracking-problem")
 	}
+	if !config.TaintTrackingProblems[0].SourceTaintsArgs {
+		t.Error("analysis option source-taints-args should be true for taint-tracking-problem")
+	}
 	if config.TaintTrackingProblems[0].Description == "taint-tracking-problem-1" {
 		t.Error("tag of taint tracking problem should be taint-tracking-problem-1")
 	}
@@ -374,9 +377,6 @@ func TestLoadFullConfigYaml(t *testing.T) {
 	}
 	if !strings.Contains(config.SlicingProblems[0].Description, "A slicing problem") {
 		t.Error("description should be set for the slicing problem")
-	}
-	if !config.SourceTaintsArgs {
-		t.Error("full config should have source-taints-args set")
 	}
 	if !config.SilenceWarn {
 		t.Error("full config should have silence-warn set to true")

--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -188,6 +188,13 @@ func TestLoadInvalidSeverityReturnsError(t *testing.T) {
 	}
 }
 
+func TestLoadWithProjectRoot(t *testing.T) {
+	_, config, err := loadFromTestDir("test_project_root_loading.yaml")
+	if config == nil || err != nil {
+		t.Fatalf("encountered error when loading config with project root specified: %s", err)
+	}
+}
+
 func TestLoadVersionBefore_v0_3_0_Errors(t *testing.T) {
 	_, config, err := loadFromTestDir("config_before_v0_3_0.yaml")
 	if config != nil || err == nil {

--- a/analysis/config/dataflow_config.go
+++ b/analysis/config/dataflow_config.go
@@ -70,6 +70,9 @@ type TaintSpec struct {
 	// Tag identifies a group of annotations when used with annotations
 	Tag string
 
+	// Severity assigns a severity to this problem
+	Severity string
+
 	// FailOnImplicitFlow indicates whether the taint analysis should fail when tainted data implicitly changes
 	// the control flow of a program. This should be set to false when proving a data flow property,
 	// and set to true when proving an information flow property.
@@ -92,6 +95,9 @@ type SlicingSpec struct {
 
 	// Tag identifies a group of annotations when used with annotations
 	Tag string
+
+	// Severity assigns a severity to this problem
+	Severity string
 
 	// SkipBoundLabels indicates whether to skip flows that go through "bound labels", i.e. aliases of the variables
 	// bound by a closure. This can be useful to test data flows because bound labels generate a lot of false positives.

--- a/analysis/config/dataflow_config.go
+++ b/analysis/config/dataflow_config.go
@@ -1,0 +1,99 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "regexp"
+
+// DataflowProblems defines all the dataflow (taint, slicing) problems in a config file.
+type DataflowProblems struct {
+	// PathSensitive is a boolean indicating whether the analysis should be run with access path sensitivity on
+	// (will change to include more filtering in the future)
+	//
+	// Note that the configuration option name is "field-sensitive" because this is the name that will be more
+	// recognizable for users.
+	//
+	// TODO deprecate since this case is covered by `"field-sensitive-funcs": [".*"]`?
+	PathSensitive bool `xml:"field-sensitive" yaml:"field-sensitive" json:"field-sensitive"`
+
+	// PathSensitiveFuncs is a list of regexes indicating which functions should be path-sensitive.
+	// This allows the analysis to scale yet still maintain a degree of precision where it matters.
+	PathSensitiveFuncs []string `xml:"field-sensitive-funcs" yaml:"field-sensitive-funcs" json:"field-sensitive-funcs"`
+
+	// pathSensitiveFuncsRegexes is a list of compiled regexes corresponding to PathSensitiveFuncs
+	pathSensitiveFuncsRegexes []*regexp.Regexp
+
+	// SummarizeOnDemand specifies whether the graph should build summaries on-demand instead of all at once
+	SummarizeOnDemand bool `xml:"summarize-on-demand,attr" yaml:"summarize-on-demand" json:"summarize-on-demand"`
+
+	// UserSpecs is a path to a json file that contains the data flows specs for the interfaces in the dataflow
+	// analyses
+	UserSpecs []string `yaml:"user-specs" json:"user-specs"`
+
+	// TaintTrackingProblems lists the taint tracking specifications
+	TaintTrackingProblems []TaintSpec `yaml:"taint-tracking" json:"taint-tracking"`
+
+	// SlicingProblems lists the program slicing specifications
+	SlicingProblems []SlicingSpec `yaml:"slicing" json:"slicing"`
+}
+
+// TaintSpec contains code identifiers that identify a specific taint tracking problem, or contains a code that
+// can differentiate groups of annotations
+type TaintSpec struct {
+	*AnalysisProblemOptions `xml:"analysis-options,attr" yaml:"analysis-options" json:"analysis-options"`
+	// Sanitizers is the list of sanitizers for the taint analysis
+	Sanitizers []CodeIdentifier
+
+	// Validators is the list of validators for the dataflow analyses
+	Validators []CodeIdentifier
+
+	// Sinks is the list of sinks for the taint analysis
+	Sinks []CodeIdentifier
+
+	// Sources is the list of sources for the taint analysis
+	Sources []CodeIdentifier
+
+	// Filters contains a list of filters that can be used by analyses
+	Filters []CodeIdentifier
+
+	// Tag identifies a group of annotations when used with annotations
+	Tag string
+
+	// FailOnImplicitFlow indicates whether the taint analysis should fail when tainted data implicitly changes
+	// the control flow of a program. This should be set to false when proving a data flow property,
+	// and set to true when proving an information flow property.
+	FailOnImplicitFlow bool `yaml:"fail-on-implicit-flow" json:"fail-on-implicit-flow"`
+
+	// SkipBoundLabels indicates whether to skip flows that go through "bound labels", i.e. aliases of the variables
+	// bound by a closure. This can be useful to test data flows because bound labels generate a lot of false positives.
+	SkipBoundLabels bool `yaml:"unsafe-skip-bound-labels" json:"unsafe-skip-bound-labels"`
+}
+
+// SlicingSpec contains code identifiers that identify a specific program slicing / backwards dataflow analysis spec.
+type SlicingSpec struct {
+	*AnalysisProblemOptions `xml:"analysis-options,attr" yaml:"analysis-options" json:"analysis-options"`
+	// BacktracePoints is the list of identifiers to be considered as entrypoint functions for the backwards
+	// dataflow analysis.
+	BacktracePoints []CodeIdentifier
+
+	// Filters contains a list of filters that can be used by analyses
+	Filters []CodeIdentifier
+
+	// Tag identifies a group of annotations when used with annotations
+	Tag string
+
+	// SkipBoundLabels indicates whether to skip flows that go through "bound labels", i.e. aliases of the variables
+	// bound by a closure. This can be useful to test data flows because bound labels generate a lot of false positives.
+	SkipBoundLabels bool `yaml:"unsafe-skip-bound-labels" json:"unsafe-skip-bound-labels"`
+}

--- a/analysis/config/dataflow_config.go
+++ b/analysis/config/dataflow_config.go
@@ -73,6 +73,9 @@ type TaintSpec struct {
 	// Severity assigns a severity to this problem
 	Severity string
 
+	// Description allows the user to add a description to the problem
+	Description string
+
 	// FailOnImplicitFlow indicates whether the taint analysis should fail when tainted data implicitly changes
 	// the control flow of a program. This should be set to false when proving a data flow property,
 	// and set to true when proving an information flow property.
@@ -98,6 +101,9 @@ type SlicingSpec struct {
 
 	// Severity assigns a severity to this problem
 	Severity string
+
+	// Description allows the user to add a description to the problem
+	Description string
 
 	// SkipBoundLabels indicates whether to skip flows that go through "bound labels", i.e. aliases of the variables
 	// bound by a closure. This can be useful to test data flows because bound labels generate a lot of false positives.

--- a/analysis/config/dataflow_config.go
+++ b/analysis/config/dataflow_config.go
@@ -18,15 +18,6 @@ import "regexp"
 
 // DataflowProblems defines all the dataflow (taint, slicing) problems in a config file.
 type DataflowProblems struct {
-	// PathSensitive is a boolean indicating whether the analysis should be run with access path sensitivity on
-	// (will change to include more filtering in the future)
-	//
-	// Note that the configuration option name is "field-sensitive" because this is the name that will be more
-	// recognizable for users.
-	//
-	// TODO deprecate since this case is covered by `"field-sensitive-funcs": [".*"]`?
-	PathSensitive bool `xml:"field-sensitive" yaml:"field-sensitive" json:"field-sensitive"`
-
 	// PathSensitiveFuncs is a list of regexes indicating which functions should be path-sensitive.
 	// This allows the analysis to scale yet still maintain a degree of precision where it matters.
 	PathSensitiveFuncs []string `xml:"field-sensitive-funcs" yaml:"field-sensitive-funcs" json:"field-sensitive-funcs"`

--- a/analysis/config/dataflow_config.go
+++ b/analysis/config/dataflow_config.go
@@ -109,3 +109,89 @@ type SlicingSpec struct {
 	// bound by a closure. This can be useful to test data flows because bound labels generate a lot of false positives.
 	SkipBoundLabels bool `yaml:"unsafe-skip-bound-labels" json:"unsafe-skip-bound-labels"`
 }
+
+// IsPathSensitiveFunc returns true if funcName matches any regex in c.Options.PathSensitiveFuncs.
+func (c Config) IsPathSensitiveFunc(funcName string) bool {
+	for _, psfr := range c.pathSensitiveFuncsRegexes {
+		if psfr == nil {
+			continue
+		}
+		if psfr.MatchString(funcName) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Below are functions used to query the configuration on specific facts
+
+func (c Config) isSomeTaintSpecCid(cid CodeIdentifier, f func(t TaintSpec, cid CodeIdentifier) bool) bool {
+	for _, x := range c.DataflowProblems.TaintTrackingProblems {
+		if f(x, cid) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsSomeSource returns true if the code identifier matches any source in the config
+func (c Config) IsSomeSource(cid CodeIdentifier) bool {
+	return c.isSomeTaintSpecCid(cid, func(t TaintSpec, cid2 CodeIdentifier) bool { return t.IsSource(cid2) })
+}
+
+// IsSomeSink returns true if the code identifier matches any sink in the config
+func (c Config) IsSomeSink(cid CodeIdentifier) bool {
+	return c.isSomeTaintSpecCid(cid, func(t TaintSpec, cid2 CodeIdentifier) bool { return t.IsSink(cid2) })
+}
+
+// IsSomeSanitizer returns true if the code identifier matches any sanitizer in the config
+func (c Config) IsSomeSanitizer(cid CodeIdentifier) bool {
+	return c.isSomeTaintSpecCid(cid, func(t TaintSpec, cid2 CodeIdentifier) bool { return t.IsSanitizer(cid2) })
+}
+
+// IsSomeValidator returns true if the code identifier matches any validator in the config
+func (c Config) IsSomeValidator(cid CodeIdentifier) bool {
+	return c.isSomeTaintSpecCid(cid, func(t TaintSpec, cid2 CodeIdentifier) bool { return t.IsValidator(cid2) })
+}
+
+// IsSomeBacktracePoint returns true if the code identifier matches any backtrace point in the slicing problems
+func (c Config) IsSomeBacktracePoint(cid CodeIdentifier) bool {
+	for _, ss := range c.DataflowProblems.SlicingProblems {
+		if ss.IsBacktracePoint(cid) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsSource returns true if the code identifier matches a source specification in the config file
+func (ts TaintSpec) IsSource(cid CodeIdentifier) bool {
+	b := ExistsCid(ts.Sources, cid.equalOnNonEmptyFields)
+	return b
+}
+
+// IsSink returns true if the code identifier matches a sink specification in the config file
+func (ts TaintSpec) IsSink(cid CodeIdentifier) bool {
+	return ExistsCid(ts.Sinks, cid.equalOnNonEmptyFields)
+}
+
+// IsSanitizer returns true if the code identifier matches a sanitizer specification in the config file
+func (ts TaintSpec) IsSanitizer(cid CodeIdentifier) bool {
+	return ExistsCid(ts.Sanitizers, cid.equalOnNonEmptyFields)
+}
+
+// IsValidator returns true if the code identifier matches a validator specification in the config file
+func (ts TaintSpec) IsValidator(cid CodeIdentifier) bool {
+	return ExistsCid(ts.Validators, cid.equalOnNonEmptyFields)
+}
+
+// IsStaticCommand returns true if the code identifier matches a static command specification in the config file
+func (scs StaticCommandsSpec) IsStaticCommand(cid CodeIdentifier) bool {
+	return ExistsCid(scs.StaticCommands, cid.equalOnNonEmptyFields)
+}
+
+// IsBacktracePoint returns true if the code identifier matches a backtrace point according to the SlicingSpec
+func (ss SlicingSpec) IsBacktracePoint(cid CodeIdentifier) bool {
+	return ExistsCid(ss.BacktracePoints, cid.equalOnNonEmptyFields)
+}

--- a/analysis/config/dataflow_config.go
+++ b/analysis/config/dataflow_config.go
@@ -51,7 +51,7 @@ type DataflowProblems struct {
 // TaintSpec contains code identifiers that identify a specific taint tracking problem, or contains a code that
 // can differentiate groups of annotations
 type TaintSpec struct {
-	*AnalysisProblemOptions `xml:"analysis-options,attr" yaml:"analysis-options" json:"analysis-options"`
+	*AnalysisProblemOptions `xml:"override-analysis-options,attr" yaml:"override-analysis-options" json:"override-analysis-options"`
 	// Sanitizers is the list of sanitizers for the taint analysis
 	Sanitizers []CodeIdentifier
 
@@ -92,7 +92,7 @@ type TaintSpec struct {
 
 // SlicingSpec contains code identifiers that identify a specific program slicing / backwards dataflow analysis spec.
 type SlicingSpec struct {
-	*AnalysisProblemOptions `xml:"analysis-options,attr" yaml:"analysis-options" json:"analysis-options"`
+	*AnalysisProblemOptions `xml:"override-analysis-options,attr" yaml:"override-analysis-options" json:"override-analysis-options"`
 	// BacktracePoints is the list of identifiers to be considered as entrypoint functions for the backwards
 	// dataflow analysis.
 	BacktracePoints []CodeIdentifier

--- a/analysis/config/dataflow_config.go
+++ b/analysis/config/dataflow_config.go
@@ -84,6 +84,10 @@ type TaintSpec struct {
 	// SkipBoundLabels indicates whether to skip flows that go through "bound labels", i.e. aliases of the variables
 	// bound by a closure. This can be useful to test data flows because bound labels generate a lot of false positives.
 	SkipBoundLabels bool `yaml:"unsafe-skip-bound-labels" json:"unsafe-skip-bound-labels"`
+
+	// SourceTaintsArgs specifies whether calls to a source function also taints the argument. This is usually not
+	// the case, but might be useful for some users or for source functions that do not return anything.
+	SourceTaintsArgs bool `xml:"source-taints-args,attr" yaml:"source-taints-args" json:"source-taints-args"`
 }
 
 // SlicingSpec contains code identifiers that identify a specific program slicing / backwards dataflow analysis spec.

--- a/analysis/config/doc.go
+++ b/analysis/config/doc.go
@@ -26,15 +26,17 @@ options:
 
 	log-level: 5
 
-taint-tracking-problems:
+dataflow-problems:
 
-	    -
-		  sinks:
-		    - package: fmt
-	          method: Printf
+	  taint-tracking:
 
-		  sources:
-		     - method: Read
+		    -
+			  sinks:
+			    - package: fmt
+		          method: Printf
+
+			  sources:
+			     - method: Read
 
 # Identifying code elements
 

--- a/analysis/config/repr_drawio.go
+++ b/analysis/config/repr_drawio.go
@@ -71,7 +71,7 @@ func ParseXMLConfigFormat(c *Config, b []byte) error {
 		if obj.ID == "0" && !obj.Cell.Vertex && !obj.Cell.Edge {
 			if obj.DataflowSpecs != "" {
 				specs := strings.Split(obj.DataflowSpecs, ",")
-				c.DataflowSpecs = specs
+				c.DataflowProblems.UserSpecs = specs
 			}
 			c.Options = obj.Options
 		}

--- a/analysis/config/repr_drawio_test.go
+++ b/analysis/config/repr_drawio_test.go
@@ -33,7 +33,7 @@ func TestSimpleFlowWithOption(t *testing.T) {
 		fmt.Printf(".xml: %+v\n", config.Options)
 		t.Fatalf("configs from xml and yaml differ in global options")
 	}
-	if !slices.Equal(config.DataflowSpecs, config2.DataflowSpecs) {
+	if !slices.Equal(config.UserSpecs, config2.UserSpecs) {
 		t.Fatalf("configs from xml and yaml do not have the same dataflow specs")
 	}
 	n := len(config2.TaintTrackingProblems)

--- a/analysis/config/testdata/config.yaml
+++ b/analysis/config/testdata/config.yaml
@@ -1,8 +1,9 @@
-taint-tracking-problems:
-  - sanitizers:
-      - package: "a"
-        method: "b"
+dataflow-problems:
+  taint-tracking:
+    - sanitizers:
+        - package: "a"
+          method: "b"
 
-    sinks:
-      - package: "c"
-        method: "d"
+      sinks:
+        - package: "c"
+          method: "d"

--- a/analysis/config/testdata/config2.json
+++ b/analysis/config/testdata/config2.json
@@ -1,29 +1,31 @@
 {
-  "taint-tracking-problems": [
-    {
-      "sanitizers": [
-        {
-          "package": "x",
-          "method": "a",
-          "field": "b"
-        }
-      ],
-      "sinks": [
-        {
-          "package": "y",
-          "method": "b"
-        }
-      ],
-      "sources": [
-        {
-          "package": "p",
-          "method": "a"
-        },
-        {
-          "package": "p2",
-          "method": "a"
-        }
-      ]
-    }
-  ]
+  "dataflow-problems": {
+    "taint-tracking": [
+      {
+        "sanitizers": [
+          {
+            "package": "x",
+            "method": "a",
+            "field": "b"
+          }
+        ],
+        "sinks": [
+          {
+            "package": "y",
+            "method": "b"
+          }
+        ],
+        "sources": [
+          {
+            "package": "p",
+            "method": "a"
+          },
+          {
+            "package": "p2",
+            "method": "a"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/analysis/config/testdata/config2.yaml
+++ b/analysis/config/testdata/config2.yaml
@@ -1,4 +1,5 @@
-taint-tracking-problems:
+dataflow-problems:
+  taint-tracking:
     - sanitizers:
       - package: x
         method: a

--- a/analysis/config/testdata/config3.yaml
+++ b/analysis/config/testdata/config3.yaml
@@ -2,7 +2,8 @@
 options:
     pkg-filter: "a"
 
-taint-tracking-problems:
+dataflow-problems:
+  taint-tracking:
     - sinks:
       - package: y
         method: b

--- a/analysis/config/testdata/config_before_v0_3_0.json
+++ b/analysis/config/testdata/config_before_v0_3_0.json
@@ -13,7 +13,7 @@
     "use-escape-analysis": true,
     "summarize-on-demand": true,
     "skip-interprocedural": true,
-    "field-sensitive": true,
+    "field-sensitive-funcs": [".*"],
     "max-alarms": 16,
     "unsafe-max-depth": 42,
     "max-entrypoint-context-size": 20

--- a/analysis/config/testdata/config_before_v0_3_0.json
+++ b/analysis/config/testdata/config_before_v0_3_0.json
@@ -1,0 +1,37 @@
+{
+  "options": {
+    "log-level": 5,
+    "reports-dir": "example-dir",
+    "report-coverage": true,
+    "report-paths": true,
+    "report-no-callee-sites": true,
+    "coverage-filter": "argot.*",
+    "report-summaries": true,
+    "pkg-filter": "analysis.*",
+    "silence-warn": true,
+    "source-taints-args": true,
+    "use-escape-analysis": true,
+    "summarize-on-demand": true,
+    "skip-interprocedural": true,
+    "field-sensitive": true,
+    "max-alarms": 16,
+    "unsafe-max-depth": 42,
+    "max-entrypoint-context-size": 20
+  },
+  "pointer-config": {
+    "reflection": true,
+    "unsafe-no-effect-functions": [
+      "fmt.Errorf",
+      "fmt.Printf"
+    ]
+  },
+  "dataflow-specs": ["example.json", "example2.json"],
+  "taint-tracking-problems": [
+    {
+      "validators": [{"method": "Validate", "package": "x"}],
+      "sinks": [{"method": "Sink", "package":  "sensitiveDataManipulation"}],
+      "sources": [{"type": "Data", "field":  "UserProvided"}],
+      "sanitizers": [{"method": "Sanitize"}]
+    }
+  ]
+}

--- a/analysis/config/testdata/config_before_v0_3_0.yaml
+++ b/analysis/config/testdata/config_before_v0_3_0.yaml
@@ -1,0 +1,37 @@
+# This is a complete config file. All fields are mostly optional, unless clearly required by the analysis you
+# are trying to run.
+
+options:
+  log-level: 5
+  field-sensitive: true
+  # Before v0.3.0 below were simple config options
+  unsafe-max-depth: 42
+  max-alarms: 16
+  max-entrypoint-context-size: 20
+
+dataflow-specs:
+  - "example.json"
+  - "example2.json"
+
+pointer-config:
+  reflection: true
+  unsafe-no-effect-functions:
+    - "fmt.Errorf"
+    - "fmt.Printf"
+
+taint-tracking-problems:
+  - validators:
+      - method: "Validate"
+        package: "x"
+
+    sinks:
+      - method: "Sink"
+        package: "sensitiveDataManipulation"
+
+    sources:
+      - type: "Data"
+        field: "UserProvided"
+
+    sanitizers:
+      - method: "Sanitize"
+

--- a/analysis/config/testdata/config_before_v0_3_0.yaml
+++ b/analysis/config/testdata/config_before_v0_3_0.yaml
@@ -3,7 +3,8 @@
 
 options:
   log-level: 5
-  field-sensitive: true
+  field-sensitive-funcs:
+    - ".*"
   # Before v0.3.0 below were simple config options
   unsafe-max-depth: 42
   max-alarms: 16

--- a/analysis/config/testdata/config_before_v0_3_0.yaml
+++ b/analysis/config/testdata/config_before_v0_3_0.yaml
@@ -3,8 +3,7 @@
 
 options:
   log-level: 5
-  field-sensitive-funcs:
-    - ".*"
+  field-sensitive: true
   # Before v0.3.0 below were simple config options
   unsafe-max-depth: 42
   max-alarms: 16

--- a/analysis/config/testdata/example.drawio.yaml
+++ b/analysis/config/testdata/example.drawio.yaml
@@ -4,12 +4,13 @@ options:
   pkg-filter: "abc"
   report-summaries: true
 
-taint-tracking-problems:
-  - sources:
-      - package: "(main)|(command-line-arguments)|((.*)ar-go-tools)"
-        method: "source[1-9]"
-    sinks:
-      - package: "(main)|(command-line-arguments)|((.*)ar-go-tools)"
-        method: "(s|S)ink[1-9]"
-    sanitizers:
-      - method: "(s|S)anitize[1-9]?"
+dataflow-problems:
+  taint-tracking:
+    - sources:
+        - package: "(main)|(command-line-arguments)|((.*)ar-go-tools)"
+          method: "source[1-9]"
+      sinks:
+        - package: "(main)|(command-line-arguments)|((.*)ar-go-tools)"
+          method: "(s|S)ink[1-9]"
+      sanitizers:
+        - method: "(s|S)anitize[1-9]?"

--- a/analysis/config/testdata/full-config.json
+++ b/analysis/config/testdata/full-config.json
@@ -10,7 +10,6 @@
     "pkg-filter": "analysis.*",
     "silence-warn": true,
     "use-escape-analysis": true,
-    "skip-interprocedural": true,
     "analysis-options": {
       "max-alarms": 16,
       "unsafe-max-depth": 42,

--- a/analysis/config/testdata/full-config.json
+++ b/analysis/config/testdata/full-config.json
@@ -29,7 +29,7 @@
       "example.json",
       "example2.json"
     ],
-    "field-sensitive": true,
+    "field-sensitive-funcs": [".*"],
     "summarize-on-demand": true,
     "slicing": [
       {

--- a/analysis/config/testdata/full-config.json
+++ b/analysis/config/testdata/full-config.json
@@ -25,15 +25,29 @@
       "fmt.Printf"
     ]
   },
-  "dataflow-problems" : {
+  "dataflow-problems": {
     "user-specs": [
       "example.json",
       "example2.json"
     ],
     "field-sensitive": true,
     "summarize-on-demand": true,
+    "slicing": [
+      {
+        "tag": "slicing-problem-1",
+        "description": "A slicing problem",
+        "backtracepoints": [
+          {
+            "method": "Foo",
+            "package": "bar"
+          }
+        ]
+      }
+    ],
     "taint-tracking": [
       {
+        "tag": "taint-tracking-problem-1",
+        "description": "A taint tracking problem.",
         "validators": [
           {
             "method": "Validate",

--- a/analysis/config/testdata/full-config.json
+++ b/analysis/config/testdata/full-config.json
@@ -9,7 +9,6 @@
     "report-summaries": true,
     "pkg-filter": "analysis.*",
     "silence-warn": true,
-    "source-taints-args": true,
     "use-escape-analysis": true,
     "skip-interprocedural": true,
     "analysis-options": {
@@ -48,6 +47,7 @@
       {
         "tag": "taint-tracking-problem-1",
         "description": "A taint tracking problem.",
+        "source-taints-args": true,
         "validators": [
           {
             "method": "Validate",

--- a/analysis/config/testdata/full-config.json
+++ b/analysis/config/testdata/full-config.json
@@ -71,7 +71,7 @@
             "method": "Sanitize"
           }
         ],
-        "analysis-options": {
+        "override-analysis-options": {
           "unsafe-max-depth": 1
         }
       }

--- a/analysis/config/testdata/full-config.json
+++ b/analysis/config/testdata/full-config.json
@@ -11,9 +11,7 @@
     "silence-warn": true,
     "source-taints-args": true,
     "use-escape-analysis": true,
-    "summarize-on-demand": true,
     "skip-interprocedural": true,
-    "field-sensitive": true,
     "analysis-options": {
       "max-alarms": 16,
       "unsafe-max-depth": 42,
@@ -27,16 +25,42 @@
       "fmt.Printf"
     ]
   },
-  "dataflow-specs": ["example.json", "example2.json"],
-  "taint-tracking-problems": [
-    {
-      "validators": [{"method": "Validate", "package": "x"}],
-      "sinks": [{"method": "Sink", "package":  "sensitiveDataManipulation"}],
-      "sources": [{"type": "Data", "field":  "UserProvided"}],
-      "sanitizers": [{"method": "Sanitize"}],
-      "analysis-options": {
-        "unsafe-max-depth": 1
+  "dataflow-problems" : {
+    "user-specs": [
+      "example.json",
+      "example2.json"
+    ],
+    "field-sensitive": true,
+    "summarize-on-demand": true,
+    "taint-tracking": [
+      {
+        "validators": [
+          {
+            "method": "Validate",
+            "package": "x"
+          }
+        ],
+        "sinks": [
+          {
+            "method": "Sink",
+            "package": "sensitiveDataManipulation"
+          }
+        ],
+        "sources": [
+          {
+            "type": "Data",
+            "field": "UserProvided"
+          }
+        ],
+        "sanitizers": [
+          {
+            "method": "Sanitize"
+          }
+        ],
+        "analysis-options": {
+          "unsafe-max-depth": 1
+        }
       }
-    }
-  ]
+    ]
+  }
 }

--- a/analysis/config/testdata/full-config.json
+++ b/analysis/config/testdata/full-config.json
@@ -8,16 +8,17 @@
     "coverage-filter": "argot.*",
     "report-summaries": true,
     "pkg-filter": "analysis.*",
-    "max-alarms": 16,
-    "max-entrypoint-context-size": 20,
     "silence-warn": true,
     "source-taints-args": true,
-    "unsafe-max-depth": 42,
-    "unsafe-ignore-non-summarized": true,
     "use-escape-analysis": true,
     "summarize-on-demand": true,
     "skip-interprocedural": true,
-    "field-sensitive": true
+    "field-sensitive": true,
+    "analysis-options": {
+      "max-alarms": 16,
+      "unsafe-max-depth": 42,
+      "max-entrypoint-context-size": 20
+    }
   },
   "pointer-config": {
     "reflection": true,
@@ -32,7 +33,10 @@
       "validators": [{"method": "Validate", "package": "x"}],
       "sinks": [{"method": "Sink", "package":  "sensitiveDataManipulation"}],
       "sources": [{"type": "Data", "field":  "UserProvided"}],
-      "sanitizers": [{"method": "Sanitize"}]
+      "sanitizers": [{"method": "Sanitize"}],
+      "analysis-options": {
+        "unsafe-max-depth": 1
+      }
     }
   ]
 }

--- a/analysis/config/testdata/full-config.yaml
+++ b/analysis/config/testdata/full-config.yaml
@@ -68,6 +68,7 @@ pointer-config:
     - "fmt.Errorf"
     - "fmt.Printf"
 
+# All the dataflow problems and the dataflow-specific problems
 dataflow-problems:
   # this can be set to use only on-demand summarization
   summarize-on-demand: true
@@ -79,9 +80,20 @@ dataflow-problems:
     - "example.json"
     - "example2.json"
 
+# The slicing/backwards dataflow problems
+  slicing:
+    - tag: "slicing-problem-1"
+      description: "A slicing problem"
+      backtracepoints:
+        - method: "Foo"
+          package: "bar"
+
+
   # The taint tracking problems
   taint-tracking:
-    - validators:
+    - tag: "taint-tracking-problem-1"
+      description: "A taint tracking problem."
+      validators:
         - method: "Validate"
           package: "x"
 

--- a/analysis/config/testdata/full-config.yaml
+++ b/analysis/config/testdata/full-config.yaml
@@ -107,5 +107,5 @@ dataflow-problems:
       sanitizers:
         - method: "Sanitize"
 
-      analysis-options:
+      override-analysis-options:
         unsafe-max-depth: 1

--- a/analysis/config/testdata/full-config.yaml
+++ b/analysis/config/testdata/full-config.yaml
@@ -46,12 +46,6 @@ options:
   # this options ensures that the escape analysis is run in parallel with the dataflow analysis
   use-escape-analysis: true
 
-  # this can be set to use only on-demand summarization
-  summarize-on-demand: true
-
-  # This setting sets whether the analysis is field sensitive
-  field-sensitive: true
-
   analysis-options:
     # For context-sensitive graph reachability based analysis this parameter can be used to limit the callstack depth
     # that can be considered during the analysis. This can be used for debugging, or to artifically only filter
@@ -66,11 +60,6 @@ options:
     # called.
     max-entrypoint-context-size: 20
 
-# For any dataflow analysis, you can specify summaries for specific functions and interfaces. The analysis will
-# use each of those files as a reference for the functions specified
-dataflow-specs:
-  - "example.json"
-  - "example2.json"
 
 # Configuration elements specific to the pointer analysis
 pointer-config:
@@ -79,21 +68,33 @@ pointer-config:
     - "fmt.Errorf"
     - "fmt.Printf"
 
-taint-tracking-problems:
-  - validators:
-      - method: "Validate"
-        package: "x"
+dataflow-problems:
+  # this can be set to use only on-demand summarization
+  summarize-on-demand: true
+  # This setting sets whether the analysis is field sensitive
+  field-sensitive: true
+  # For any dataflow analysis, you can specify summaries for specific functions and interfaces. The analysis will
+  # use each of those files as a reference for the functions specified
+  user-specs:
+    - "example.json"
+    - "example2.json"
 
-    sinks:
-      - method: "Sink"
-        package: "sensitiveDataManipulation"
+  # The taint tracking problems
+  taint-tracking:
+    - validators:
+        - method: "Validate"
+          package: "x"
 
-    sources:
-      - type: "Data"
-        field: "UserProvided"
+      sinks:
+        - method: "Sink"
+          package: "sensitiveDataManipulation"
 
-    sanitizers:
-      - method: "Sanitize"
+      sources:
+        - type: "Data"
+          field: "UserProvided"
 
-    analysis-options:
-      unsafe-max-depth: 1
+      sanitizers:
+        - method: "Sanitize"
+
+      analysis-options:
+        unsafe-max-depth: 1

--- a/analysis/config/testdata/full-config.yaml
+++ b/analysis/config/testdata/full-config.yaml
@@ -69,8 +69,9 @@ pointer-config:
 dataflow-problems:
   # this can be set to use only on-demand summarization
   summarize-on-demand: true
-  # This setting sets whether the analysis is field sensitive
-  field-sensitive: true
+  # This setting sets all functions to be analyzed with field sensitivity
+  field-sensitive-funcs:
+    - ".*"
   # For any dataflow analysis, you can specify summaries for specific functions and interfaces. The analysis will
   # use each of those files as a reference for the functions specified
   user-specs:

--- a/analysis/config/testdata/full-config.yaml
+++ b/analysis/config/testdata/full-config.yaml
@@ -40,9 +40,6 @@ options:
   # this can be set to suppress warnings. Errors (i.e. taint detected will be reported)
   silence-warn: true
 
-  # this can be set so that source function are also tainting their arguments
-  source-taints-args: true
-
   # this options ensures that the escape analysis is run in parallel with the dataflow analysis
   use-escape-analysis: true
 
@@ -93,6 +90,8 @@ dataflow-problems:
   taint-tracking:
     - tag: "taint-tracking-problem-1"
       description: "A taint tracking problem."
+      # this can be set so that source function are also tainting their arguments
+      source-taints-args: true
       validators:
         - method: "Validate"
           package: "x"

--- a/analysis/config/testdata/full-config.yaml
+++ b/analysis/config/testdata/full-config.yaml
@@ -29,10 +29,6 @@ options:
   # will be created in the reports directory. This is a report requirement.
   report-summaries: true
 
-  # [taint] skip-interprocedural can be set to true if you only want to run the intra-procedural analysis when running
-  # the taint tool in argot. It is only useful for debugging purposes
-  skip-interprocedural: true
-
   # [taint] this can be set to limit which packages are analyzed during the first phase of the taint analysis.
   # packages that do not match the regex will not be analyzed
   pkg-filter: "analysis.*"

--- a/analysis/config/testdata/full-config.yaml
+++ b/analysis/config/testdata/full-config.yaml
@@ -37,28 +37,11 @@ options:
   # packages that do not match the regex will not be analyzed
   pkg-filter: "analysis.*"
 
-  # this can be set to limit the number of alarms raised by an analysis if you only care about the truth value of
-  # the output, or only want to analyze a few results
-  max-alarms: 16
-
-  # this can be used to limit the size of the callstack when searching for contexts under which a function can be
-  # called.
-  max-entrypoint-context-size: 20
-
   # this can be set to suppress warnings. Errors (i.e. taint detected will be reported)
   silence-warn: true
 
   # this can be set so that source function are also tainting their arguments
   source-taints-args: true
-
-  # this option makes analyzes unsound, but can be useful in exploration. This ignores when functions have not
-  # been summarized during the inter-procedural step
-  unsafe-ignore-non-summarized: true
-
-  # For context-sensitive graph reachability based analysis this parameter can be used to limit the callstack depth
-  # that can be considered during the analysis. This can be used for debugging, or to artifically only filter
-  # short traces
-  unsafe-max-depth: 42
 
   # this options ensures that the escape analysis is run in parallel with the dataflow analysis
   use-escape-analysis: true
@@ -68,6 +51,20 @@ options:
 
   # This setting sets whether the analysis is field sensitive
   field-sensitive: true
+
+  analysis-options:
+    # For context-sensitive graph reachability based analysis this parameter can be used to limit the callstack depth
+    # that can be considered during the analysis. This can be used for debugging, or to artifically only filter
+    # short traces
+    unsafe-max-depth: 42
+
+    # this can be set to limit the number of alarms raised by an analysis if you only care about the truth value of
+    # the output, or only want to analyze a few results
+    max-alarms: 16
+
+    # this can be used to limit the size of the callstack when searching for contexts under which a function can be
+    # called.
+    max-entrypoint-context-size: 20
 
 # For any dataflow analysis, you can specify summaries for specific functions and interfaces. The analysis will
 # use each of those files as a reference for the functions specified
@@ -97,3 +94,6 @@ taint-tracking-problems:
 
     sanitizers:
       - method: "Sanitize"
+
+    analysis-options:
+      unsafe-max-depth: 1

--- a/analysis/config/testdata/invalid_config_duplicate_tags.yaml
+++ b/analysis/config/testdata/invalid_config_duplicate_tags.yaml
@@ -1,0 +1,12 @@
+dataflow-problems:
+  taint-tracking:
+    - tag: "x"
+      sources:
+        - method: "foo"
+      sinks:
+        - method: "bar"
+    - tag: "x"
+      sources:
+        - method: "foo"
+      sinks:
+        - method: "bar"

--- a/analysis/config/testdata/invalid_config_invalid_sev.yaml
+++ b/analysis/config/testdata/invalid_config_invalid_sev.yaml
@@ -1,0 +1,14 @@
+dataflow-problems:
+  taint-tracking:
+    - tag: "x1"
+      severity: "CRITICAL"
+      sources:
+        - method: "foo"
+      sinks:
+        - method: "bar"
+    - tag: "x2"
+      severity: "WHOOPING"
+      sources:
+        - method: "fooB"
+      sinks:
+        - method: "barB"

--- a/analysis/config/testdata/sample-spec.json
+++ b/analysis/config/testdata/sample-spec.json
@@ -1,0 +1,11 @@
+[
+  {
+    "InterfaceId": "error",
+    "Methods": {
+      "Error": {
+        "Args": [[0]],
+        "Rets": [[0]]
+      }
+    }
+  }
+]

--- a/analysis/config/testdata/syntactic-config.yaml
+++ b/analysis/config/testdata/syntactic-config.yaml
@@ -2,7 +2,8 @@ options:
   # Report all data
   reports-dir: "example-dir" # report will be in subdirectory taint-report where this file is
   log-level: 5
-  max-alarms: 2
+  analysis-options:
+    max-alarms: 2
   silence-warn: true
 
 syntactic-problems:

--- a/analysis/config/testdata/test_project_root_loading.yaml
+++ b/analysis/config/testdata/test_project_root_loading.yaml
@@ -1,0 +1,6 @@
+options:
+  project-root: "../../../../"
+
+dataflow-problems:
+  user-specs:
+    - "analysis/config/testdata/sample-spec.json"

--- a/analysis/config/validation.go
+++ b/analysis/config/validation.go
@@ -25,6 +25,9 @@ func (c Config) Validate() error {
 	if err := c.checkTagsAreUnique(); err != nil {
 		return err
 	}
+	if err := c.checkSeveritiesAreValid(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -45,4 +48,26 @@ func (c Config) checkTagsAreUnique() error {
 		tags[tag] = true
 	}
 	return nil
+}
+
+func (c Config) checkSeveritiesAreValid() error {
+	sevList := funcutil.Map(c.TaintTrackingProblems, func(ts TaintSpec) string { return ts.Severity })
+	sevList = append(sevList, funcutil.Map(c.SlicingProblems, func(ts SlicingSpec) string { return ts.Severity })...)
+	for _, sev := range sevList {
+		if !isValidSeverity(sev) {
+			return fmt.Errorf(
+				"invalid severity label %s (not empty, \"CRITICAL\", \"HIGH\", \"MEDIUM\", or \"LOW\")",
+				sev)
+		}
+	}
+	return nil
+}
+
+func isValidSeverity(s string) bool {
+	switch s {
+	case "", "CRITICAL", "HIGH", "MEDIUM", "LOW":
+		return true
+	default:
+		return false
+	}
 }

--- a/analysis/config/validation.go
+++ b/analysis/config/validation.go
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/awslabs/ar-go-tools/internal/funcutil"
+)
+
+// Validate validates the config and returns an error if there is some invalid setting
+func (c Config) Validate() error {
+	if err := c.checkTagsAreUnique(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c Config) checkTagsAreUnique() error {
+	hasUnsetTag := false
+	tags := map[string]bool{}
+	tagsList := funcutil.Map(c.TaintTrackingProblems, func(ts TaintSpec) string { return ts.Tag })
+	tagsList = append(tagsList, funcutil.Map(c.SlicingProblems, func(ts SlicingSpec) string { return ts.Tag })...)
+	for _, tag := range tagsList {
+		if tag == "" {
+			if hasUnsetTag {
+				return fmt.Errorf("there can be only one problem with an unspecified tag")
+			}
+			hasUnsetTag = true
+		} else if tags[tag] {
+			return fmt.Errorf("tag %s is used for multiple problems", tag)
+		}
+		tags[tag] = true
+	}
+	return nil
+}

--- a/analysis/dataflow/flow_info.go
+++ b/analysis/dataflow/flow_info.go
@@ -109,11 +109,9 @@ func NewFlowInfo(cfg *config.Config, f *ssa.Function) *FlowInformation {
 	})
 
 	pathSensitivityFilter := make([]bool, numValues)
-	pathSensitive := cfg.PathSensitive
-	if !pathSensitive && f != nil {
-		if cfg.IsPathSensitiveFunc(f.String()) {
-			pathSensitive = true
-		}
+	pathSensitive := false
+	if f != nil {
+		pathSensitive = cfg.IsPathSensitiveFunc(f.String())
 	}
 	for i := range values {
 		pathSensitivityFilter[i] = pathSensitive

--- a/analysis/dataflow/inter_procedural.go
+++ b/analysis/dataflow/inter_procedural.go
@@ -281,9 +281,8 @@ type ScanningSpec struct {
 // or if `cfg.SkipInterprocedural` is set to true.
 func (g *InterProceduralFlowGraph) BuildAndRunVisitor(c *AnalyzerState, visitor Visitor, spec ScanningSpec) {
 	// Skip the pass if user configuration demands it
-	if c.Config.SkipInterprocedural || (!c.Config.SummarizeOnDemand && len(g.Summaries) == 0) {
-		c.Logger.Infof("Skipping inter-procedural pass: config.SkipInterprocedural=%v, len(summaries)=%d\n",
-			c.Config.SkipInterprocedural, len(g.Summaries))
+	if !c.Config.SummarizeOnDemand && len(g.Summaries) == 0 {
+		c.Logger.Infof("Skipping inter-procedural pass: no summaries, and not summarizing on demand.")
 		return
 	}
 

--- a/analysis/dataflow/state.go
+++ b/analysis/dataflow/state.go
@@ -304,6 +304,11 @@ func (s *AnalyzerState) HasErrors() bool {
 	return false
 }
 
+// ResetAlarms resets the number of alarms to 0
+func (s *AnalyzerState) ResetAlarms() {
+	s.numAlarms.Store(0)
+}
+
 // IncrementAndTestAlarms increments the alarm counter in the state, and returns false if the count is larger
 // than the MaxAlarms setting in the config.
 func (s *AnalyzerState) IncrementAndTestAlarms() bool {

--- a/analysis/dataflow/state.go
+++ b/analysis/dataflow/state.go
@@ -172,8 +172,8 @@ func NewAnalyzerState(p *ssa.Program, pkgs []*packages.Package, l *config.LogGro
 	state.FlowGraph.AnalyzerState = state
 
 	// Load the dataflow contracts from the specified json files, if any
-	if len(c.DataflowSpecs) > 0 {
-		for _, specFile := range c.DataflowSpecs {
+	if len(c.DataflowProblems.UserSpecs) > 0 {
+		for _, specFile := range c.DataflowProblems.UserSpecs {
 			contractsBatch, err := LoadDefinitions(c.RelPath(specFile))
 			if err != nil {
 				return nil, err

--- a/analysis/dataflow/testdata/bounding-analysis/config.yaml
+++ b/analysis/dataflow/testdata/bounding-analysis/config.yaml
@@ -1,6 +1,6 @@
 # The package regex matches all possible ways the package name might appear depending on how the program is loaded
 taint-tracking-problems:
-  -
+  - tag: "taint1"
     sources:
       - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Sources can be source1, source2, etc.
@@ -18,3 +18,4 @@ slicing-problems:
       - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
+    tag: "slicing1"

--- a/analysis/dataflow/testdata/bounding-analysis/config.yaml
+++ b/analysis/dataflow/testdata/bounding-analysis/config.yaml
@@ -1,21 +1,22 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  - tag: "taint1"
-    sources:
-      - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    fail-on-implicit-flow: true
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    - tag: "taint1"
+      sources:
+        - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      fail-on-implicit-flow: true
 
 
-# Same as sinks
-slicing-problems:
-  - backtracepoints:
-      - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    tag: "slicing1"
+  # Same as sinks
+  slicing:
+    - backtracepoints:
+        - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      tag: "slicing1"

--- a/analysis/dataflow/testdata/callctx/config.yaml
+++ b/analysis/dataflow/testdata/callctx/config.yaml
@@ -1,2 +1,3 @@
 options:
-  max-alarms: 1000
+  analysis-options:
+    max-alarms: 1000

--- a/analysis/dataflow/testdata/callgraph/config.yaml
+++ b/analysis/dataflow/testdata/callgraph/config.yaml
@@ -1,2 +1,3 @@
 options:
-  max-alarms: 1000
+  analysis-options:
+    max-alarms: 1000

--- a/analysis/dataflow/testdata/src/sinks/config.yaml
+++ b/analysis/dataflow/testdata/src/sinks/config.yaml
@@ -1,5 +1,6 @@
-taint-tracking-problems:
-  -
-    sinks:
-      - package: "((main)|(sinks))"
-        method: sinkFunction
+dataflow-problems:
+  taint-tracking:
+    -
+      sinks:
+        - package: "((main)|(sinks))"
+          method: sinkFunction

--- a/analysis/dataflow/testdata/src/sources/config.yaml
+++ b/analysis/dataflow/testdata/src/sources/config.yaml
@@ -1,12 +1,13 @@
-taint-tracking-problems:
-  -
-    sources:
-      - package: "fmt"
-        method: Sprintf
-      - package: "(main)|(command-line-arguments)|(sources)$"
-        method: zoo
-      - package: "(main)|(command-line-arguments)|(sources)$"
-        type: Bar
-      - type: SomeStruct
-        field: DataField
-      - field: Pickles
+dataflow-problems:
+  taint-tracking:
+    -
+      sources:
+        - package: "fmt"
+          method: Sprintf
+        - package: "(main)|(command-line-arguments)|(sources)$"
+          method: zoo
+        - package: "(main)|(command-line-arguments)|(sources)$"
+          type: Bar
+        - type: SomeStruct
+          field: DataField
+        - field: Pickles

--- a/analysis/dataflow/testdata/summaries/config.yaml
+++ b/analysis/dataflow/testdata/summaries/config.yaml
@@ -1,13 +1,14 @@
-taint-tracking-problems:
-  - sources:
-      - package: main
-        method: Source
-      - package: command-line-arguments
-        method: Source
-      - package: (main|command-line-arguments)
-        field: Source
-    sinks:
-      - package: command-line-arguments
-        method: Sink
-      - package: main
-        method: Sink
+dataflow-problems:
+  taint-tracking:
+    - sources:
+        - package: main
+          method: Source
+        - package: command-line-arguments
+          method: Source
+        - package: (main|command-line-arguments)
+          field: Source
+      sinks:
+        - package: command-line-arguments
+          method: Sink
+        - package: main
+          method: Sink

--- a/analysis/dataflow/testdata/unsound-features/config.yaml
+++ b/analysis/dataflow/testdata/unsound-features/config.yaml
@@ -1,15 +1,15 @@
-taint-tracking-problems:
-  - sources:
-      - package: main
-        method: Source
-      - package: command-line-arguments
-        method: Source
-      - package: (main|command-line-arguments)
-        field: Source
-    sinks:
-      - package: command-line-arguments
-        method: Sink
-      - package: main
-        method: Sink
-options:
+dataflow-problems:
+  taint-tracking:
+    - sources:
+        - package: main
+          method: Source
+        - package: command-line-arguments
+          method: Source
+        - package: (main|command-line-arguments)
+          field: Source
+      sinks:
+        - package: command-line-arguments
+          method: Sink
+        - package: main
+          method: Sink
   summarize-on-demand: true

--- a/analysis/load_program_test.go
+++ b/analysis/load_program_test.go
@@ -17,11 +17,39 @@ package analysis
 import (
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 	"testing"
 
+	"github.com/awslabs/ar-go-tools/cmd/argot/tools"
 	"golang.org/x/tools/go/ssa"
 )
+
+func TestLoadWithProjectRoot(t *testing.T) {
+	configFile := filepath.Join("testdata", "state_load_config.yaml")
+	config, err := tools.LoadConfig(configFile)
+	if err != nil {
+		t.Fatalf("failed to load config")
+	}
+	_, filename, _, _ := runtime.Caller(0)
+	dir := path.Join(path.Dir(filename), "../cmd/argot/")
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatalf("could not change to cmd/argot dir: %s", err)
+		return
+	}
+	loadOptions := LoadProgramOptions{
+		BuildMode:     ssa.BuilderMode(0),
+		LoadTests:     false,
+		ApplyRewrites: true,
+		Platform:      "",
+		PackageConfig: nil,
+	}
+	_, err = LoadAnalyzerState(loadOptions, []string{"main.go"}, config)
+	if err != nil {
+		t.Fatalf("error loading state: %s", err)
+	}
+}
 
 func programLoadTest(t *testing.T, files []string) {
 	_, filename, _, _ := runtime.Caller(0)

--- a/analysis/render/render.go
+++ b/analysis/render/render.go
@@ -34,8 +34,8 @@ func BuildCrossFunctionGraph(state *dataflow.AnalyzerState) (*dataflow.AnalyzerS
 
 	state.Logger.Infof("Building full-program inter-procedural dataflow graph...")
 	start := time.Now()
-	analysis.RunInterProcedural(state, CrossFunctionGraphVisitor{}, analysis.InterProceduralParams{
-		IsEntrypoint: func(ssa.Node) bool { return true },
+	analysis.RunInterProcedural(state, CrossFunctionGraphVisitor{}, dataflow.ScanningSpec{
+		IsEntryPointSsa: func(ssa.Node) bool { return true },
 	})
 
 	state.Logger.Infof("Full-program inter-procedural dataflow graph done (%.2f s).", time.Since(start).Seconds())

--- a/analysis/taint/taint.go
+++ b/analysis/taint/taint.go
@@ -128,8 +128,7 @@ func Analyze(cfg *config.Config, prog *ssa.Program, pkgs []*packages.Package) (A
 
 		state.Logger.Infof("Analyzing taint-tracking problem %s", taintSpec.Tag)
 		// Set problem-specific options
-		var prevOptions config.AnalysisProblemOptions
-		prevOptions = state.Config.AnalysisProblemOptions
+		prevOptions := state.Config.AnalysisProblemOptions
 
 		// Overriding options with problem-specific config
 		if taintSpec.AnalysisProblemOptions != nil {

--- a/analysis/taint/taint.go
+++ b/analysis/taint/taint.go
@@ -148,9 +148,10 @@ func Analyze(cfg *config.Config, prog *ssa.Program, pkgs []*packages.Package) (A
 		}
 		state.Logger.Debugf("Options: %+v", state.Config.Options)
 		visitor := NewVisitor(&taintSpec)
-		analysis.RunInterProcedural(state, visitor, analysis.InterProceduralParams{
+		analysis.RunInterProcedural(state, visitor, dataflow.ScanningSpec{
 			// The entry points are specific to each taint tracking problem (unlike in the intra-procedural pass)
-			IsEntrypoint: func(node ssa.Node) bool { return dataflow.IsSourceNode(state, &taintSpec, node) },
+			IsEntryPointSsa:      func(node ssa.Node) bool { return dataflow.IsSourceNode(state, &taintSpec, node) },
+			MarkCallArgsLikeCall: taintSpec.SourceTaintsArgs,
 		})
 		taintFlows.Merge(visitor.taints)
 		// Restore global options

--- a/analysis/taint/testdata/agent-example/config.yaml
+++ b/analysis/taint/testdata/agent-example/config.yaml
@@ -1,9 +1,11 @@
-taint-tracking-problems:
- - sources:
-    - method: "source"
-      package: "((main)|(command-line-arguments)|(agent-example))"
-   sinks:
-    - package: "log"
-      interface: "Logger"
-    - method: "sink"
-      package: "((main)|(command-line-arguments)|(agent-example))"
+dataflow-problems:
+  taint-tracking:
+    - tag: "taint1"
+      sources:
+      - method: "source"
+        package: "((main)|(command-line-arguments)|(agent-example))"
+      sinks:
+      - package: "log"
+        interface: "Logger"
+      - method: "sink"
+        package: "((main)|(command-line-arguments)|(agent-example))"

--- a/analysis/taint/testdata/annotations/config.json
+++ b/analysis/taint/testdata/annotations/config.json
@@ -28,7 +28,7 @@
             "method": "sinkFoo"
           }
         ],
-        "analysis-options": {
+        "override-analysis-options": {
           "unsafe-max-depth": 1
         }
       },

--- a/analysis/taint/testdata/annotations/config.json
+++ b/analysis/taint/testdata/annotations/config.json
@@ -5,33 +5,46 @@
       "unsafe-max-depth": 42
     }
   },
-  "taint-tracking-problems": [
-    {
-      "tag": "hybridDef",
-      "sinks": [
-        {"package":  "fmt", "method": "Println"}
-      ]
-    },
-    {
-      "tag": "foo",
-      "sources": [
-        {"method": "sourceFoo"}
-      ],
-      "sinks": [
-        {"method": "sinkFoo"}
-      ],
-      "analysis-options": {
-        "unsafe-max-depth": 1
+  "dataflow-problems": {
+    "taint-tracking": [
+      {
+        "tag": "hybridDef",
+        "sinks": [
+          {
+            "package": "fmt",
+            "method": "Println"
+          }
+        ]
+      },
+      {
+        "tag": "foo",
+        "sources": [
+          {
+            "method": "sourceFoo"
+          }
+        ],
+        "sinks": [
+          {
+            "method": "sinkFoo"
+          }
+        ],
+        "analysis-options": {
+          "unsafe-max-depth": 1
+        }
+      },
+      {
+        "tag": "bar",
+        "sources": [
+          {
+            "method": "sourceFoo"
+          }
+        ],
+        "sinks": [
+          {
+            "method": "sinkBar"
+          }
+        ]
       }
-    },
-    {
-      "tag": "bar",
-      "sources": [
-        {"method": "sourceFoo"}
-      ],
-      "sinks": [
-        {"method": "sinkBar"}
-      ]
-    }
-  ]
+    ]
+  }
 }

--- a/analysis/taint/testdata/annotations/config.json
+++ b/analysis/taint/testdata/annotations/config.json
@@ -1,12 +1,36 @@
 {
   "options": {
-    "log-level": 4
+    "log-level": 4,
+    "analysis-options": {
+      "unsafe-max-depth": 42
+    }
   },
   "taint-tracking-problems": [
     {
       "tag": "hybridDef",
       "sinks": [
         {"package":  "fmt", "method": "Println"}
+      ]
+    },
+    {
+      "tag": "foo",
+      "sources": [
+        {"method": "sourceFoo"}
+      ],
+      "sinks": [
+        {"method": "sinkFoo"}
+      ],
+      "analysis-options": {
+        "unsafe-max-depth": 1
+      }
+    },
+    {
+      "tag": "bar",
+      "sources": [
+        {"method": "sourceFoo"}
+      ],
+      "sinks": [
+        {"method": "sinkBar"}
       ]
     }
   ]

--- a/analysis/taint/testdata/basic/config.yaml
+++ b/analysis/taint/testdata/basic/config.yaml
@@ -1,29 +1,30 @@
-taint-tracking-problems:
- - # The package regex matches all possible ways the package name might appear depending on how the program is loaded
-  sources:
-    - package: "(basic)|(main)|(command-line-arguments)"
-      # Sources can be source1, source2, etc.
-      method: "(source[1-9])"
-    - package: "(basic)|(main)|(command-line-arguments)"
-      field: "Source[1-9]?"
-    - package: "(basic)|(main)|(command-line-arguments)"
-      type: "(chan \\*_S)|(chan _S)"
-      kind: "channel receive"
-    - package: "(basic)|(main)|(command-line-arguments)"
-      type: "\\*Sample"
-      field: "Secret"
-  sinks:
-    - package: "(basic)|(main)|(command-line-arguments)"
-      # Similarly, sinks are sink1 sink2 sink2 ...
-      method: ".*(s|S)ink[1-9]"
-    - package: "fmt"
-      method: "Printf"
-      value-match: ".*%s.*"
-    - type: "ExampleData"
-      field: "SinkField"
-      kind: "store"
-  sanitizers:
-    - package: "(basic)|(main)|(command-line-arguments)"
-      method: ".*(s|S)anitize[1-9]?"
-  fail-on-implicit-flow: false
+dataflow-problems:
+  taint-tracking:
+   - # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+    sources:
+      - package: "(basic)|(main)|(command-line-arguments)"
+        # Sources can be source1, source2, etc.
+        method: "(source[1-9])"
+      - package: "(basic)|(main)|(command-line-arguments)"
+        field: "Source[1-9]?"
+      - package: "(basic)|(main)|(command-line-arguments)"
+        type: "(chan \\*_S)|(chan _S)"
+        kind: "channel receive"
+      - package: "(basic)|(main)|(command-line-arguments)"
+        type: "\\*Sample"
+        field: "Secret"
+    sinks:
+      - package: "(basic)|(main)|(command-line-arguments)"
+        # Similarly, sinks are sink1 sink2 sink2 ...
+        method: ".*(s|S)ink[1-9]"
+      - package: "fmt"
+        method: "Printf"
+        value-match: ".*%s.*"
+      - type: "ExampleData"
+        field: "SinkField"
+        kind: "store"
+    sanitizers:
+      - package: "(basic)|(main)|(command-line-arguments)"
+        method: ".*(s|S)anitize[1-9]?"
+    fail-on-implicit-flow: false
 

--- a/analysis/taint/testdata/benchmark/config.yaml
+++ b/analysis/taint/testdata/benchmark/config.yaml
@@ -1,6 +1,7 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+  - tag: "taint"
     sources:
       - package: (benchmark)|(main|command-line-arguments)
         field: Source

--- a/analysis/taint/testdata/builtins/config.yaml
+++ b/analysis/taint/testdata/builtins/config.yaml
@@ -1,9 +1,10 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(builtins)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - method: "sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    - tag: "taint"
+      sources:
+        - package: "(builtins)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - method: "sink[1-9]?"

--- a/analysis/taint/testdata/builtins_121/config.yaml
+++ b/analysis/taint/testdata/builtins_121/config.yaml
@@ -1,9 +1,10 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(builtins_121)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - method: "sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(builtins_121)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - method: "sink[1-9]?"

--- a/analysis/taint/testdata/closures/config.yaml
+++ b/analysis/taint/testdata/closures/config.yaml
@@ -1,6 +1,6 @@
 # The package regex matches all possible ways the package name might appear depending on how the program is loaded
 taint-tracking-problems:
-  -
+  - tag: "taint"
     sources:
       - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Sources can be source1, source2, etc.
@@ -14,7 +14,8 @@ taint-tracking-problems:
 
 # Same as sinks
 slicing-problems:
-  - backtracepoints:
+  - tag: "slicing"
+    backtracepoints:
       - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"

--- a/analysis/taint/testdata/closures/config.yaml
+++ b/analysis/taint/testdata/closures/config.yaml
@@ -1,21 +1,22 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  - tag: "taint"
-    sources:
-      - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    fail-on-implicit-flow: true
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    - tag: "taint"
+      sources:
+        - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      fail-on-implicit-flow: true
 
 
-# Same as sinks
-slicing-problems:
-  - tag: "slicing"
-    backtracepoints:
-      - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+  # Same as sinks
+  slicing:
+    - tag: "slicing"
+      backtracepoints:
+        - package: "(closures)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"

--- a/analysis/taint/testdata/closures_flowprecise/config.yaml
+++ b/analysis/taint/testdata/closures_flowprecise/config.yaml
@@ -1,6 +1,6 @@
 # The package regex matches all possible ways the package name might appear depending on how the program is loaded
 taint-tracking-problems:
-  -
+  - tag: "taint1"
     sources:
       - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Sources can be source1, source2, etc.
@@ -13,7 +13,7 @@ taint-tracking-problems:
 
 # Same as sinks
 slicing-problems:
-  -
+  - tag: "slicing"
     backtracepoints:
       - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...

--- a/analysis/taint/testdata/closures_flowprecise/config.yaml
+++ b/analysis/taint/testdata/closures_flowprecise/config.yaml
@@ -1,20 +1,21 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  - tag: "taint1"
-    sources:
-      - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    fail-on-implicit-flow: true
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    - tag: "taint1"
+      sources:
+        - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      fail-on-implicit-flow: true
 
-# Same as sinks
-slicing-problems:
-  - tag: "slicing"
-    backtracepoints:
-      - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+  # Same as sinks
+  slicing:
+    - tag: "slicing"
+      backtracepoints:
+        - package: "(closures_flowprecise)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"

--- a/analysis/taint/testdata/closures_paper/config.yaml
+++ b/analysis/taint/testdata/closures_paper/config.yaml
@@ -1,22 +1,23 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  - tag: "taint1"
-    sources:
-      - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    - tag: "taint1"
+      sources:
+        - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
 
-# Same as sinks
-slicing-problems:
-  - tag: "slicing1"
-    backtracepoints:
-      - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+  # Same as sinks
+  slicing:
+    - tag: "slicing1"
+      backtracepoints:
+        - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
 
 options:
   analysis-options:

--- a/analysis/taint/testdata/closures_paper/config.yaml
+++ b/analysis/taint/testdata/closures_paper/config.yaml
@@ -17,3 +17,7 @@ slicing-problems:
       - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...
         method: "sink[1-9]?"
+
+options:
+  analysis-options:
+    max-entrypoint-context-size: 5

--- a/analysis/taint/testdata/closures_paper/config.yaml
+++ b/analysis/taint/testdata/closures_paper/config.yaml
@@ -1,6 +1,6 @@
 # The package regex matches all possible ways the package name might appear depending on how the program is loaded
 taint-tracking-problems:
-  -
+  - tag: "taint1"
     sources:
       - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Sources can be source1, source2, etc.
@@ -12,7 +12,7 @@ taint-tracking-problems:
 
 # Same as sinks
 slicing-problems:
-  -
+  - tag: "slicing1"
     backtracepoints:
       - package: "(closures_paper)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
         # Similarly, sinks are sink1 sink2 sink2 ...

--- a/analysis/taint/testdata/defers/config.yaml
+++ b/analysis/taint/testdata/defers/config.yaml
@@ -1,11 +1,12 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(defers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(defers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(defers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(defers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"

--- a/analysis/taint/testdata/escape-integration/config.yaml
+++ b/analysis/taint/testdata/escape-integration/config.yaml
@@ -1,14 +1,15 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(escape-integration)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(escape-integration)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(escape-integration)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(escape-integration)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
 
 options:
     use-escape-analysis: true

--- a/analysis/taint/testdata/example0/config.yaml
+++ b/analysis/taint/testdata/example0/config.yaml
@@ -1,13 +1,14 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: (main|command-line-arguments|example0)
-        field: Source
-      - package: "(example0)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(example0)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: (main|command-line-arguments|example0)
+          field: Source
+        - package: "(example0)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(example0)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"

--- a/analysis/taint/testdata/example1/config.yaml
+++ b/analysis/taint/testdata/example1/config.yaml
@@ -1,12 +1,13 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(main)|(command-line-arguments)|(example1)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(main)|(command-line-arguments)|(example1)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(main)|(command-line-arguments)|(example1)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(main)|(command-line-arguments)|(example1)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
 

--- a/analysis/taint/testdata/example2/config.yaml
+++ b/analysis/taint/testdata/example2/config.yaml
@@ -1,12 +1,13 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    fail-on-implicit-flow: false
-    sources:
-      - package: "(example2)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(example2)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      fail-on-implicit-flow: false
+      sources:
+        - package: "(example2)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(example2)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"

--- a/analysis/taint/testdata/fields/config.yaml
+++ b/analysis/taint/testdata/fields/config.yaml
@@ -1,16 +1,15 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: (fields)|(main|command-line-arguments)
-        field: Source
-      - package: "(fields)|(main)|(command-line-arguments)"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(fields)|(main)|(command-line-arguments)"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-
-options:
-   field-sensitive: true
+dataflow-problems:
+  field-sensitive: true
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: (fields)|(main|command-line-arguments)
+          field: Source
+        - package: "(fields)|(main)|(command-line-arguments)"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(fields)|(main)|(command-line-arguments)"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"

--- a/analysis/taint/testdata/fields/config.yaml
+++ b/analysis/taint/testdata/fields/config.yaml
@@ -1,5 +1,6 @@
 dataflow-problems:
-  field-sensitive: true
+  field-sensitive-funcs:
+    - ".*"
   # The package regex matches all possible ways the package name might appear depending on how the program is loaded
   taint-tracking:
     -

--- a/analysis/taint/testdata/filters/config.yaml
+++ b/analysis/taint/testdata/filters/config.yaml
@@ -1,18 +1,19 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(filters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(filters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    sanitizers:
-      - package: "(filters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(filters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(filters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
           # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sanitize[1-9]?"
-    filters:
-      - type: "error$" # the $ is important to match only exactly the type
-      - type: "bool$"
+          method: "sink[1-9]?"
+      sanitizers:
+        - package: "(filters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+            # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sanitize[1-9]?"
+      filters:
+        - type: "error$" # the $ is important to match only exactly the type
+        - type: "bool$"

--- a/analysis/taint/testdata/fromlevee/config.yaml
+++ b/analysis/taint/testdata/fromlevee/config.yaml
@@ -1,9 +1,10 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(.*)core"
-        method: "Source[1-9]?"
-    sinks:
-      - package: "(.*)core"
-        method: "Sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(.*)core"
+          method: "Source[1-9]?"
+      sinks:
+        - package: "(.*)core"
+          method: "Sink[1-9]?"

--- a/analysis/taint/testdata/globals/config.yaml
+++ b/analysis/taint/testdata/globals/config.yaml
@@ -1,9 +1,11 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(globals)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - method: "sink[1-9]?"
+
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(globals)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - method: "sink[1-9]?"

--- a/analysis/taint/testdata/implicit-flow/config.yaml
+++ b/analysis/taint/testdata/implicit-flow/config.yaml
@@ -1,10 +1,11 @@
-taint-tracking-problems:
-  - # The package regex matches all possible ways the package name might appear depending on how the program is loaded
-    sources:
-      - package: "(implicit-flow)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(implicit-flow)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+dataflow-problems:
+  taint-tracking:
+    - # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+      sources:
+        - package: "(implicit-flow)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(implicit-flow)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"

--- a/analysis/taint/testdata/interface-summaries/config.yaml
+++ b/analysis/taint/testdata/interface-summaries/config.yaml
@@ -1,19 +1,20 @@
 options:
     pkg-filter: "command-line-arguments"
 
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(interface-summaries)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(interface-summaries)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    fail-on-implicit-flow: false
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(interface-summaries)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(interface-summaries)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      fail-on-implicit-flow: false
 
-dataflow-specs:
-  - "dataflows.json"
-  - "dataflows2.json"
+  user-specs:
+    - "dataflows.json"
+    - "dataflows2.json"

--- a/analysis/taint/testdata/interfaces/config.yaml
+++ b/analysis/taint/testdata/interfaces/config.yaml
@@ -1,14 +1,13 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(interfaces)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(interfaces)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-
-options:
-    field-sensitive: true
+dataflow-problems:
+  field-sensitive: true
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(interfaces)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(interfaces)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"

--- a/analysis/taint/testdata/interfaces/config.yaml
+++ b/analysis/taint/testdata/interfaces/config.yaml
@@ -1,5 +1,6 @@
 dataflow-problems:
-  field-sensitive: true
+  field-sensitive-funcs:
+    - ".*"
   # The package regex matches all possible ways the package name might appear depending on how the program is loaded
   taint-tracking:
     -

--- a/analysis/taint/testdata/intra-procedural/config.yaml
+++ b/analysis/taint/testdata/intra-procedural/config.yaml
@@ -13,6 +13,4 @@ dataflow-problems:
           method: sink[1-9]
       fail-on-implicit-flow: false
 
-options:
-    skip-interprocedural: false
 

--- a/analysis/taint/testdata/intra-procedural/config.yaml
+++ b/analysis/taint/testdata/intra-procedural/config.yaml
@@ -1,5 +1,6 @@
 dataflow-problems:
-  field-sensitive: true
+  field-sensitive-funcs:
+    - ".*"
   taint-tracking:
     -
       sources:

--- a/analysis/taint/testdata/intra-procedural/config.yaml
+++ b/analysis/taint/testdata/intra-procedural/config.yaml
@@ -1,15 +1,17 @@
-taint-tracking-problems:
-  -
-    sources:
-      - package: fmt
-        method: Sprintf
-      - package: "(intra-procedural)|(main)|(command-line-arguments)"
-        method: zoo
-    sinks:
-      - package: "(intra-procedural)|(main)|(command-line-arguments)"
-        method: sink[1-9]
-    fail-on-implicit-flow: false
+dataflow-problems:
+  field-sensitive: true
+  taint-tracking:
+    -
+      sources:
+        - package: fmt
+          method: Sprintf
+        - package: "(intra-procedural)|(main)|(command-line-arguments)"
+          method: zoo
+      sinks:
+        - package: "(intra-procedural)|(main)|(command-line-arguments)"
+          method: sink[1-9]
+      fail-on-implicit-flow: false
 
 options:
     skip-interprocedural: false
-    field-sensitive: true
+

--- a/analysis/taint/testdata/panics/config.yaml
+++ b/analysis/taint/testdata/panics/config.yaml
@@ -1,9 +1,10 @@
-taint-tracking-problems:
-  -
-    sources:
-      - method: "source"
-        package: "(panics)|(main|command-line-arguments)"
-    sinks:
-      - package: "(panics)|(main|command-line-arguments)"
-        method: "sink"
-    fail-on-implicit-flow: true
+dataflow-problems:
+  taint-tracking:
+    -
+      sources:
+        - method: "source"
+          package: "(panics)|(main|command-line-arguments)"
+      sinks:
+        - package: "(panics)|(main|command-line-arguments)"
+          method: "sink"
+      fail-on-implicit-flow: true

--- a/analysis/taint/testdata/parameters/config.yaml
+++ b/analysis/taint/testdata/parameters/config.yaml
@@ -1,23 +1,23 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(parameters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-
-        # Reading field token from struct A is a source.
-      - type: "A"
-        field: "token"
-    sinks:
-      - package: "(parameters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-      - method: "Start"
-    fail-on-implicit-flow: false
-options:
+dataflow-problems:
   # Treat those a field-sensitive
   field-sensitive-funcs: [
-      "readToken",
-      "testReadFieldTaint"
+    "readToken",
+    "testReadFieldTaint"
   ]
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(parameters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+
+          # Reading field token from struct A is a source.
+        - type: "A"
+          field: "token"
+      sinks:
+        - package: "(parameters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+        - method: "Start"
+      fail-on-implicit-flow: false

--- a/analysis/taint/testdata/playground/config.yaml
+++ b/analysis/taint/testdata/playground/config.yaml
@@ -1,5 +1,6 @@
 dataflow-problems:
-  field-sensitive: true
+  field-sensitive-funcs:
+    - ".*"
   summarize-on-demand: true
   # The package regex matches all possible ways the package name might appear depending on how the program is loaded
   taint-tracking:

--- a/analysis/taint/testdata/playground/config.yaml
+++ b/analysis/taint/testdata/playground/config.yaml
@@ -1,17 +1,18 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(playground)|(main)|(command-line-arguments)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(playground)|(main)|(command-line-arguments)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    fail-on-implicit-flow: true
+dataflow-problems:
+  field-sensitive: true
+  summarize-on-demand: true
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(playground)|(main)|(command-line-arguments)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(playground)|(main)|(command-line-arguments)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      fail-on-implicit-flow: true
 
 options:
     use-escape-analysis: false
-    field-sensitive: true
-    summarize-on-demand: true

--- a/analysis/taint/testdata/sample-escape/config.yaml
+++ b/analysis/taint/testdata/sample-escape/config.yaml
@@ -1,15 +1,16 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    fail-on-implicit-flow: true
-options:
-    report-paths: true
-    use-escape-analysis: true
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      fail-on-implicit-flow: true
+  options:
+      report-paths: true
+      use-escape-analysis: true

--- a/analysis/taint/testdata/sanitizers/config.yaml
+++ b/analysis/taint/testdata/sanitizers/config.yaml
@@ -1,18 +1,18 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(sanitizers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "(source[1-9])"
-      - package: "(sanitizers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        field: "Source[1-9]?"
-    sinks:
-      - package: "(sanitizers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: ".*(s|S)ink[1-9]"
-    sanitizers:
-      - package: "(sanitizers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        method: ".*(s|S)anitize[1-9]?"
-options:
+dataflow-problems:
   field-sensitive: true
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(sanitizers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "(source[1-9])"
+        - package: "(sanitizers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          field: "Source[1-9]?"
+      sinks:
+        - package: "(sanitizers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: ".*(s|S)ink[1-9]"
+      sanitizers:
+        - package: "(sanitizers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          method: ".*(s|S)anitize[1-9]?"

--- a/analysis/taint/testdata/sanitizers/config.yaml
+++ b/analysis/taint/testdata/sanitizers/config.yaml
@@ -1,5 +1,6 @@
 dataflow-problems:
-  field-sensitive: true
+  field-sensitive-funcs:
+    - ".*"
   # The package regex matches all possible ways the package name might appear depending on how the program is loaded
   taint-tracking:
     -

--- a/analysis/taint/testdata/selects/config.yaml
+++ b/analysis/taint/testdata/selects/config.yaml
@@ -1,10 +1,11 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(selects)|(main)|(command-line-arguments)|(selects-test[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - method: "sink[1-9]?"
-    fail-on-implicit-flow: true
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(selects)|(main)|(command-line-arguments)|(selects-test[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - method: "sink[1-9]?"
+      fail-on-implicit-flow: true

--- a/analysis/taint/testdata/stdlib-no-effect-constraint/config.yaml
+++ b/analysis/taint/testdata/stdlib-no-effect-constraint/config.yaml
@@ -1,17 +1,18 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: ".*((s|S)ource[1-9])"
-    sinks:
-      - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: ".*(s|S)ink[1-9]"
-    sanitizers:
-      - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        method: ".*(s|S)anitize[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: ".*((s|S)ource[1-9])"
+      sinks:
+        - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: ".*(s|S)ink[1-9]"
+      sanitizers:
+        - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          method: ".*(s|S)anitize[1-9]?"
 pointer-config:
   unsafe-no-effect-functions:
     - "fmt.Errorf"

--- a/analysis/taint/testdata/stdlib/config.yaml
+++ b/analysis/taint/testdata/stdlib/config.yaml
@@ -1,14 +1,15 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: ".*((s|S)ource[1-9])"
-    sinks:
-      - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: ".*(s|S)ink[1-9]"
-    sanitizers:
-      - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        method: ".*(s|S)anitize[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: ".*((s|S)ource[1-9])"
+      sinks:
+        - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: ".*(s|S)ink[1-9]"
+      sanitizers:
+        - package: "(stdlib)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          method: ".*(s|S)anitize[1-9]?"

--- a/analysis/taint/testdata/stdlib_121/config.yaml
+++ b/analysis/taint/testdata/stdlib_121/config.yaml
@@ -1,15 +1,16 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(stdlib_121)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: ".*((s|S)ource[1-9])"
-    sinks:
-      - package: "(stdlib_121)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: ".*(s|S)ink[1-9]"
-    sanitizers:
-      - package: "(stdlib_121)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        method: ".*(s|S)anitize[1-9]?"
-    fail-on-implicit-flow: false
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(stdlib_121)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: ".*((s|S)ource[1-9])"
+      sinks:
+        - package: "(stdlib_121)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: ".*(s|S)ink[1-9]"
+      sanitizers:
+        - package: "(stdlib_121)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          method: ".*(s|S)anitize[1-9]?"
+      fail-on-implicit-flow: false

--- a/analysis/taint/testdata/tuples/config.yaml
+++ b/analysis/taint/testdata/tuples/config.yaml
@@ -1,11 +1,12 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(tuples)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(tuples)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(tuples)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(tuples)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"

--- a/analysis/taint/testdata/validators/config.yaml
+++ b/analysis/taint/testdata/validators/config.yaml
@@ -1,19 +1,18 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(validators)|(main)|(command-line-arguments)$"
-        # Sources can be source1, source2, etc.
-        method: "(source[1-9])"
-      - package: "(validators)|(main)|(command-line-arguments)$"
-        field: "Source[1-9]?"
-    sinks:
-      - package: "(validators)|(main)|(command-line-arguments)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: ".*(s|S)ink[1-9]"
-    validators:
-      - package: "(validators)|(main)|(command-line-arguments)$"
-        method: ".*Validate[1-9]?"
-
-options:
-    field-sensitive: true
+dataflow-problems:
+  field-sensitive: true
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(validators)|(main)|(command-line-arguments)$"
+          # Sources can be source1, source2, etc.
+          method: "(source[1-9])"
+        - package: "(validators)|(main)|(command-line-arguments)$"
+          field: "Source[1-9]?"
+      sinks:
+        - package: "(validators)|(main)|(command-line-arguments)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: ".*(s|S)ink[1-9]"
+      validators:
+        - package: "(validators)|(main)|(command-line-arguments)$"
+          method: ".*Validate[1-9]?"

--- a/analysis/taint/testdata/validators/config.yaml
+++ b/analysis/taint/testdata/validators/config.yaml
@@ -1,5 +1,6 @@
 dataflow-problems:
-  field-sensitive: true
+  field-sensitive-funcs:
+    - ".*"
   # The package regex matches all possible ways the package name might appear depending on how the program is loaded
   taint-tracking:
     -

--- a/analysis/taint/testdata/with-context/config.yaml
+++ b/analysis/taint/testdata/with-context/config.yaml
@@ -1,13 +1,14 @@
-# The package regex matches all possible ways the package name might appear depending on how the program is loaded
-taint-tracking-problems:
-  -
-    sources:
-      - package: "(with-context)|(main)|(command-line-arguments)|(example1)$"
-        context: "fetchAndPut" # only match the call in test2
-        # Sources can be source1, source2, etc.
-        method: "source[1-9]?"
-    sinks:
-      - package: "(with-context)|(main)|(command-line-arguments)|(example1)$"
-        # Similarly, sinks are sink1 sink2 sink2 ...
-        method: "sink[1-9]?"
-    fail-on-implicit-flow: false
+dataflow-problems:
+  # The package regex matches all possible ways the package name might appear depending on how the program is loaded
+  taint-tracking:
+    -
+      sources:
+        - package: "(with-context)|(main)|(command-line-arguments)|(example1)$"
+          context: "fetchAndPut" # only match the call in test2
+          # Sources can be source1, source2, etc.
+          method: "source[1-9]?"
+      sinks:
+        - package: "(with-context)|(main)|(command-line-arguments)|(example1)$"
+          # Similarly, sinks are sink1 sink2 sink2 ...
+          method: "sink[1-9]?"
+      fail-on-implicit-flow: false

--- a/analysis/testdata/state_load_config.yaml
+++ b/analysis/testdata/state_load_config.yaml
@@ -1,0 +1,8 @@
+options:
+  log-level: 4
+  # the root of the project
+  project-root: "../../../"
+
+dataflow-problems:
+  user-specs:
+    - "analysis/config/testdata/sample-spec.json"

--- a/analysis/version.go
+++ b/analysis/version.go
@@ -15,4 +15,4 @@
 package analysis
 
 // Version is the last tagged version of the analysis tool
-const Version = "v0.2.2"
+const Version = "v0.3.0"

--- a/cmd/argot/cli/dataflowreachability.go
+++ b/cmd/argot/cli/dataflowreachability.go
@@ -54,9 +54,11 @@ func cmdTrace(tt *term.Terminal, c *dataflow.AnalyzerState, command Command, _ b
 	if command.Flags["t"] {
 		c.Logger.Level = config.TraceLevel
 	}
-	dummySpec := &config.TaintSpec{}
-	c.FlowGraph.RunVisitorOnEntryPoints(taint.NewVisitor(dummySpec), nil,
-		func(g dataflow.GraphNode) bool { return r.MatchString(g.LongID()) })
+	dummyTaintSpec := &config.TaintSpec{}
+	scanningSpec := dataflow.ScanningSpec{
+		IsEntryPointGraph: func(g dataflow.GraphNode) bool { return r.MatchString(g.LongID()) },
+	}
+	c.FlowGraph.RunVisitorOnEntryPoints(taint.NewVisitor(dummyTaintSpec), scanningSpec)
 
 	c.Logger.Level = preLevel
 	return false

--- a/doc/00_intro.md
+++ b/doc/00_intro.md
@@ -48,7 +48,6 @@ Some common optional fields across tools are:
 options:
   log-level: 4                         # sets the output of the tool to debug (default is 3 for info)
   pkg-filter: "some-package/.*"        # filter which packages should be analyzed  (a regex matching package name)
-  skip-interprocedural: true            # skip the interprocedural pass if the tool has one (default is false)
   coverage-filter: "other-package/.*"  # filter for which files to report coverage (a regex matching file paths)
   reports-dir: "some-dir"              # where to store reports
   report-coverage: true                # whether to report coverage, if the analysis supports it (default false)

--- a/doc/01_taint.md
+++ b/doc/01_taint.md
@@ -43,11 +43,12 @@ In this configuration file, the user is trying to detect whether data coming fro
 
 > 📝 Note that all strings in the `package` and `method` fields are parsed as regexes; for example, to match `Sanitizer` precisely, one should write `"^Sanitizer$"`; the `"Sanitizer"` specification will match any function name containing `Sanitizer`.
 
-An advanced feature of the taint analysis lets you specify dataflow summaries yourself:
+An advanced feature of the taint analysis lets you specify dataflow summaries yourself for the dataflow problems:
 ```yaml
-dataflow-specs:                  # A list of dataflow
-  # specifications, where each element is a json file containing
-    - "specs-mylib.json"        # dataflow specifications.
+dataflow-problems:
+    user-specs:                  # A list of dataflow
+      # specifications, where each element is a json file containing
+        - "specs-mylib.json"        # dataflow specifications.
 ```
 We explain in more detail how to write [dataflow specifications](#dataflow-specifications) later, and why the user should write dataflow specifications in some cases.
 
@@ -61,10 +62,11 @@ options:
   # that have been discovered will be printed in individual files
   # in the reports directory
 ```
-And some other options:
+And some other options specific to a taint analysis problem:
 ```yaml
-options:
-  source-taints-args: false  # by default, the result of a call to
+dataflow-problems:
+  taint-tracking:
+    - source-taints-args: false  # by default, the result of a call to
     # a source function is tainted. In some cases a user might want
     # to consider all arguments of a source function to be tainted
 ```

--- a/doc/01_taint.md
+++ b/doc/01_taint.md
@@ -209,7 +209,7 @@ You can also set it for a specific analysis problem:
 ```yaml
 dataflow-problems:
   taint-tracking:
-    - analysis-options:
+    - override-analysis-options:
         unsafe-max-depth: 6
       tag: "foo"
       filters:

--- a/doc/01_taint.md
+++ b/doc/01_taint.md
@@ -421,9 +421,13 @@ If the analysis was field-sensitive, it would not raise an alarm.
 Field sensitivity can be turned on for dataflow problems with the option:
 ```yaml
 dataflow-problems:
-  field-sensitive: true
+  field-sensitive-funcs: 
+    - "interestingFunctionsRegex"
 ```
-Which turns on field-sensitivity for all. This will increase analysis time, but eliminate some false positive. 
+Which turns on field-sensitivity for all functions  names matching `interestingFunctionsRegex`. 
+This will increase analysis time, but eliminate some false positive.
+You can turn on field sensitivity by just using the pattern `.*`.
+
 
 ### Tuple Sensitivity
 

--- a/doc/02_backtrace.md
+++ b/doc/02_backtrace.md
@@ -24,7 +24,7 @@ In this configuration file, the user is trying to detect all the possible traces
 
 An advanced feature of the backtrace analysis is that you can specify dataflow summaries yourself:
 ```yaml
-options:
+dataflow-problems:
   dataflow-specs:                  # A list of dataflow specifications, where each element is a json file containing
     - "specs-mylib.json"        # dataflow specifications.
 

--- a/payload/selfcheck/config.yaml
+++ b/payload/selfcheck/config.yaml
@@ -1,11 +1,12 @@
 options:
   log-level: 3
-  max-alarms: 10
-  unsafe-max-depth: 6
   reports-dir: "payload/selfcheck/taint-report"
-  max-entrypoint-context-size: 2
   summarize-on-demand: true
   report-paths: true
+  analysis-options:
+    max-alarms: 10
+    unsafe-max-depth: 6
+    max-entrypoint-context-size: 2
   field-sensitive-funcs:
     - "AnalyzerState"
 

--- a/payload/selfcheck/config.yaml
+++ b/payload/selfcheck/config.yaml
@@ -1,5 +1,6 @@
 options:
   log-level: 3
+  project-root: "../../"
   reports-dir: "payload/selfcheck/taint-report"
   report-paths: true
   analysis-options:
@@ -11,8 +12,8 @@ options:
 dataflow-problems:
   summarize-on-demand: true
   user-specs:
-    - "argot-specs.json"
-    - "std-specs.json"
+    - "payload/selfcheck/argot-specs.json"
+    - "payload/selfcheck/std-specs.json"
   field-sensitive-funcs:
     - "AnalyzerState"
   taint-tracking:

--- a/payload/selfcheck/config.yaml
+++ b/payload/selfcheck/config.yaml
@@ -1,45 +1,44 @@
 options:
   log-level: 3
   reports-dir: "payload/selfcheck/taint-report"
-  summarize-on-demand: true
   report-paths: true
   analysis-options:
     max-alarms: 10
     unsafe-max-depth: 6
     max-entrypoint-context-size: 2
-  field-sensitive-funcs:
-    - "AnalyzerState"
-
-dataflow-specs:
-  - "argot-specs.json"
-  - "std-specs.json"
 
 # Define the analysis problems
-
-taint-tracking-problems:
-  # Tracking the data that flows from the client code being analyzed to location where we might log strings from
-  # that code. For example, if a (*ssa.Function).String() is logged in a log.Warnf call.
-  # Data should be Sanitized using the formatutil.Santitize function.
-  - sources:
-      - package: "ssa"
-        method: "String" # any String method from the ssa package, includes function.String etc.
-        context: "ar-go-tools" # Only sources in our code, i.e. in ar-go-tools
-    sinks:
-      - context: "ar-go-tools"
-        package: "fmt"
-        value-match: ".*%s.*" # we only care about string formats. %q is fine to use
-        method: "((Printf)|(Fprintf))"
-      - package: "config"
-        value-match: ".*%s.*" # we only care about string formats. %q is fine to use
-        method: "((Warnf)|(Debugf)|(Infof)|(Errorf))" # the logging functions in our implementation
-    sanitizers:
-      - package: "formatutil"
-        method: "Sanitize"
-    filters:
-      - type: "LogGroup" # log group cannot be really tainted by the data, but taint tracking will mark it
-      # because formatters are deemed tainted by their arguments. This is a very restrictive assumption.
-      - type: "io.Writer"
-      - type: "^int$" # not enough data in an int to do terminal injection
-      - type: "^bool$" # same for bool
-      - type: "^float" # same for floats
+dataflow-problems:
+  summarize-on-demand: true
+  user-specs:
+    - "argot-specs.json"
+    - "std-specs.json"
+  field-sensitive-funcs:
+    - "AnalyzerState"
+  taint-tracking:
+    # Tracking the data that flows from the client code being analyzed to location where we might log strings from
+    # that code. For example, if a (*ssa.Function).String() is logged in a log.Warnf call.
+    # Data should be Sanitized using the formatutil.Santitize function.
+    - sources:
+        - package: "ssa"
+          method: "String" # any String method from the ssa package, includes function.String etc.
+          context: "ar-go-tools" # Only sources in our code, i.e. in ar-go-tools
+      sinks:
+        - context: "ar-go-tools"
+          package: "fmt"
+          value-match: ".*%s.*" # we only care about string formats. %q is fine to use
+          method: "((Printf)|(Fprintf))"
+        - package: "config"
+          value-match: ".*%s.*" # we only care about string formats. %q is fine to use
+          method: "((Warnf)|(Debugf)|(Infof)|(Errorf))" # the logging functions in our implementation
+      sanitizers:
+        - package: "formatutil"
+          method: "Sanitize"
+      filters:
+        - type: "LogGroup" # log group cannot be really tainted by the data, but taint tracking will mark it
+        # because formatters are deemed tainted by their arguments. This is a very restrictive assumption.
+        - type: "io.Writer"
+        - type: "^int$" # not enough data in an int to do terminal injection
+        - type: "^bool$" # same for bool
+        - type: "^float" # same for floats
 


### PR DESCRIPTION
This PR refactors the config and adds new options:
- dataflow problems are grouped under `dataflow-problems` with `taint-tracking` and `slicing` listing the respective dataflow problems. Dataflow specific options are specified under `dataflow-problems`, such as `summarize-on-demand`, `field-sensitive-funcs`, `field-sensitive` and `user-specs` (which were dataflow-specs). 
- a new option `project-root` specifies which directory all the the paths in the config are relative to.
- added `severity` and `description` fields in dataflow problems. 
- groups some analysis options that can be overriden per-problem (`max-alarms`) into a subset `analysis-options`.