### PR TITLE
Analysis targets

### DIFF
--- a/analysis/backtrace/backtrace_taint_test.go
+++ b/analysis/backtrace/backtrace_taint_test.go
@@ -107,7 +107,11 @@ func runBacktraceTest(t *testing.T, test testDef, isOnDemand bool) {
 	}
 	cfg.SlicingProblems = []config.SlicingSpec{{BacktracePoints: cfg.TaintTrackingProblems[0].Sinks}}
 	log := config.NewLogGroup(cfg)
-	res, err := backtrace.Analyze(log, cfg, program, lp.Pkgs)
+	state, err := dataflow.NewInitializedAnalyzerState(program, lp.Pkgs, log, cfg)
+	if err != nil {
+		t.Fatalf("failed to load state: %s", err)
+	}
+	res, err := backtrace.Analyze(state)
 	if err != nil {
 		t.Fatalf("failed to run analysis: %v", err)
 	}

--- a/analysis/backtrace/backtrace_test.go
+++ b/analysis/backtrace/backtrace_test.go
@@ -69,7 +69,11 @@ var ignoreMatch = match{-1, nil, -1}
 
 func testAnalyze(t *testing.T, lp analysistest.LoadedTestProgram) {
 	lg := config.NewLogGroup(lp.Config)
-	res, err := backtrace.Analyze(lg, lp.Config, lp.Prog, lp.Pkgs)
+	state, err := dataflow.NewInitializedAnalyzerState(lp.Prog, lp.Pkgs, lg, lp.Config)
+	if err != nil {
+		t.Fatalf("failed to load state: %s", err)
+	}
+	res, err := backtrace.Analyze(state)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -377,7 +381,11 @@ func TestAnalyze_Closures_OnDemand(t *testing.T) {
 func testAnalyzeClosures(t *testing.T, lp analysistest.LoadedTestProgram) {
 	lp.Config.LogLevel = int(config.InfoLevel) // increasing to level > InfoLevel throws off IDE
 	lg := config.NewLogGroup(lp.Config)
-	res, err := backtrace.Analyze(lg, lp.Config, lp.Prog, lp.Pkgs)
+	state, err := dataflow.NewInitializedAnalyzerState(lp.Prog, lp.Pkgs, lg, lp.Config)
+	if err != nil {
+		t.Fatalf("failed to load state: %s", err)
+	}
+	res, err := backtrace.Analyze(state)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/analysis/config/config.go
+++ b/analysis/config/config.go
@@ -130,6 +130,9 @@ type Config struct {
 
 	// DataflowProblems specifies the dataflow problems to solve in the config
 	DataflowProblems `yaml:"dataflow-problems" json:"dataflow-problems"`
+
+	// Targets specifies the set of targets that may be used in the config
+	Targets []TargetSpec
 }
 
 // AnalysisProblemOptions are the options that are specific to an analysis problem.
@@ -185,6 +188,7 @@ type SyntacticSpecs struct {
 
 // StructInitSpec contains specs for the problem of tracking a specific struct initialization.
 type StructInitSpec struct {
+	Targets []string
 	// Struct is the struct type whose initialization should be tracked.
 	Struct CodeIdentifier
 	// FieldsSet is the list of the fields of Struct that must always be set to a specific value.
@@ -201,6 +205,15 @@ type FieldsSetSpec struct {
 	// Value is the value that Field must always be set to.
 	// We only support static values for now (e.g., constants and static functions).
 	Value CodeIdentifier
+}
+
+// A TargetSpec is a set of files the form a Go program together with a name to identify the target in the configuration
+// file.
+type TargetSpec struct {
+	// Name identifies the target in the rest of the configuration file
+	Name string
+	// Files identifies the target's files
+	Files []string
 }
 
 // Options holds the global options for analyses

--- a/analysis/config/config.go
+++ b/analysis/config/config.go
@@ -578,6 +578,15 @@ func (c Config) ExceedsMaxDepth(d int) bool {
 	return !(c.UnsafeMaxDepth <= 0) && d > c.UnsafeMaxDepth
 }
 
+// GetTargetMap returns a map from target names to target files
+func (c Config) GetTargetMap() map[string][]string {
+	targets := map[string][]string{}
+	for _, targetSpec := range c.Targets {
+		targets[targetSpec.Name] = targetSpec.Files
+	}
+	return targets
+}
+
 // SetOption sets config option value using a string name for the option and a string value.
 // Returns the value (as a string) of the previous setting, or an error.
 // Settings that can be set using this function:

--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -200,7 +200,7 @@ func TestLoadWithUndefinedTargetReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error when loading config with undefined target")
 	}
-	if !strings.Contains(err.Error(), "taint analysis target foo is undefined") {
+	if !strings.Contains(err.Error(), "taint analysis target \"foo\" is undefined") {
 		t.Errorf("config with undefined target should have explicit error message")
 	}
 }

--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -195,6 +195,16 @@ func TestLoadWithProjectRoot(t *testing.T) {
 	}
 }
 
+func TestLoadWithUndefinedTargetReturnsError(t *testing.T) {
+	_, _, err := loadFromTestDir("config_undefined_target.yaml")
+	if err == nil {
+		t.Fatalf("expected error when loading config with undefined target")
+	}
+	if !strings.Contains(err.Error(), "taint analysis target foo is undefined") {
+		t.Errorf("config with undefined target should have explicit error message")
+	}
+}
+
 func TestLoadVersionBefore_v0_3_0_Errors(t *testing.T) {
 	_, config, err := loadFromTestDir("config_before_v0_3_0.yaml")
 	if config != nil || err == nil {

--- a/analysis/config/dataflow_config.go
+++ b/analysis/config/dataflow_config.go
@@ -14,7 +14,14 @@
 
 package config
 
-import "regexp"
+import (
+	"regexp"
+
+	funcs "github.com/awslabs/ar-go-tools/internal/funcutil"
+)
+
+// TargetsAll is the universal target
+const TargetsAll = "all"
 
 // DataflowProblems defines all the dataflow (taint, slicing) problems in a config file.
 type DataflowProblems struct {
@@ -67,6 +74,9 @@ type TaintSpec struct {
 	// Description allows the user to add a description to the problem
 	Description string
 
+	// Targets identifies the names of the targets this analysis must run against
+	Targets []string
+
 	// FailOnImplicitFlow indicates whether the taint analysis should fail when tainted data implicitly changes
 	// the control flow of a program. This should be set to false when proving a data flow property,
 	// and set to true when proving an information flow property.
@@ -99,6 +109,9 @@ type SlicingSpec struct {
 
 	// Description allows the user to add a description to the problem
 	Description string
+
+	// Targets identifies the names of the targets this analysis must run against
+	Targets []string
 
 	// SkipBoundLabels indicates whether to skip flows that go through "bound labels", i.e. aliases of the variables
 	// bound by a closure. This can be useful to test data flows because bound labels generate a lot of false positives.
@@ -189,4 +202,10 @@ func (scs StaticCommandsSpec) IsStaticCommand(cid CodeIdentifier) bool {
 // IsBacktracePoint returns true if the code identifier matches a backtrace point according to the SlicingSpec
 func (ss SlicingSpec) IsBacktracePoint(cid CodeIdentifier) bool {
 	return ExistsCid(ss.BacktracePoints, cid.equalOnNonEmptyFields)
+}
+
+// TargetIncludes returns true if the list of targets includes the targets or has the "all" target, or the target
+// is empty (the program is passed through the command line)
+func TargetIncludes(targets []string, sub string) bool {
+	return sub == "" || funcs.Contains(targets, TargetsAll) || funcs.Contains(targets, sub)
 }

--- a/analysis/config/testdata/config_undefined_target.yaml
+++ b/analysis/config/testdata/config_undefined_target.yaml
@@ -54,32 +54,13 @@ options:
     max-entrypoint-context-size: 20
 
 targets:
-  - name: "foo"
-    files: [ "cmd/main.go", "cmd/foo.go"]
   - name: "bar"
     files: [ "test/main.go", "test/bar.go" ]
 
-# Configuration elements specific to the pointer analysis
-pointer-config:
-  reflection: true
-  unsafe-no-effect-functions:
-    - "fmt.Errorf"
-    - "fmt.Printf"
-
 # All the dataflow problems and the dataflow-specific problems
 dataflow-problems:
-  # this can be set to use only on-demand summarization
-  summarize-on-demand: true
-  # This setting sets all functions to be analyzed with field sensitivity
-  field-sensitive-funcs:
-    - ".*"
-  # For any dataflow analysis, you can specify summaries for specific functions and interfaces. The analysis will
-  # use each of those files as a reference for the functions specified
-  user-specs:
-    - "example.json"
-    - "example2.json"
 
-# The slicing/backwards dataflow problems
+  # The slicing/backwards dataflow problems
   slicing:
     - tag: "slicing-problem-1"
       description: "A slicing problem"

--- a/analysis/config/testdata/full-config.json
+++ b/analysis/config/testdata/full-config.json
@@ -16,6 +16,22 @@
       "max-entrypoint-context-size": 20
     }
   },
+  "targets": [
+    {
+      "name": "foo",
+      "files": [
+        "cmd/main.go",
+        "cmd/foo.go"
+      ]
+    },
+    {
+      "name": "bar",
+      "files": [
+        "test/main.go",
+        "test/bar.go"
+      ]
+    }
+  ],
   "pointer-config": {
     "reflection": true,
     "unsafe-no-effect-functions": [
@@ -28,12 +44,17 @@
       "example.json",
       "example2.json"
     ],
-    "field-sensitive-funcs": [".*"],
+    "field-sensitive-funcs": [
+      ".*"
+    ],
     "summarize-on-demand": true,
     "slicing": [
       {
         "tag": "slicing-problem-1",
         "description": "A slicing problem",
+        "targets": [
+          "all"
+        ],
         "backtracepoints": [
           {
             "method": "Foo",
@@ -47,6 +68,10 @@
         "tag": "taint-tracking-problem-1",
         "description": "A taint tracking problem.",
         "source-taints-args": true,
+        "targets": [
+          "foo",
+          "bar"
+        ],
         "validators": [
           {
             "method": "Validate",

--- a/analysis/config/validation.go
+++ b/analysis/config/validation.go
@@ -78,14 +78,14 @@ func (c Config) checkTargetsUniqueAndDefined() error {
 	for _, trackingProblem := range c.TaintTrackingProblems {
 		for _, problemTarget := range trackingProblem.Targets {
 			if !isDefined(problemTarget) {
-				return fmt.Errorf("taint analysis target %s is undefined", problemTarget)
+				return fmt.Errorf("taint analysis target \"%s\" is undefined", problemTarget)
 			}
 		}
 	}
 	for _, slicingProblem := range c.SlicingProblems {
 		for _, problemTarget := range slicingProblem.Targets {
 			if !isDefined(problemTarget) {
-				return fmt.Errorf("backwards dataflow analysis target %s is undefined", problemTarget)
+				return fmt.Errorf("backwards dataflow analysis target \"%s\" is undefined", problemTarget)
 			}
 		}
 	}
@@ -93,7 +93,7 @@ func (c Config) checkTargetsUniqueAndDefined() error {
 		for _, structInitProblem := range sp.StructInitProblems {
 			for _, problemTarget := range structInitProblem.Targets {
 				if !isDefined(problemTarget) {
-					return fmt.Errorf("syntactic analysis target %s is undefined", problemTarget)
+					return fmt.Errorf("syntactic analysis target \"%s\" is undefined", problemTarget)
 				}
 			}
 		}

--- a/analysis/dataflow/state.go
+++ b/analysis/dataflow/state.go
@@ -36,6 +36,9 @@ import (
 // AnalyzerState holds information that might need to be used during program analysis, and represents the state of
 // the analyzer. Different steps of the analysis will populate the fields of this structure.
 type AnalyzerState struct {
+	// Target identifies the target this state corresponds to
+	Target string
+
 	// Annotations contains all the annotations of the program
 	Annotations annotations.ProgramAnnotations
 

--- a/analysis/taint/taint_utils_test.go
+++ b/analysis/taint/taint_utils_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/ar-go-tools/analysis/config"
+	"github.com/awslabs/ar-go-tools/analysis/dataflow"
 	"github.com/awslabs/ar-go-tools/analysis/taint"
 	"github.com/awslabs/ar-go-tools/internal/analysistest"
 	"golang.org/x/tools/go/ssa"
@@ -277,7 +278,11 @@ func runTestWithoutCheck(t *testing.T, dirName string, files []string, summarize
 		t.Fatalf("failed to load test: %v", err)
 	}
 	setupConfig(lp.Config, summarizeOnDemand)
-	result, err := taint.Analyze(lp.Config, lp.Prog, lp.Pkgs)
+	state, err := dataflow.NewInitializedAnalyzerState(lp.Prog, lp.Pkgs, config.NewLogGroup(lp.Config), lp.Config)
+	if err != nil {
+		t.Fatalf("failed to initialize state")
+	}
+	result, err := taint.Analyze(state)
 	if err != nil {
 		// t.Logf("taint analysis failed: %v", err) // use for debugging: sometimes errors are expected
 		if result.State != nil {

--- a/cmd/argot/backtrace/backtrace.go
+++ b/cmd/argot/backtrace/backtrace.go
@@ -25,6 +25,7 @@ import (
 	"github.com/awslabs/ar-go-tools/analysis"
 	"github.com/awslabs/ar-go-tools/analysis/backtrace"
 	"github.com/awslabs/ar-go-tools/analysis/config"
+	df "github.com/awslabs/ar-go-tools/analysis/dataflow"
 	"github.com/awslabs/ar-go-tools/cmd/argot/tools"
 	"github.com/awslabs/ar-go-tools/internal/formatutil"
 	"golang.org/x/tools/go/ssa"
@@ -63,7 +64,12 @@ func Run(flags tools.CommonFlags) error {
 	}
 
 	start := time.Now()
-	result, err := backtrace.Analyze(config.NewLogGroup(cfg), cfg, program, pkgs)
+	cfgLog := config.NewLogGroup(cfg)
+	state, err := df.NewInitializedAnalyzerState(program, pkgs, cfgLog, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to load state: %s", err)
+	}
+	result, err := backtrace.Analyze(state)
 	if err != nil {
 		return fmt.Errorf("analysis failed: %v", err)
 	}

--- a/cmd/argot/taint/taint.go
+++ b/cmd/argot/taint/taint.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/awslabs/ar-go-tools/analysis"
 	"github.com/awslabs/ar-go-tools/analysis/config"
+	"github.com/awslabs/ar-go-tools/analysis/dataflow"
 	"github.com/awslabs/ar-go-tools/analysis/taint"
 	"github.com/awslabs/ar-go-tools/cmd/argot/tools"
 	"github.com/awslabs/ar-go-tools/internal/formatutil"
@@ -112,7 +113,12 @@ func Run(flags Flags) error {
 
 	// Starting the analysis
 	start := time.Now()
-	result, err := taint.Analyze(taintConfig, program, pkgs)
+	cfgLog := config.NewLogGroup(taintConfig)
+	state, err := dataflow.NewInitializedAnalyzerState(program, pkgs, cfgLog, taintConfig)
+	if err != nil {
+		return fmt.Errorf("failed to load state: %s", err)
+	}
+	result, err := taint.Analyze(state)
 	duration := time.Since(start)
 	if err != nil {
 		if result.State != nil {

--- a/cmd/argot/tools/tools.go
+++ b/cmd/argot/tools/tools.go
@@ -121,3 +121,35 @@ func LoadConfig(configPath string) (*config.Config, error) {
 
 	return cfg, nil
 }
+
+// GetTargets returns the map from target names to target files that are in the config or the arguments
+// and are used by the tool.
+//
+// When args is not empty, only the target "" -> args is returned.
+// When the tool name is not recognized, all the targets in the config file are returned.
+func GetTargets(args []string, c *config.Config, tool string) map[string][]string {
+	if len(args) > 0 {
+		return map[string][]string{"": args}
+	}
+	allTargets := c.GetTargetMap()
+	switch tool {
+	case "taint":
+		taintTargets := map[string][]string{}
+		for _, ttp := range c.TaintTrackingProblems {
+			for _, target := range ttp.Targets {
+				taintTargets[target] = allTargets[target]
+			}
+		}
+		return taintTargets
+	case "backtrace":
+		backtraceTargets := map[string][]string{}
+		for _, ttp := range c.SlicingProblems {
+			for _, target := range ttp.Targets {
+				backtraceTargets[target] = allTargets[target]
+			}
+		}
+		return backtraceTargets
+	default:
+		return allTargets
+	}
+}

--- a/doc/00_intro.md
+++ b/doc/00_intro.md
@@ -35,7 +35,7 @@ The following tools are included in Argot:
 - the `render` tool can be used to render various representations of the code, such as its [Static Single Assignment](https://en.wikipedia.org/wiki/Static_single-assignment_form) (SSA) form or its callgraph (see [Render Tool](10_render.md#render-tool)).
 - the `racerg` tool, an experimental tool for data race detection (See [RacerG](11_racerg.md#racerg-sound-and-scalable-static-data-race-detector-for-go)).
 
-These tools can be used by developers to better understand their code, through the analysis of higher-level representations. For example, one can understand how the code is organized by looking at the callgraph, which abstract away the code and retains only the caller/callee information. In general, we do not state guarantees about the correctness of these tools, except for the dataflow analyses (see [taint analysis](01_taint.md#taint-analysis) and [backtrace](02_backtrace.md#backtrace-analysis))). However, we believe the representations obtained for each of these tools are useful enough to aid programmers.
+These tools can be used by developers to better understand their code, through the analysis of higher-level representations. For example, one can understand how the code is organized by looking at the callgraph, which abstract away the code and retains only the caller/callee information. In general, we do not state guarantees about the correctness of these tools, except for the dataflow analyses (see [taint analysis](01_taint.md#taint-analysis) and [backtrace](02_backtrace.md#backtrace-analysis)). However, we believe the representations obtained for each of these tools are useful enough to aid programmers.
 
 ### Configuration
 
@@ -54,3 +54,30 @@ options:
 ```
 
 > 📝 The tool accepts five different settings for the logging level: 1 for error logging, 2 for warnings, 3 for info, 4 for debugging information and 5 for tracing. Tracing should not be used on large programs.
+
+
+### Targets
+
+The `taint` and `backtrace` tools of Argot support running against specific targets that can be defined in the config file (as opposed to passed in the command line).
+
+The targets are defined in `targets`, and each target must have a `name` and a set of `files`. The file paths are taken relatively to the directory where the config file is by default, or relatively to the project root when the `option` `project-root` is defined. 
+For example, we can define two targets in the following config file:
+```yaml
+options:
+  project-root: "../"
+targets:
+  - name: "target1"
+    files:
+      - "cmd/target1/main.go"
+  - name: "target2"
+    files:
+      - "cmd/target2/main.go"
+
+```
+This assumes the config file is in a directory next to the `cmd` directory that contains all the executables of the project.
+Analysis problems that can use specific targets will have a `targets: ["target1", "target2"]` option for example. Then each tool can be run with a single argument, the config file.The `"all"` target is a special target that means the problem applies to every target.
+
+If some file paths are specified on the command line, the targets are ignored: all the analysis problems for the tool being called are run against the target provided on the command line.
+
+
+> See for example the config file `payload/selfcheck/config.yaml` which is an example of using the targets to run both taint and backtrace analyses.

--- a/internal/funcutil/collections.go
+++ b/internal/funcutil/collections.go
@@ -162,8 +162,8 @@ func Contains[T comparable](a []T, x T) bool {
 
 // Set takes an array of elements and returns a set of those elements, represented as a map from
 // elements to empty struct
-func Set[T comparable](a []T) map[T]any {
-	set := map[T]any{}
+func Set[T comparable](a []T) map[T]struct{} {
+	set := map[T]struct{}{}
 	for _, x := range a {
 		set[x] = struct{}{}
 	}

--- a/internal/funcutil/collections.go
+++ b/internal/funcutil/collections.go
@@ -160,6 +160,16 @@ func Contains[T comparable](a []T, x T) bool {
 	return Exists(a, func(y T) bool { return x == y })
 }
 
+// Set takes an array of elements and returns a set of those elements, represented as a map from
+// elements to empty struct
+func Set[T comparable](a []T) map[T]any {
+	set := map[T]any{}
+	for _, x := range a {
+		set[x] = struct{}{}
+	}
+	return set
+}
+
 // SetToOrderedSlice converts a set represented as a map from elements to booleans into a slice.
 // Sorts the result in increasing order
 func SetToOrderedSlice[T constraints.Ordered](set map[T]bool) []T {

--- a/payload/selfcheck/config.yaml
+++ b/payload/selfcheck/config.yaml
@@ -8,6 +8,14 @@ options:
     unsafe-max-depth: 6
     max-entrypoint-context-size: 2
 
+targets:
+  - name: "argot"
+    files:
+      - "cmd/argot/main.go"
+  - name: "racerg"
+    files:
+      - "cmd/racerg/main.go"
+
 # Define the analysis problems
 dataflow-problems:
   summarize-on-demand: true
@@ -20,7 +28,9 @@ dataflow-problems:
     # Tracking the data that flows from the client code being analyzed to location where we might log strings from
     # that code. For example, if a (*ssa.Function).String() is logged in a log.Warnf call.
     # Data should be Sanitized using the formatutil.Santitize function.
-    - sources:
+    - tag: "source-formats"
+      targets: [ "argot" ]
+      sources:
         - package: "ssa"
           method: "String" # any String method from the ssa package, includes function.String etc.
           context: "ar-go-tools" # Only sources in our code, i.e. in ar-go-tools
@@ -42,4 +52,14 @@ dataflow-problems:
         - type: "^int$" # not enough data in an int to do terminal injection
         - type: "^bool$" # same for bool
         - type: "^float" # same for floats
+  slicing:
+    # Check that the arguments of MustCompile are regexes defined entirely statically (i.e. all data flowing to the
+    # arguments of MustCompile comes from constants).
+    # Run me with: argot backtrace -config path-to-this-file
+    - tag: "compile-static-regex"
+      description: "Checking that MustCompile is used only with static strings."
+      targets: [ "argot", "racerg" ]
+      backtracepoints:
+        - package: "^regexp$"
+          method: "^MustCompile$"
 

--- a/payload/selfcheck/config.yaml
+++ b/payload/selfcheck/config.yaml
@@ -53,9 +53,12 @@ dataflow-problems:
         - type: "^bool$" # same for bool
         - type: "^float" # same for floats
   slicing:
-    # Check that the arguments of MustCompile are regexes defined entirely statically (i.e. all data flowing to the
-    # arguments of MustCompile comes from constants).
+    # Trace the source of the arguments of MustCompile; all data flowing to the arguments of MustCompile
+    # must come from constants.
     # Run me with: argot backtrace -config path-to-this-file
+    # The tool does not automatically check the origin but only traces the sources; for now, the property
+    # can be checked by verifying (manually) that every trace originates from constants. There are very
+    # few traces in this example.
     - tag: "compile-static-regex"
       description: "Checking that MustCompile is used only with static strings."
       targets: [ "argot", "racerg" ]


### PR DESCRIPTION
This PR introduces analysis targets: the target programs for the `taint` and `backtrace` tools can be defined in the config file. 
See for example the config file in `payload/selfcheck/config.yaml`. Two targets `argot` and `racerg` are defined in the `targets:` top-level option, and then the `targets` option in each analysis subproblem specifies which program that analysis applies to.

Additional work needs to be done to improve the reporting when multiple targets are analyzed.