### PR TITLE
Json reports for taint and backtrace

### DIFF
--- a/analysis/backtrace/backtrace.go
+++ b/analysis/backtrace/backtrace.go
@@ -21,7 +21,6 @@ package backtrace
 import (
 	"errors"
 	"fmt"
-	"go/token"
 	"runtime"
 	"strings"
 
@@ -42,73 +41,6 @@ type AnalysisResult struct {
 
 	// Traces represents all the paths where data flows out from the analysis entry points.
 	Traces map[df.GraphNode][]Trace
-}
-
-// Trace represents a dataflow path (sequence of nodes) out of an analysis
-// entrypoint.
-//
-// The first node in the trace is the origin of the data flow.
-//
-// The last node in the trace is an argument to the backtrace entrypoint function
-// defined in the config.
-type Trace []TraceNode
-
-func (t Trace) String() string {
-	if len(t) == 0 {
-		return "<empty trace>"
-	}
-
-	first := fmt.Sprintf("%v from %v:\n", formatutil.Bold("Trace"), t[0].String())
-	var rest []TraceNode
-	if len(t) > 1 {
-		rest = t[1:]
-	}
-
-	b := &strings.Builder{}
-	if _, err := b.WriteString(first); err != nil {
-		panic(fmt.Errorf("failed to write first node to trace string: %v", err))
-	}
-	for i, tn := range rest {
-		if _, err := b.WriteString("\t"); err != nil {
-			panic(fmt.Errorf("failed to write to trace string: %v", err))
-		}
-		if _, err := b.WriteString(tn.String()); err != nil {
-			panic(fmt.Errorf("failed to write trace node %v to string: %v", tn, err))
-		}
-
-		if i == len(rest)-1 {
-			continue
-		}
-		if _, err := b.WriteString("\n"); err != nil {
-			panic(fmt.Errorf("failed to write to trace string: %v", err))
-		}
-	}
-
-	return b.String()
-}
-
-// Key generates a unique key for trace t.
-func (t Trace) Key() df.KeyType {
-	keys := make([]string, 0, len(t))
-	for _, node := range t {
-		keys = append(keys, node.LongID())
-	}
-
-	return strings.Join(keys, "_")
-}
-
-// TraceNode represents a node in the trace.
-type TraceNode struct {
-	df.GraphNode
-	Pos token.Position
-}
-
-func (n TraceNode) String() string {
-	if n.GraphNode == nil {
-		return ""
-	}
-
-	return fmt.Sprintf("%v at %v", n.GraphNode.String(), n.Pos)
 }
 
 // Analyze runs the analysis on the program prog with the user-provided configuration config.
@@ -173,6 +105,16 @@ func Analyze(state *df.AnalyzerState) (AnalysisResult, error) {
 				}
 				if len(vTrace) > 0 {
 					resTraces[entry] = append(resTraces[entry], vTrace)
+					state.Report.AddEntry(
+						state.Logger,
+						state.Config,
+						config.ReportDesc{
+							Tool:     "backtrace",
+							Tag:      ps.Tag,
+							Severity: ps.Severity,
+							Content:  report(state, entry, vTrace, &ps),
+						},
+					)
 				}
 			}
 		}

--- a/analysis/backtrace/backtrace.go
+++ b/analysis/backtrace/backtrace.go
@@ -109,7 +109,7 @@ func Analyze(state *df.AnalyzerState) (AnalysisResult, error) {
 						state.Logger,
 						state.Config,
 						config.ReportDesc{
-							Tool:     "backtrace",
+							Tool:     config.BacktraceTool,
 							Tag:      ps.Tag,
 							Severity: ps.Severity,
 							Content:  report(state, entry, vTrace, &ps),

--- a/analysis/backtrace/report.go
+++ b/analysis/backtrace/report.go
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backtrace
+
+import (
+	"github.com/awslabs/ar-go-tools/analysis/config"
+	"github.com/awslabs/ar-go-tools/analysis/dataflow"
+	"github.com/awslabs/ar-go-tools/internal/funcutil"
+)
+
+// A FlowReport contains the information we serialize about a taint flow: a tag, the source and the sink, and
+// the trace from source to sink.
+type FlowReport struct {
+	Tag   string
+	Entry dataflow.ReportNodeInfo
+	Trace []dataflow.ReportNodeInfo
+}
+
+// report generates a json report for a specific data flow
+func report(s *dataflow.AnalyzerState,
+	entry dataflow.GraphNode,
+	trace Trace,
+	ss *config.SlicingSpec) FlowReport {
+	entryNode := dataflow.GetReportNodeInfo(dataflow.NodeWithTrace{Node: entry}, s)
+
+	reportTrace := funcutil.Map(trace,
+		func(x TraceNode) dataflow.ReportNodeInfo {
+			return dataflow.GetReportNodeInfo(dataflow.NodeWithTrace{Node: x.GraphNode}, s)
+		})
+
+	return FlowReport{
+		Tag:   ss.Tag,
+		Entry: entryNode,
+		Trace: reportTrace,
+	}
+}

--- a/analysis/backtrace/trace.go
+++ b/analysis/backtrace/trace.go
@@ -1,0 +1,91 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backtrace
+
+import (
+	"fmt"
+	"go/token"
+	"strings"
+
+	df "github.com/awslabs/ar-go-tools/analysis/dataflow"
+	"github.com/awslabs/ar-go-tools/internal/formatutil"
+)
+
+// Trace represents a dataflow path (sequence of nodes) out of an analysis
+// entrypoint.
+//
+// The first node in the trace is the origin of the data flow.
+//
+// The last node in the trace is an argument to the backtrace entrypoint function
+// defined in the config.
+type Trace []TraceNode
+
+func (t Trace) String() string {
+	if len(t) == 0 {
+		return "<empty trace>"
+	}
+
+	first := fmt.Sprintf("%v from %v:\n", formatutil.Bold("Trace"), t[0].String())
+	var rest []TraceNode
+	if len(t) > 1 {
+		rest = t[1:]
+	}
+
+	b := &strings.Builder{}
+	if _, err := b.WriteString(first); err != nil {
+		panic(fmt.Errorf("failed to write first node to trace string: %v", err))
+	}
+	for i, tn := range rest {
+		if _, err := b.WriteString("\t"); err != nil {
+			panic(fmt.Errorf("failed to write to trace string: %v", err))
+		}
+		if _, err := b.WriteString(tn.String()); err != nil {
+			panic(fmt.Errorf("failed to write trace node %v to string: %v", tn, err))
+		}
+
+		if i == len(rest)-1 {
+			continue
+		}
+		if _, err := b.WriteString("\n"); err != nil {
+			panic(fmt.Errorf("failed to write to trace string: %v", err))
+		}
+	}
+
+	return b.String()
+}
+
+// Key generates a unique key for trace t.
+func (t Trace) Key() df.KeyType {
+	keys := make([]string, 0, len(t))
+	for _, node := range t {
+		keys = append(keys, node.LongID())
+	}
+
+	return strings.Join(keys, "_")
+}
+
+// TraceNode represents a node in the trace.
+type TraceNode struct {
+	df.GraphNode
+	Pos token.Position
+}
+
+func (n TraceNode) String() string {
+	if n.GraphNode == nil {
+		return ""
+	}
+
+	return fmt.Sprintf("%v at %v", n.GraphNode.String(), n.Pos)
+}

--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -363,6 +363,9 @@ func TestLoadFullConfigYaml(t *testing.T) {
 	if config.TaintTrackingProblems[0].UnsafeMaxDepth != 1 {
 		t.Error("analysis option unsafe-max-depth should be 1 for taint-tracking-problem")
 	}
+	if config.TaintTrackingProblems[0].Severity != High {
+		t.Error("taint-tracking-problem severity should be HIGH")
+	}
 	if !config.TaintTrackingProblems[0].SourceTaintsArgs {
 		t.Error("analysis option source-taints-args should be true for taint-tracking-problem")
 	}

--- a/analysis/config/dataflow_config.go
+++ b/analysis/config/dataflow_config.go
@@ -69,7 +69,7 @@ type TaintSpec struct {
 	Tag string
 
 	// Severity assigns a severity to this problem
-	Severity string
+	Severity Severity
 
 	// Description allows the user to add a description to the problem
 	Description string
@@ -105,7 +105,7 @@ type SlicingSpec struct {
 	Tag string
 
 	// Severity assigns a severity to this problem
-	Severity string
+	Severity Severity
 
 	// Description allows the user to add a description to the problem
 	Description string

--- a/analysis/config/report.go
+++ b/analysis/config/report.go
@@ -1,0 +1,154 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/awslabs/ar-go-tools/internal/formatutil"
+)
+
+// ReportInfo contains the information in the main report of argot
+type ReportInfo struct {
+	CountBySeverity map[Severity]int
+
+	// Reports groups entries by tag
+	Reports map[string]ReportGroup
+}
+
+// A ReportGroup lists the report contents in each details file
+type ReportGroup struct {
+	Tool     string
+	Severity Severity
+	Details  []string
+}
+
+// ReportEntry is one entry in the report, with high-level information about the severity and what tool
+// generated it. Contents of the report should be stored in a separate content file.
+type ReportEntry struct {
+	Tool        string
+	ContentFile string
+	Severity    Severity
+}
+
+// A ReportDesc gathers content and metadata about a specific report entry.
+type ReportDesc struct {
+	Tool     string
+	Tag      string
+	Severity Severity
+	Content  any
+}
+
+// NewReport returns a new ReportInfo with initialized maps
+func NewReport() ReportInfo {
+	return ReportInfo{
+		CountBySeverity: map[Severity]int{},
+		Reports:         map[string]ReportGroup{},
+	}
+}
+
+// Merge merges the report elements of other into the receiver
+func (r *ReportInfo) Merge(other *ReportInfo) {
+	for sev, count := range other.CountBySeverity {
+		r.IncrementSevCount(sev, count)
+	}
+	for tag, reportGroup := range other.Reports {
+		if thisReportGroup, ok := r.Reports[tag]; ok {
+			thisReportGroup.Details = append(thisReportGroup.Details, r.Reports[tag].Details...)
+		} else {
+			r.Reports[tag] = reportGroup
+		}
+	}
+}
+
+// IncrementSevCount increments the count of the provided severity label
+func (r *ReportInfo) IncrementSevCount(sev Severity, count int) {
+	if prev, ok := r.CountBySeverity[sev]; ok {
+		r.CountBySeverity[sev] = prev + count
+	} else {
+		r.CountBySeverity[sev] = count
+	}
+}
+
+func (r *ReportInfo) addEntry(tag string, entry ReportEntry) {
+	if _, tagPresent := r.Reports[tag]; !tagPresent {
+		r.Reports[tag] = ReportGroup{
+			Tool:     entry.Tool,
+			Severity: entry.Severity,
+			Details:  []string{entry.ContentFile},
+		}
+		return
+	}
+	group := r.Reports[tag]
+	newDetails := append(group.Details, entry.ContentFile)
+	r.Reports[tag] = ReportGroup{
+		Tool:     entry.Tool,
+		Severity: entry.Severity,
+		Details:  newDetails,
+	}
+}
+
+// AddEntry write the information in the ReportDesc to a new file in the ReportsDir, and adds a new entry into the
+// receiver.
+func (r *ReportInfo) AddEntry(logger *LogGroup, c *Config, report ReportDesc) {
+	r.IncrementSevCount(report.Severity, 1)
+	logger.Debugf("Write report for tool=%s, tag=%s, severity=%s", report.Tool, report.Tag, report.Severity)
+	tmp, err := os.CreateTemp(c.ReportsDir, report.Tag+"-report-*.json")
+	if err != nil {
+		logger.Errorf("Could not write report for %s (severity %s)", report.Tag, report.Severity)
+		return
+	}
+	defer tmp.Close()
+	logger.Infof("Report in %s\n", formatutil.Sanitize(tmp.Name()))
+
+	content, err := json.MarshalIndent(report.Content, "", "  ")
+	if err != nil {
+		logger.Errorf("Error serlializing report: %s", err)
+	}
+	_, err = tmp.Write(content)
+	logger.Infof("Write report for tool=%s, tag=%s, severity=%s in %s",
+		report.Tool, report.Tag, report.Severity, tmp.Name())
+	if err != nil {
+		logger.Errorf("Error writing report: %s", err)
+	}
+
+	r.addEntry(report.Tag, ReportEntry{
+		Tool:        report.Tool,
+		ContentFile: tmp.Name(),
+		Severity:    report.Severity,
+	})
+}
+
+// Dump writes a new report file in the ReportsDir of the config file.
+func (r *ReportInfo) Dump(logger *LogGroup, c *Config) {
+	tmp, err := os.CreateTemp(c.ReportsDir, "overall-report-*.json")
+	if err != nil {
+		logger.Errorf("Could not write final report")
+		return
+	}
+	defer tmp.Close()
+	payload, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		// This should not happen, there is no reason it should fail to marshal a simple struct of strings and lists
+		// of strings
+		panic("Failed to marshal report summary")
+	}
+	_, err = tmp.Write(payload)
+	if err != nil {
+		logger.Errorf("Failed to write report, consult logs.")
+	}
+	logger.Infof("Wrote final report in %s", tmp.Name())
+}

--- a/analysis/config/report.go
+++ b/analysis/config/report.go
@@ -31,7 +31,7 @@ type ReportInfo struct {
 
 // A ReportGroup lists the report contents in each details file
 type ReportGroup struct {
-	Tool     string
+	Tool     ToolName
 	Severity Severity
 	Details  []string
 }
@@ -39,14 +39,14 @@ type ReportGroup struct {
 // ReportEntry is one entry in the report, with high-level information about the severity and what tool
 // generated it. Contents of the report should be stored in a separate content file.
 type ReportEntry struct {
-	Tool        string
+	Tool        ToolName
 	ContentFile string
 	Severity    Severity
 }
 
 // A ReportDesc gathers content and metadata about a specific report entry.
 type ReportDesc struct {
-	Tool     string
+	Tool     ToolName
 	Tag      string
 	Severity Severity
 	Content  any
@@ -116,7 +116,7 @@ func (r *ReportInfo) AddEntry(logger *LogGroup, c *Config, report ReportDesc) {
 
 	content, err := json.MarshalIndent(report.Content, "", "  ")
 	if err != nil {
-		logger.Errorf("Error serlializing report: %s", err)
+		logger.Errorf("Error serializing report: %s", err)
 	}
 	_, err = tmp.Write(content)
 	logger.Infof("Write report for tool=%s, tag=%s, severity=%s in %s",
@@ -136,7 +136,7 @@ func (r *ReportInfo) AddEntry(logger *LogGroup, c *Config, report ReportDesc) {
 func (r *ReportInfo) Dump(logger *LogGroup, c *Config) {
 	tmp, err := os.CreateTemp(c.ReportsDir, "overall-report-*.json")
 	if err != nil {
-		logger.Errorf("Could not write final report")
+		logger.Errorf("Could not write final report: %s.", err)
 		return
 	}
 	defer tmp.Close()
@@ -148,7 +148,7 @@ func (r *ReportInfo) Dump(logger *LogGroup, c *Config) {
 	}
 	_, err = tmp.Write(payload)
 	if err != nil {
-		logger.Errorf("Failed to write report, consult logs.")
+		logger.Errorf("Failed to write report: %s. Please consult logs.", err)
 	}
 	logger.Infof("Wrote final report in %s", tmp.Name())
 }

--- a/analysis/config/severity.go
+++ b/analysis/config/severity.go
@@ -14,7 +14,9 @@
 
 package config
 
-import "github.com/awslabs/ar-go-tools/internal/funcutil"
+import (
+	"github.com/awslabs/ar-go-tools/internal/funcutil"
+)
 
 // Severity is the severity label of an analysis problem
 type Severity string
@@ -48,7 +50,6 @@ func FromString(s string) funcutil.Optional[Severity] {
 	return funcutil.None[Severity]()
 }
 
-// ToString converts the severity to a string type
-func (s Severity) ToString() string {
+func (s Severity) String() string {
 	return string(s)
 }

--- a/analysis/config/severity.go
+++ b/analysis/config/severity.go
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "github.com/awslabs/ar-go-tools/internal/funcutil"
+
+// Severity is the severity label of an analysis problem
+type Severity string
+
+const (
+	// Critical severity: often triggers early failure in analyses
+	Critical Severity = "CRITICAL"
+	// High severity
+	High Severity = "HIGH"
+	// Medium severity problems
+	Medium Severity = "MEDIUM"
+	// Low severity problems
+	Low Severity = "LOW"
+)
+
+// IsValidSeverityStr returns true is the string s is a valid severity strings
+func IsValidSeverityStr(s string) bool {
+	switch s {
+	case "", "CRITICAL", "HIGH", "MEDIUM", "LOW":
+		return true
+	default:
+		return false
+	}
+}
+
+// FromString returns some severity when the string is a valid severity, otherwise none
+func FromString(s string) funcutil.Optional[Severity] {
+	if IsValidSeverityStr(s) {
+		return funcutil.Some(Severity(s))
+	}
+	return funcutil.None[Severity]()
+}
+
+// ToString converts the severity to a string type
+func (s Severity) ToString() string {
+	return string(s)
+}

--- a/analysis/config/testdata/full-config.json
+++ b/analysis/config/testdata/full-config.json
@@ -67,6 +67,7 @@
       {
         "tag": "taint-tracking-problem-1",
         "description": "A taint tracking problem.",
+        "severity": "HIGH",
         "source-taints-args": true,
         "targets": [
           "foo",

--- a/analysis/config/testdata/full-config.yaml
+++ b/analysis/config/testdata/full-config.yaml
@@ -92,6 +92,7 @@ dataflow-problems:
   # The taint tracking problems
   taint-tracking:
     - tag: "taint-tracking-problem-1"
+      severity: "HIGH"
       description: "A taint tracking problem."
       targets: ["foo", "bar"]
       # this can be set so that source function are also tainting their arguments

--- a/analysis/config/tool_names.go
+++ b/analysis/config/tool_names.go
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// ToolName is the type of tool names
+type ToolName string
+
+const (
+	// BacktraceTool name
+	BacktraceTool ToolName = "backtrace"
+	// CliTool name
+	CliTool ToolName = "cli"
+	// CompareTool name
+	CompareTool ToolName = "compare"
+	// DeferTool name
+	DeferTool ToolName = "defer"
+	// DependenciesTool name
+	DependenciesTool ToolName = "dependencies"
+	// MayPanicTool name
+	MayPanicTool ToolName = "maypanic"
+	// PackageScanTool name
+	PackageScanTool ToolName = "packagescan"
+	// ReachabilityTool name
+	ReachabilityTool ToolName = "reachability"
+	// RenderTool name
+	RenderTool ToolName = "render"
+	// SsaStatisticsTool name
+	SsaStatisticsTool ToolName = "ssa-statistics"
+	// SyntacticTool name
+	SyntacticTool ToolName = "syntactic"
+	// TaintTool name
+	TaintTool ToolName = "taint"
+)

--- a/analysis/config/validation.go
+++ b/analysis/config/validation.go
@@ -54,10 +54,10 @@ func (c Config) checkTagsAreUnique() error {
 }
 
 func (c Config) checkSeveritiesAreValid() error {
-	sevList := funcutil.Map(c.TaintTrackingProblems, func(ts TaintSpec) string { return ts.Severity })
-	sevList = append(sevList, funcutil.Map(c.SlicingProblems, func(ts SlicingSpec) string { return ts.Severity })...)
+	sevList := funcutil.Map(c.TaintTrackingProblems, func(ts TaintSpec) Severity { return ts.Severity })
+	sevList = append(sevList, funcutil.Map(c.SlicingProblems, func(ts SlicingSpec) Severity { return ts.Severity })...)
 	for _, sev := range sevList {
-		if !isValidSeverity(sev) {
+		if !IsValidSeverityStr(sev.ToString()) {
 			return fmt.Errorf(
 				"invalid severity label %s (not empty, \"CRITICAL\", \"HIGH\", \"MEDIUM\", or \"LOW\")",
 				sev)
@@ -99,13 +99,4 @@ func (c Config) checkTargetsUniqueAndDefined() error {
 		}
 	}
 	return nil
-}
-
-func isValidSeverity(s string) bool {
-	switch s {
-	case "", "CRITICAL", "HIGH", "MEDIUM", "LOW":
-		return true
-	default:
-		return false
-	}
 }

--- a/analysis/config/validation.go
+++ b/analysis/config/validation.go
@@ -57,7 +57,7 @@ func (c Config) checkSeveritiesAreValid() error {
 	sevList := funcutil.Map(c.TaintTrackingProblems, func(ts TaintSpec) Severity { return ts.Severity })
 	sevList = append(sevList, funcutil.Map(c.SlicingProblems, func(ts SlicingSpec) Severity { return ts.Severity })...)
 	for _, sev := range sevList {
-		if !IsValidSeverityStr(sev.ToString()) {
+		if !IsValidSeverityStr(sev.String()) {
 			return fmt.Errorf(
 				"invalid severity label %s (not empty, \"CRITICAL\", \"HIGH\", \"MEDIUM\", or \"LOW\")",
 				sev)

--- a/analysis/dataflow/function_summary_graph_nodes.go
+++ b/analysis/dataflow/function_summary_graph_nodes.go
@@ -148,11 +148,49 @@ func NodeKind(g GraphNode) string {
 	return ""
 }
 
-// NodeSummary returns a string summary of the node, highlighting with terminal colors
+// NodeSummary returns a string summary of the node, without using any escape codes.
+func NodeSummary(g GraphNode) string {
+	switch x := g.(type) {
+	case *ParamNode:
+		return fmt.Sprintf("Parameter %s (type %s) of %s",
+			x.ssaNode.Name(),
+			x.Type().String(),
+			fmt.Sprintf("%q", x.parent.Parent.Name()))
+	case *CallNode:
+		return fmt.Sprintf("Result of call to %s (type %s)",
+			x.Callee().Name(),
+			x.Type().String())
+	case *CallNodeArg:
+		return fmt.Sprintf("Argument #%d (type %s) in call to %s",
+			x.Index(),
+			x.Type().String(),
+			x.ParentNode().Callee().Name())
+	case *ReturnValNode:
+		return fmt.Sprintf("Return value %d (type %s) of %s",
+			x.Index(),
+			x.Type().String(),
+			x.ParentName())
+	case *ClosureNode:
+		return fmt.Sprintf("Closure")
+	case *BoundLabelNode:
+		return fmt.Sprintf("Bound label of type %s", x.targetInfo.Type().String())
+	case *SyntheticNode:
+		return fmt.Sprintf("Synthetic node")
+	case *BoundVarNode:
+		return "Bound variable"
+	case *FreeVarNode:
+		return fmt.Sprintf("Free variable #%d of %q", x.fvPos, x.ssaNode.Parent().String())
+	case *AccessGlobalNode:
+		return fmt.Sprintf("Global variable %q", x.Global.String())
+	}
+	return ""
+}
+
+// TermNodeSummary returns a string summary of the node, highlighting with terminal colors
 // green indicates a relative index/argument name,
 // magenta is used for function names,
 // italic is used for types.
-func NodeSummary(g GraphNode) string {
+func TermNodeSummary(g GraphNode) string {
 	switch x := g.(type) {
 	case *ParamNode:
 		return fmt.Sprintf("Parameter %s (type %s) of %s",

--- a/analysis/dataflow/report.go
+++ b/analysis/dataflow/report.go
@@ -24,6 +24,24 @@ import (
 	"golang.org/x/tools/go/ssa"
 )
 
+// ReportNodeInfo is the information retained in reports for a dataflow node.
+// A ReportNodeInfo can be serialized on its own.
+type ReportNodeInfo struct {
+	Position    string
+	Context     string
+	Description string
+}
+
+// GetReportNodeInfo converts the information in a NodeWithTrace into a ReportNodeInfo.
+// This involved extracting descriptions for the node, context information and string positions using the state.
+func GetReportNodeInfo(g NodeWithTrace, c *AnalyzerState) ReportNodeInfo {
+	return ReportNodeInfo{
+		Position:    g.Node.Position(c).String(),
+		Context:     FuncNames(g.Trace, false),
+		Description: NodeSummary(g.Node),
+	}
+}
+
 // ReportMissingOrNotConstructedSummary prints a missing summary message to the cache's logger.
 func (s *AnalyzerState) ReportMissingOrNotConstructedSummary(callSite *CallNode) {
 	if !s.Config.Verbose() {

--- a/analysis/dataflow/state.go
+++ b/analysis/dataflow/state.go
@@ -82,6 +82,9 @@ type AnalyzerState struct {
 	// a map
 	BoundingInfo BoundingMap
 
+	// Report contains the accumulated report information
+	Report *config.ReportInfo
+
 	reachableFunctions map[*ssa.Function]bool
 
 	// a callgraph computed using the cha analysis. Useful to boostrap the reachable functions
@@ -148,6 +151,7 @@ func NewAnalyzerState(p *ssa.Program, pkgs []*packages.Package, l *config.LogGro
 	}
 	l.Infof("Loaded %d annotations from program\n", pa.Count())
 
+	report := config.NewReport()
 	// New state with initial cha callgraph
 	state := &AnalyzerState{
 		Annotations:           pa,
@@ -167,6 +171,7 @@ func NewAnalyzerState(p *ssa.Program, pkgs []*packages.Package, l *config.LogGro
 			Globals:       map[*GlobalNode]map[*AccessGlobalNode]bool{},
 			AnalyzerState: nil,
 		},
+		Report:            &report,
 		chaCallgraph:      cha.CallGraph(p),
 		isReachabilityCha: false,
 		errors:            map[string][]error{},
@@ -245,6 +250,7 @@ func (s *AnalyzerState) CopyTo(b *AnalyzerState) {
 	b.PointerAnalysis = s.PointerAnalysis
 	b.errors = s.errors
 	b.Program = s.Program
+	b.Report = s.Report
 	b.keys = s.keys
 	b.reachableFunctions = s.reachableFunctions
 	// copy everything except mutex

--- a/analysis/taint/dataflow_visitor.go
+++ b/analysis/taint/dataflow_visitor.go
@@ -154,12 +154,12 @@ func (v *Visitor) Visit(s *df.AnalyzerState, source df.NodeWithTrace) {
 					cur.Node.Position(s))
 			} else {
 				if v.taints.addNewPathCandidate(NewFlowNode(v.currentSource), NewFlowNode(cur.NodeWithTrace)) {
-					reportTaintFlow(s, v.currentSource, cur)
+					logTaintFlow(s, v.currentSource, cur)
 					s.Report.AddEntry(s.Logger, s.Config, config.ReportDesc{
-						Tool:     "taint",
+						Tool:     config.TaintTool,
 						Tag:      v.taintSpec.Tag,
 						Severity: v.taintSpec.Severity,
-						Content:  report(s, v.currentSource, cur, v.taintSpec),
+						Content:  newFlowReport(s, v.currentSource, cur, v.taintSpec),
 					})
 					if v.taintSpec.Severity == config.Critical {
 						panic(fmt.Sprintf("taint flows to critical location (problem tag %s)", v.taintSpec.Tag))

--- a/analysis/taint/dataflow_visitor.go
+++ b/analysis/taint/dataflow_visitor.go
@@ -155,6 +155,15 @@ func (v *Visitor) Visit(s *df.AnalyzerState, source df.NodeWithTrace) {
 			} else {
 				if v.taints.addNewPathCandidate(NewFlowNode(v.currentSource), NewFlowNode(cur.NodeWithTrace)) {
 					reportTaintFlow(s, v.currentSource, cur)
+					s.Report.AddEntry(s.Logger, s.Config, config.ReportDesc{
+						Tool:     "taint",
+						Tag:      v.taintSpec.Tag,
+						Severity: v.taintSpec.Severity,
+						Content:  report(s, v.currentSource, cur, v.taintSpec),
+					})
+					if v.taintSpec.Severity == config.Critical {
+						panic(fmt.Sprintf("taint flows to critical location (problem tag %s)", v.taintSpec.Tag))
+					}
 				}
 				// Stop if there is a limit on number of alarms, and it has been reached.
 				if !s.IncrementAndTestAlarms() {

--- a/analysis/taint/report.go
+++ b/analysis/taint/report.go
@@ -75,10 +75,8 @@ func reportCoverage(coverage map[string]bool, coverageWriter io.StringWriter) {
 	}
 }
 
-// reportTaintFlow reports a taint flow by writing to a file if the configuration has the ReportPaths flag set,
-// and writing in the logger.
-// The function checks the annotations to suppress reports where there are //argot:ignore annotations.
-func reportTaintFlow(s *dataflow.AnalyzerState, source dataflow.NodeWithTrace, sink *dataflow.VisitorNode) {
+// logTaintFlow logs a taint flow on the state's logger.
+func logTaintFlow(s *dataflow.AnalyzerState, source dataflow.NodeWithTrace, sink *dataflow.VisitorNode) {
 	s.Logger.Infof(" !!!! TAINT FLOW !!!!")
 	s.Logger.Infof(" 💀 Sink reached at %s\n", formatutil.Red(sink.Node.Position(s)))
 	s.Logger.Infof(" Add new path from %s to %s <== \n",
@@ -126,8 +124,8 @@ type FlowReport struct {
 	Trace  []dataflow.ReportNodeInfo
 }
 
-// report generates a json report for a specific taint flow
-func report(s *dataflow.AnalyzerState,
+// newFlowReport generates a FlowReport for a specific taint flow
+func newFlowReport(s *dataflow.AnalyzerState,
 	source dataflow.NodeWithTrace,
 	sink *dataflow.VisitorNode,
 	ts *config.TaintSpec) FlowReport {

--- a/cmd/argot/backtrace/backtrace.go
+++ b/cmd/argot/backtrace/backtrace.go
@@ -49,6 +49,7 @@ func Run(flags tools.CommonFlags) error {
 		cfg.LogLevel = int(config.DebugLevel)
 		cfgLog = config.NewLogGroup(cfg)
 	}
+	overallReport := config.NewReport()
 	for targetName, targetFiles := range tools.GetTargets(flags.FlagSet.Args(), cfg, "backtrace") {
 		cfgLog.Infof("Reading backtrace entrypoints")
 		loadOptions := analysis.LoadProgramOptions{
@@ -73,10 +74,12 @@ func Run(flags tools.CommonFlags) error {
 			return fmt.Errorf("analysis failed: %v", err)
 		}
 		duration := time.Since(start)
+		overallReport.Merge(state.Report)
 		cfgLog.Infof("")
 		cfgLog.Infof("-%s", strings.Repeat("*", 80))
 		cfgLog.Infof("Analysis took %3.4f s\n", duration.Seconds())
 		cfgLog.Infof("Found traces for %d entrypoints\n", len(result.Traces))
 	}
+	overallReport.Dump(cfgLog, cfg)
 	return nil
 }

--- a/cmd/argot/main.go
+++ b/cmd/argot/main.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"github.com/awslabs/ar-go-tools/analysis"
+	"github.com/awslabs/ar-go-tools/analysis/config"
 	"github.com/awslabs/ar-go-tools/cmd/argot/backtrace"
 	"github.com/awslabs/ar-go-tools/cmd/argot/cli"
 	"github.com/awslabs/ar-go-tools/cmd/argot/compare"
@@ -72,22 +73,22 @@ func main() {
 	}
 
 	args := os.Args[2:]
-	switch cmd := os.Args[1]; cmd {
-	case "backtrace":
-		flags, err := tools.NewCommonFlags("backtrace", args, backtrace.Usage)
+	switch cmd := os.Args[1]; config.ToolName(cmd) {
+	case config.BacktraceTool:
+		flags, err := tools.NewCommonFlags(config.BacktraceTool, args, backtrace.Usage)
 		if err != nil {
 			errExit(err)
 		}
 		if err := backtrace.Run(flags); err != nil {
 			errExit(err)
 		}
-	case "cli":
-		flags, err := tools.NewCommonFlags("cli", args, cli.Usage)
+	case config.CliTool:
+		flags, err := tools.NewCommonFlags(config.CliTool, args, cli.Usage)
 		if err != nil {
 			errExit(err)
 		}
 		cli.Run(flags)
-	case "compare":
+	case config.CompareTool:
 		flags, err := compare.NewFlags(args)
 		if err != nil {
 			errExit(err)
@@ -95,15 +96,15 @@ func main() {
 		if err := compare.Run(flags); err != nil {
 			errExit(err)
 		}
-	case "defer":
-		flags, err := tools.NewCommonFlags("defer", args, defers.Usage)
+	case config.DeferTool:
+		flags, err := tools.NewCommonFlags(config.DeferTool, args, defers.Usage)
 		if err != nil {
 			errExit(err)
 		}
 		if err := defers.Run(flags.FlagSet.Args(), flags.Verbose); err != nil {
 			errExit(err)
 		}
-	case "dependencies":
+	case config.DependenciesTool:
 		flags, err := dependencies.NewFlags(args)
 		if err != nil {
 			errExit(err)
@@ -111,14 +112,14 @@ func main() {
 		if err := dependencies.Run(flags); err != nil {
 			errExit(err)
 		}
-	case "maypanic":
+	case config.MayPanicTool:
 		flags, err := maypanic.NewFlags(args)
 		if err != nil {
 			errExit(err)
 		}
 		if err := maypanic.Run(flags); err != nil {
 		}
-	case "packagescan":
+	case config.PackageScanTool:
 		flags, err := packagescan.NewFlags(args)
 		if err != nil {
 			errExit(err)
@@ -126,7 +127,7 @@ func main() {
 		if err := packagescan.Run(flags); err != nil {
 			errExit(err)
 		}
-	case "reachability":
+	case config.ReachabilityTool:
 		flags, err := reachability.NewFlags(args)
 		if err != nil {
 			errExit(err)
@@ -134,7 +135,7 @@ func main() {
 		if err := reachability.Run(flags); err != nil {
 			errExit(err)
 		}
-	case "render":
+	case config.RenderTool:
 		flags, err := render.NewFlags(args)
 		if err != nil {
 			errExit(err)
@@ -142,7 +143,7 @@ func main() {
 		if err := render.Run(flags); err != nil {
 			errExit(err)
 		}
-	case "ssa-statistics":
+	case config.SsaStatisticsTool:
 		flags, err := statistics.NewFlags(args)
 		if err != nil {
 			errExit(err)
@@ -150,15 +151,15 @@ func main() {
 		if err := statistics.Run(flags); err != nil {
 			errExit(err)
 		}
-	case "syntactic":
-		flags, err := tools.NewCommonFlags("syntactic", args, syntactic.Usage)
+	case config.SyntacticTool:
+		flags, err := tools.NewCommonFlags(config.SyntacticTool, args, syntactic.Usage)
 		if err != nil {
 			errExit(err)
 		}
 		if err := syntactic.Run(flags); err != nil {
 			errExit(err)
 		}
-	case "taint":
+	case config.TaintTool:
 		flags, err := taint.NewFlags(args)
 		if err != nil {
 			errExit(err)

--- a/cmd/argot/tools/tools.go
+++ b/cmd/argot/tools/tools.go
@@ -36,8 +36,8 @@ type UnparsedCommonFlags struct {
 // NewUnparsedCommonFlags returns an unparsed flag set with a given name.
 // This is useful for creating sub-commands that have the flags -config,
 // -verbose, -with-test, and -build-tags but need other flags in addition.
-func NewUnparsedCommonFlags(name string) UnparsedCommonFlags {
-	cmd := flag.NewFlagSet(name, flag.ExitOnError)
+func NewUnparsedCommonFlags(name config.ToolName) UnparsedCommonFlags {
+	cmd := flag.NewFlagSet(string(name), flag.ExitOnError)
 	configPath := cmd.String("config", "", "config file path for analysis")
 	verbose := cmd.Bool("verbose", false, "verbose printing on standard output")
 	withTest := cmd.Bool("with-test", false, "load tests during analysis")
@@ -64,7 +64,7 @@ type CommonFlags struct {
 // NewCommonFlags returns a parsed flag set with a given name.
 // Returns an error if args are invalid.
 // Prints cmdUsage along with flag docs as the --help message.
-func NewCommonFlags(name string, args []string, cmdUsage string) (CommonFlags, error) {
+func NewCommonFlags(name config.ToolName, args []string, cmdUsage string) (CommonFlags, error) {
 	flags := NewUnparsedCommonFlags(name)
 	SetUsage(flags.FlagSet, cmdUsage)
 	if err := flags.FlagSet.Parse(args); err != nil {

--- a/payload/selfcheck/config.yaml
+++ b/payload/selfcheck/config.yaml
@@ -1,7 +1,7 @@
 options:
   log-level: 3
   project-root: "../../"
-  reports-dir: "payload/selfcheck/taint-report"
+  reports-dir: "payload/selfcheck/all-report"
   report-paths: true
   analysis-options:
     max-alarms: 10
@@ -30,6 +30,7 @@ dataflow-problems:
     # Data should be Sanitized using the formatutil.Santitize function.
     - tag: "source-formats"
       targets: [ "argot" ]
+      severity: "LOW"
       sources:
         - package: "ssa"
           method: "String" # any String method from the ssa package, includes function.String etc.
@@ -62,6 +63,7 @@ dataflow-problems:
     - tag: "compile-static-regex"
       description: "Checking that MustCompile is used only with static strings."
       targets: [ "argot", "racerg" ]
+      severity: "HIGH"
       backtracepoints:
         - package: "^regexp$"
           method: "^MustCompile$"


### PR DESCRIPTION
This PR adds reporting of traces in json format in the reporting directory. Users can quickly scan the `overall-report-*.json` file to see a map from problem tag to individual reports and a count of findings per severity level.

For example, run:
`argot backtrace -config payload/selfcheck/config.yaml`
or the same command with the `taint` tool.

