### PR TITLE
Using targets and tags in struct init analysis.

### DIFF
--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -200,8 +200,8 @@ func TestLoadWithUndefinedTargetReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error when loading config with undefined target")
 	}
-	if !strings.Contains(err.Error(), "taint analysis target \"foo\" is undefined") {
-		t.Errorf("config with undefined target should have explicit error message")
+	if !strings.Contains(err.Error(), "target \"foo\" for problem with tag") {
+		t.Errorf("config with undefined target should have explicit error message not %s", err)
 	}
 }
 
@@ -282,32 +282,29 @@ func TestLoadSyntacticConfigYaml(t *testing.T) {
 		t.Error("syntactic config should have set silence-warn to true")
 	}
 
-	if len(config.SyntacticProblems) == 0 {
-		t.Error("syntactic config should have syntactic problems")
+	if len(config.SyntacticProblems.StructInitProblems) == 0 {
+		t.Error("syntactic config should have struct-init problems")
 	}
-	for _, spec := range config.SyntacticProblems {
-		if len(spec.StructInitProblems) == 0 {
-			t.Error("syntactic config should have struct-init problems")
+
+	for _, sspec := range config.SyntacticProblems.StructInitProblems {
+		if sspec.Struct.Type == "" {
+			t.Error("syntactic config should have a struct-init struct type")
 		}
-		for _, sspec := range spec.StructInitProblems {
-			if sspec.Struct.Type == "" {
-				t.Error("syntactic config should have a struct-init struct type")
+		if len(sspec.FieldsSet) == 0 {
+			t.Error("syntactic config should have a struct-init fields-set list")
+		}
+		for _, fspec := range sspec.FieldsSet {
+			if fspec.Field == "" {
+				t.Error("syntactic config should have a struct-init fields-set field")
 			}
-			if len(sspec.FieldsSet) == 0 {
-				t.Error("syntactic config should have a struct-init fields-set list")
+			if fspec.Value.Package == "" {
+				t.Error("syntactic config should have a struct-init fields-set value package")
 			}
-			for _, fspec := range sspec.FieldsSet {
-				if fspec.Field == "" {
-					t.Error("syntactic config should have a struct-init fields-set field")
-				}
-				if fspec.Value.Package == "" {
-					t.Error("syntactic config should have a struct-init fields-set value package")
-				}
-				if fspec.Value.Const == "" {
-					t.Error("syntactic config should have a struct-init fields-set value const")
-				}
+			if fspec.Value.Const == "" {
+				t.Error("syntactic config should have a struct-init fields-set value const")
 			}
 		}
+
 	}
 	os.Remove(config.ReportsDir)
 }

--- a/analysis/config/dataflow_config.go
+++ b/analysis/config/dataflow_config.go
@@ -91,6 +91,21 @@ type TaintSpec struct {
 	SourceTaintsArgs bool `xml:"source-taints-args,attr" yaml:"source-taints-args" json:"source-taints-args"`
 }
 
+// SpecTag returns the tag of the taint specification
+func (ts TaintSpec) SpecTag() string {
+	return ts.Tag
+}
+
+// SpecTargets returns the targets of the taint specification
+func (ts TaintSpec) SpecTargets() []string {
+	return ts.Targets
+}
+
+// SpecSeverity returns the severity of the taint specification
+func (ts TaintSpec) SpecSeverity() Severity {
+	return ts.Severity
+}
+
 // SlicingSpec contains code identifiers that identify a specific program slicing / backwards dataflow analysis spec.
 type SlicingSpec struct {
 	*AnalysisProblemOptions `xml:"override-analysis-options,attr" yaml:"override-analysis-options" json:"override-analysis-options"`
@@ -116,6 +131,21 @@ type SlicingSpec struct {
 	// SkipBoundLabels indicates whether to skip flows that go through "bound labels", i.e. aliases of the variables
 	// bound by a closure. This can be useful to test data flows because bound labels generate a lot of false positives.
 	SkipBoundLabels bool `yaml:"unsafe-skip-bound-labels" json:"unsafe-skip-bound-labels"`
+}
+
+// SpecTag returns the tag of the slicing spec
+func (ss SlicingSpec) SpecTag() string {
+	return ss.Tag
+}
+
+// SpecTargets returns the targets of the slicing spec
+func (ss SlicingSpec) SpecTargets() []string {
+	return ss.Targets
+}
+
+// SpecSeverity returns the severity of the slicing spec
+func (ss SlicingSpec) SpecSeverity() Severity {
+	return ss.Severity
 }
 
 // IsPathSensitiveFunc returns true if funcName matches any regex in c.Options.PathSensitiveFuncs.

--- a/analysis/config/report.go
+++ b/analysis/config/report.go
@@ -62,6 +62,9 @@ func NewReport() ReportInfo {
 
 // Merge merges the report elements of other into the receiver
 func (r *ReportInfo) Merge(other *ReportInfo) {
+	if other == nil {
+		return
+	}
 	for sev, count := range other.CountBySeverity {
 		r.IncrementSevCount(sev, count)
 	}

--- a/analysis/config/testdata/syntactic-config.yaml
+++ b/analysis/config/testdata/syntactic-config.yaml
@@ -7,11 +7,11 @@ options:
   silence-warn: true
 
 syntactic-problems:
-  - struct-inits:
-      - struct:
-          type: "package/testType"
-        fields-set:
-          - field: "TestField"
-            value:
-              package: "path/testPackage"
-              const: "TestConst"
+  struct-inits:
+    - struct:
+        type: "package/testType"
+      fields-set:
+        - field: "TestField"
+          value:
+            package: "path/testPackage"
+            const: "TestConst"

--- a/analysis/syntactic/structinit/structinit_test.go
+++ b/analysis/syntactic/structinit/structinit_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/ar-go-tools/analysis/config"
+	"github.com/awslabs/ar-go-tools/analysis/dataflow"
 	"github.com/awslabs/ar-go-tools/analysis/syntactic/structinit"
 	"github.com/awslabs/ar-go-tools/internal/analysistest"
 	"github.com/awslabs/ar-go-tools/internal/funcutil"
@@ -88,7 +89,11 @@ func runAnalysis(t *testing.T, dirName string) (analysistest.LoadedTestProgram, 
 		t.Fatalf("failed to load test: %v", err)
 	}
 	setupConfig(lp.Config)
-	result, err := structinit.Analyze(lp.Config, lp.Prog, lp.Pkgs)
+	state, err := dataflow.NewInitializedAnalyzerState(lp.Prog, lp.Pkgs, config.NewLogGroup(lp.Config), lp.Config)
+	if err != nil {
+		t.Fatalf("failed to initialize analyzer state")
+	}
+	result, err := structinit.Analyze(state)
 	if err != nil {
 		t.Fatalf("struct-init analysis failed: %v", err)
 	}

--- a/analysis/syntactic/structinit/testdata/field-func/config.yaml
+++ b/analysis/syntactic/structinit/testdata/field-func/config.yaml
@@ -1,9 +1,9 @@
 syntactic-problems:
-  - struct-inits:
-      - struct:
-          type: ".*target$"
-        fields-set:
-          - field: "f"
-            value:
-              package: "(field-func)|(main)|(command-line-arguments)"
-              method: "^Func"
+  struct-inits:
+    - struct:
+        type: ".*target$"
+      fields-set:
+        - field: "f"
+          value:
+            package: "(field-func)|(main)|(command-line-arguments)"
+            method: "^Func"

--- a/analysis/syntactic/structinit/testdata/field-val/config.yaml
+++ b/analysis/syntactic/structinit/testdata/field-val/config.yaml
@@ -1,9 +1,9 @@
 syntactic-problems:
-  - struct-inits:
-      - struct:
-          type: ".*target$"
-        fields-set:
-          - field: "x"
-            value:
-              package: "(field-val)|(main)|(command-line-arguments)"
-              const: "^One$"
+  struct-inits:
+    - struct:
+        type: ".*target$"
+      fields-set:
+        - field: "x"
+          value:
+            package: "(field-val)|(main)|(command-line-arguments)"
+            const: "^One$"

--- a/analysis/version.go
+++ b/analysis/version.go
@@ -15,4 +15,4 @@
 package analysis
 
 // Version is the last tagged version of the analysis tool
-const Version = "v0.3.0"
+const Version = "v0.3.1"

--- a/cmd/argot/backtrace/backtrace.go
+++ b/cmd/argot/backtrace/backtrace.go
@@ -23,10 +23,8 @@ import (
 	"github.com/awslabs/ar-go-tools/analysis"
 	"github.com/awslabs/ar-go-tools/analysis/backtrace"
 	"github.com/awslabs/ar-go-tools/analysis/config"
-	df "github.com/awslabs/ar-go-tools/analysis/dataflow"
 	"github.com/awslabs/ar-go-tools/cmd/argot/tools"
 	"github.com/awslabs/ar-go-tools/internal/formatutil"
-	"golang.org/x/tools/go/ssa"
 )
 
 // Usage for CLI
@@ -51,21 +49,8 @@ func Run(flags tools.CommonFlags) error {
 	}
 	overallReport := config.NewReport()
 	for targetName, targetFiles := range tools.GetTargets(flags.FlagSet.Args(), cfg, "backtrace") {
-		cfgLog.Infof("Reading backtrace entrypoints")
-		loadOptions := analysis.LoadProgramOptions{
-			PackageConfig: nil,
-			BuildMode:     ssa.InstantiateGenerics,
-			LoadTests:     flags.WithTest,
-			ApplyRewrites: true,
-		}
-		program, pkgs, err := analysis.LoadProgram(loadOptions, targetFiles)
-		if err != nil {
-			return fmt.Errorf("%s could not load program: %v", targetName, err)
-		}
-
 		start := time.Now()
-		state, err := df.NewInitializedAnalyzerState(program, pkgs, cfgLog, cfg)
-		state.Target = targetName
+		state, err := analysis.LoadTarget(targetName, targetFiles, cfgLog, cfg, flags.WithTest)
 		if err != nil {
 			return fmt.Errorf("failed to load state: %s", err)
 		}

--- a/cmd/argot/tools/tools.go
+++ b/cmd/argot/tools/tools.go
@@ -127,13 +127,13 @@ func LoadConfig(configPath string) (*config.Config, error) {
 //
 // When args is not empty, only the target "" -> args is returned.
 // When the tool name is not recognized, all the targets in the config file are returned.
-func GetTargets(args []string, c *config.Config, tool string) map[string][]string {
+func GetTargets(args []string, c *config.Config, tool config.ToolName) map[string][]string {
 	if len(args) > 0 {
 		return map[string][]string{"": args}
 	}
 	allTargets := c.GetTargetMap()
 	switch tool {
-	case "taint":
+	case config.TaintTool:
 		taintTargets := map[string][]string{}
 		for _, ttp := range c.TaintTrackingProblems {
 			for _, target := range ttp.Targets {
@@ -141,7 +141,7 @@ func GetTargets(args []string, c *config.Config, tool string) map[string][]strin
 			}
 		}
 		return taintTargets
-	case "backtrace":
+	case config.BacktraceTool:
 		backtraceTargets := map[string][]string{}
 		for _, ttp := range c.SlicingProblems {
 			for _, target := range ttp.Targets {
@@ -149,6 +149,14 @@ func GetTargets(args []string, c *config.Config, tool string) map[string][]strin
 			}
 		}
 		return backtraceTargets
+	case config.SyntacticTool:
+		structInitTargets := map[string][]string{}
+		for _, sis := range c.SyntacticProblems.StructInitProblems {
+			for _, target := range sis.Targets {
+				structInitTargets[target] = allTargets[target]
+			}
+		}
+		return structInitTargets
 	default:
 		return allTargets
 	}


### PR DESCRIPTION
Makes the `syntactic` tool use the targets like `taint` and `backtrace`.
