### PR TITLE
Run with tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Argot is a collection of static analysis tools:
 - `taint` performs a taint analysis on a given program
 - `backtrace` identifies backwards data-flow traces from function calls
 - `cli` is an interactive terminal-like interface for parts of the analysis (in `cmd/cli`)
+- `syntactic` runs syntactic analyses
 - `compare` prints a comparison of the functions that are reachable according to two different analyses, and the
 functions that appear in the binary
 - `dependencies` prints the dependencies of a given program
@@ -58,7 +59,6 @@ Static analyses that require pointer and callgraph information should depend on 
 - `reachability` contains function-reachability analyses
 - `refactor` contains implements refactoring operations,
 - `render` contains various information rendering utilities
-- `static-commands` implements the static command detection analysis,
 - `summaries` defines dataflow summaries of some functions,
 - `taint` implements the taint analysis
 

--- a/analysis/analyzers.go
+++ b/analysis/analyzers.go
@@ -48,7 +48,7 @@ type IntraAnalysisParams struct {
 // RunIntraProceduralPass runs an intra-procedural analysis pass of program prog in parallel using numRoutines, using the
 // analyzer state. The args specify the intraprocedural analysis parameters.
 // RunIntraProceduralPass updates the summaries stored in the state's FlowGraph
-func RunIntraProceduralPass(state *dataflow.AnalyzerState, numRoutines int, args IntraAnalysisParams) {
+func RunIntraProceduralPass(state *dataflow.AnalyzerState, numRoutines int, args IntraAnalysisParams) { //argot:ignore df-intra-uses
 	state.Logger.Infof("Starting intra-procedural analysis ...")
 	start := time.Now()
 

--- a/analysis/version.go
+++ b/analysis/version.go
@@ -15,4 +15,4 @@
 package analysis
 
 // Version is the last tagged version of the analysis tool
-const Version = "v0.3.1"
+const Version = "v0.3.2"

--- a/cmd/argot/backtrace/backtrace.go
+++ b/cmd/argot/backtrace/backtrace.go
@@ -47,8 +47,12 @@ func Run(flags tools.CommonFlags) error {
 		cfg.LogLevel = int(config.DebugLevel)
 		cfgLog = config.NewLogGroup(cfg)
 	}
+	if flags.Tag != "" {
+		cfgLog.Infof("tag specified on command-line, will analyze only problem with tag \"%s\"", flags.Tag)
+	}
+
 	overallReport := config.NewReport()
-	for targetName, targetFiles := range tools.GetTargets(flags.FlagSet.Args(), cfg, "backtrace") {
+	for targetName, targetFiles := range tools.GetTargets(flags.FlagSet.Args(), flags.Tag, cfg, "backtrace") {
 		start := time.Now()
 		state, err := analysis.LoadTarget(targetName, targetFiles, cfgLog, cfg, flags.WithTest)
 		if err != nil {

--- a/cmd/argot/main.go
+++ b/cmd/argot/main.go
@@ -41,6 +41,7 @@ Usage:
 Tools:
   - taint: performs a taint analysis on a given program
   - backtrace: identifies backwards data-flow traces from function calls
+  - syntactic: runs some syntactic analyses using the SSA representation
   - cli: interactive terminal-like interface for parts of the analysis
   - compare: prints a comparison of the functions that are reachable according to two different analyses, and the functions that appear in the binary
   - dependencies: prints the dependencies of a given program

--- a/cmd/argot/render/render.go
+++ b/cmd/argot/render/render.go
@@ -94,7 +94,7 @@ func WriteCrossFunctionGraph(cfg *config.Config, logger *config.LogGroup, progra
 
 	analysis.RunIntraProceduralPass(state, numRoutines, analysis.IntraAnalysisParams{
 		ShouldBuildSummary: dataflow.ShouldBuildSummary,
-		ShouldTrack:        func(*dataflow.AnalyzerState, ssa.Node) bool { return true },
+		ShouldTrack:        func(*dataflow.AnalyzerState, ssa.Node) bool { return true }, //argot:ignore df-intra-uses
 	})
 
 	state, err = render.BuildCrossFunctionGraph(state)

--- a/cmd/argot/syntactic/syntactic.go
+++ b/cmd/argot/syntactic/syntactic.go
@@ -52,9 +52,13 @@ func Run(flags tools.CommonFlags) error {
 		return nil
 	}
 
+	if flags.Tag != "" {
+		logger.Infof("tag specified on command-line, will analyze only problem with tag \"%s\"", flags.Tag)
+	}
+
 	failCount := 0
 	overallReport := config.NewReport()
-	for targetName, targetFiles := range tools.GetTargets(flags.FlagSet.Args(), cfg, config.SyntacticTool) {
+	for targetName, targetFiles := range tools.GetTargets(flags.FlagSet.Args(), flags.Tag, cfg, config.SyntacticTool) {
 		report, err := runTarget(flags, targetName, targetFiles, logger, cfg)
 		if err != nil {
 			logger.Errorf("Analysis for %s failed: %s", targetName, err)

--- a/cmd/argot/taint/taint.go
+++ b/cmd/argot/taint/taint.go
@@ -58,6 +58,7 @@ func NewFlags(args []string) (Flags, error) {
 			ConfigPath: *flags.ConfigPath,
 			Verbose:    *flags.Verbose,
 			WithTest:   *flags.WithTest,
+			Tag:        *flags.Tag,
 		},
 		maxDepth: *maxDepth,
 		dryRun:   *dryRun,

--- a/cmd/argot/taint/taint.go
+++ b/cmd/argot/taint/taint.go
@@ -86,11 +86,14 @@ func Run(flags Flags) error {
 		cfgLog.Infof("dry-run command line flag sets on demand summarization to true")
 		taintConfig.SummarizeOnDemand = true
 	}
+	if flags.Tag != "" {
+		cfgLog.Infof("tag specified on command-line, will analyze only problem with tag \"%s\"", flags.Tag)
+	}
 
 	hasFlows := false
 	overallReport := config.NewReport()
 	// Loop over every target of the taint analysis
-	for targetName, targetFiles := range tools.GetTargets(flags.FlagSet.Args(), taintConfig, config.TaintTool) {
+	for targetName, targetFiles := range tools.GetTargets(flags.FlagSet.Args(), flags.Tag, taintConfig, config.TaintTool) {
 		targetHasFlows, report, err := runTarget(flags, targetName, targetFiles, cfgLog, taintConfig)
 		hasFlows = targetHasFlows || hasFlows
 		if err != nil {

--- a/payload/selfcheck/config.yaml
+++ b/payload/selfcheck/config.yaml
@@ -68,3 +68,15 @@ dataflow-problems:
         - package: "^regexp$"
           method: "^MustCompile$"
 
+syntactic-problems:
+  struct-inits:
+    - tag: "df-intra-uses" # search for //argot:ignore df-intra-uses to see where there are different allocations
+      description: "When using RunIntraProceduralPass, initialize with dataflow.IsNodeOfInterest unless you know better."
+      targets: ["argot"]
+      struct:
+        type: "github.com/awslabs/ar-go-tools/analysis.IntraAnalysisParams"
+      fields-set:
+        - field: "ShouldTrack"
+          value:
+            package: "github.com/awslabs/ar-go-tools/analysis/dataflow"
+            method: "IsNodeOfInterest"


### PR DESCRIPTION
This PR makes some improvements in using tags to organize your analyses:
- in taint, backtrace and syntactic, specify `-tag my-tag` on the command line to run only the problems with tag `my-tag`.
- struct-init analysis in syntactic tool now respects `//argot:ignore tag` instruction for problems tagged with `tag`. Try `argot syntactic -config payload/selfcheck/config.yaml`
