### PR TITLE
Must be static option in backtrace

### DIFF
--- a/analysis/backtrace/backtrace_taint_test.go
+++ b/analysis/backtrace/backtrace_taint_test.go
@@ -190,7 +190,7 @@ func isExpected(expected analysistest.TargetToSources, sourcePos analysistest.LP
 func reachedSinkPositions(s *dataflow.AnalyzerState, res backtrace.AnalysisResult) map[token.Position]map[token.Position]bool {
 	positions := make(map[token.Position]map[token.Position]bool)
 	prog := s.Program
-	for sink, traces := range res.Traces {
+	for sink, traces := range res.Traces[""] {
 		// sink is the analysis entrypoint
 		si := dataflow.Instr(sink)
 		if si == nil {
@@ -323,7 +323,7 @@ func mergeTraces(result backtrace.AnalysisResult) []backtrace.Trace {
 		n += len(traces)
 	}
 	res := make([]backtrace.Trace, 0, n)
-	for _, traces := range result.Traces {
+	for _, traces := range result.Traces[""] {
 		res = append(res, traces...)
 	}
 

--- a/analysis/backtrace/backtrace_test.go
+++ b/analysis/backtrace/backtrace_test.go
@@ -517,6 +517,33 @@ func testAnalyzeClosures(t *testing.T, lp analysistest.LoadedTestProgram) {
 	}
 }
 
+func TestAnalyze_CheckStatic(t *testing.T) {
+	dir := filepath.Join("./testdata", "check_static")
+	lp, err := analysistest.LoadTest(testfsys, dir, []string{}, analysistest.LoadTestOptions{ApplyRewrite: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lp.Config.SummarizeOnDemand = true
+	lp.Config.LogLevel = int(config.InfoLevel) // increasing to level > InfoLevel throws off IDE
+	lg := config.NewLogGroup(lp.Config)
+	state, err := dataflow.NewInitializedAnalyzerState(lp.Prog, lp.Pkgs, lg, lp.Config)
+	if err != nil {
+		t.Fatalf("failed to load state: %s", err)
+	}
+	res, err := backtrace.Analyze(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Traces) != 1 {
+		t.Fatalf("expected a single entry point with a trace for check_static")
+	}
+	for _, traces := range res.Traces {
+		if len(traces) != 1 {
+			t.Fatalf("expected a single trace for check_static")
+		}
+	}
+}
+
 type nodeType int
 
 const (

--- a/analysis/backtrace/report.go
+++ b/analysis/backtrace/report.go
@@ -20,8 +20,8 @@ import (
 	"github.com/awslabs/ar-go-tools/internal/funcutil"
 )
 
-// A FlowReports contains the information we serialize about a taint flow: a tag, the source and the sink, and
-// the trace from source to sink.
+// A FlowReports contains the information we serialize about backwards data flow traces. Traces are grouped by problem
+// tag. A trace in the report is a list of dataflow.ReportNodeInfo.
 type FlowReports struct {
 	Tag    string
 	Traces map[string][][]dataflow.ReportNodeInfo

--- a/analysis/backtrace/testdata/check_static/config.yaml
+++ b/analysis/backtrace/testdata/check_static/config.yaml
@@ -1,0 +1,10 @@
+options:
+  log-level: 3
+
+dataflow-problems:
+  slicing:
+    - tag: "must-compile-constant"
+      must-be-static: true
+      backtracepoints:
+        - package: regexp
+          method: MustCompile

--- a/analysis/backtrace/testdata/check_static/main.go
+++ b/analysis/backtrace/testdata/check_static/main.go
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package backtrace defines a dataflow analysis that finds all the backwards
+// dataflow paths from an entrypoint. This analysis finds data flows which means
+// that a backtrace consists of the data flowing backwards from an argument to
+// the "backtracepoint" (entrypoint) call.
+
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp"
+)
+
+func makesRegex(s string, s2 string) *regexp.Regexp {
+	regex := fmt.Sprintf("%s+%s", s, s2)
+	return regexp.MustCompile(regex)
+}
+
+func buildRegex(s string) *regexp.Regexp {
+	return regexp.MustCompile(s)
+}
+
+func buildRegexWithNonConstant(s string) *regexp.Regexp {
+	rval := fmt.Sprintf("%s-%d", s, rand.Int())
+	return regexp.MustCompile(rval)
+}
+
+func main() {
+	regexp.MustCompile("ok")
+	buildRegex("ok")
+	makesRegex("ok", "good")
+	buildRegexWithNonConstant("bad")
+}

--- a/analysis/config/dataflow_config.go
+++ b/analysis/config/dataflow_config.go
@@ -128,6 +128,10 @@ type SlicingSpec struct {
 	// Targets identifies the names of the targets this analysis must run against
 	Targets []string
 
+	// MustBeStatic set to true indicates that all the data flowing to backtrace points must be static (constants,
+	// static string)
+	MustBeStatic bool `yaml:"must-be-static" json:"must-be-static"`
+
 	// SkipBoundLabels indicates whether to skip flows that go through "bound labels", i.e. aliases of the variables
 	// bound by a closure. This can be useful to test data flows because bound labels generate a lot of false positives.
 	SkipBoundLabels bool `yaml:"unsafe-skip-bound-labels" json:"unsafe-skip-bound-labels"`

--- a/cmd/argot/backtrace/backtrace.go
+++ b/cmd/argot/backtrace/backtrace.go
@@ -52,6 +52,7 @@ func Run(flags tools.CommonFlags) error {
 	}
 
 	overallReport := config.NewReport()
+	foundTraces := false
 	for targetName, targetFiles := range tools.GetTargets(flags.FlagSet.Args(), flags.Tag, cfg, "backtrace") {
 		start := time.Now()
 		state, err := analysis.LoadTarget(targetName, targetFiles, cfgLog, cfg, flags.WithTest)
@@ -67,8 +68,14 @@ func Run(flags tools.CommonFlags) error {
 		cfgLog.Infof("")
 		cfgLog.Infof("-%s", strings.Repeat("*", 80))
 		cfgLog.Infof("Analysis took %3.4f s\n", duration.Seconds())
-		cfgLog.Infof("Found traces for %d entrypoints\n", len(result.Traces))
+		if len(result.Traces) > 0 {
+			foundTraces = true
+			cfgLog.Errorf("Found traces for %d slicing problems\n", len(result.Traces))
+		}
 	}
 	overallReport.Dump(cfgLog, cfg)
+	if foundTraces {
+		return fmt.Errorf("backtrace analysis found traces, inspect logs for more information")
+	}
 	return nil
 }

--- a/doc/02_backtrace.md
+++ b/doc/02_backtrace.md
@@ -18,7 +18,17 @@ slicing-problems:
         - package: "os/exec"
           method: "Command$"
 ```
-In this configuration file, the user is trying to detect all the possible traces from calls to some function `Command` in a package matching `os/exec`. The tool will treat all the arguments to all the calls to `os/exec.Command` as entry points.
+In this configuration file, the user is trying to detect all the possible traces from calls to some function `Command` in a package matching `os/exec`. The tool will treat all the arguments to all the calls to `os/exec.Command` as entry points, and will report any trace from some data source to the code locations matching some `backtracepoint`.
+
+A slicing problem can also be defined with the `must-be-static` option set to true:
+```yaml
+slicing-problems:  
+  - must-be-static: true
+    backtracepoints:
+      - package: "regexp"
+        method: "MustCompile"
+```
+With that setting, the tool will report any flow of data from a source of data that is not static to the entry points. If there is any flow found, then this is an error; in the example above, the analysis returns an error if `regexp.MustCompile` has an argument that is not entirely statically defined (i.e. constants).
 
 > 📝 Note that all strings in the `package` and `method` fields are parsed as regexes; for example, to match `F` precisely, one should write `"^F"`; the `"backtracepoints"` specification will match any function name containing `F`.
 

--- a/payload/selfcheck/config.yaml
+++ b/payload/selfcheck/config.yaml
@@ -64,6 +64,7 @@ dataflow-problems:
       description: "Checking that MustCompile is used only with static strings."
       targets: [ "argot", "racerg" ]
       severity: "HIGH"
+      must-be-static: true
       backtracepoints:
         - package: "^regexp$"
           method: "^MustCompile$"


### PR DESCRIPTION
This PR add the `must-be-static` option in the slicing specs of the backtrace tool. 
For example:
```
dataflow-problems:
  slicing:
    - must-be-static: true
      backtracepoints:
        - package: regexp
           method: MustCompile 
```
Reports an error only when non-static data reaches a call to `regexp.MustCompile`.

This PR also changes the behavior of backtrace in general to report an error when any trace is detected. `must-be-static` is a constraint on which traces are reported; only the non-static ones. 

Using the tool without the `must-be-static` means all traces are reported, and almost guarantees that an error will be shown. This should not be a problem since backtrace without the must-be-static option should only be used as an exploration tool right now.