### PR TITLE
Fix annotation loading for comments in the AST

### DIFF
--- a/analysis/annotations/annotations.go
+++ b/analysis/annotations/annotations.go
@@ -25,7 +25,6 @@ import (
 	"github.com/awslabs/ar-go-tools/analysis/config"
 	"github.com/awslabs/ar-go-tools/internal/funcutil"
 	"golang.org/x/exp/slices"
-	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/ssa"
 )
 
@@ -218,13 +217,13 @@ func (pa ProgramAnnotations) Iter(fx func(a Annotation)) {
 
 // CompleteFromSyntax takes a set of program annotations and adds additional non-ssa linked annotations
 // to the annotations
-func (pa ProgramAnnotations) CompleteFromSyntax(logger *config.LogGroup, pkg *packages.Package) {
-	for _, astFile := range pkg.Syntax {
+func (pa ProgramAnnotations) CompleteFromSyntax(logger *config.LogGroup, fset *token.FileSet, files []*ast.File) {
+	for _, astFile := range files {
 		pa.loadPackageDocAnnotations(astFile.Doc)
 		for _, comments := range astFile.Comments {
 			for _, comment := range comments.List {
 				if annotationContents := extractAnnotation(comment); annotationContents != nil {
-					pa.loadFileAnnotations(logger, annotationContents, pkg.Fset.Position(comment.Pos()))
+					pa.loadFileAnnotations(logger, annotationContents, fset.Position(comment.Pos()))
 				}
 			}
 		}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`analysisutil.VisitPackages` does not visit all the packages in the program. Instead, we need to manually parse each file in the project to get its AST.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
