### PR TITLE
Option `-targets`

### DIFF
--- a/analysis/backtrace/backtrace_taint_test.go
+++ b/analysis/backtrace/backtrace_taint_test.go
@@ -110,7 +110,7 @@ func runBacktraceTest(t *testing.T, test testDef, isOnDemand bool) {
 	if err != nil {
 		t.Fatalf("failed to load dataflow state: %s", err)
 	}
-	res, err := backtrace.Analyze(state)
+	res, err := backtrace.Analyze(state, backtrace.AnalysisReqs{})
 	if err != nil {
 		t.Fatalf("failed to run analysis: %v", err)
 	}

--- a/analysis/backtrace/backtrace_test.go
+++ b/analysis/backtrace/backtrace_test.go
@@ -75,7 +75,7 @@ func testAnalyze(t *testing.T, lp *loadprogram.State) {
 	if err != nil {
 		t.Fatalf("failed to load state: %s", err)
 	}
-	res, err := backtrace.Analyze(state)
+	res, err := backtrace.Analyze(state, backtrace.AnalysisReqs{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -386,7 +386,7 @@ func testAnalyzeClosures(t *testing.T, lp *loadprogram.State) {
 	if err != nil {
 		t.Fatalf("failed to load state: %s", err)
 	}
-	res, err := backtrace.Analyze(state)
+	res, err := backtrace.Analyze(state, backtrace.AnalysisReqs{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -530,7 +530,7 @@ func TestAnalyze_CheckStatic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to load state: %s", err)
 	}
-	res, err := backtrace.Analyze(state)
+	res, err := backtrace.Analyze(state, backtrace.AnalysisReqs{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/analysis/taint/taint_utils_test.go
+++ b/analysis/taint/taint_utils_test.go
@@ -289,7 +289,7 @@ func runTestWithoutCheck(t *testing.T, dirName string, files []string, summarize
 	if err != nil {
 		t.Fatalf("failed to initialize state")
 	}
-	res, err := taint.Analyze(state)
+	res, err := taint.Analyze(state, taint.AnalysisReqs{})
 	if err != nil {
 		if res.State != nil {
 			for _, err := range res.State.Report.CheckError() {

--- a/cmd/argot/backtrace/backtrace.go
+++ b/cmd/argot/backtrace/backtrace.go
@@ -87,7 +87,9 @@ func Run(flags tools.CommonFlags) error {
 		if err != nil {
 			return fmt.Errorf("loading failed: %v", err)
 		}
-		analysisResult, err := backtrace.Analyze(state)
+		analysisResult, err := backtrace.Analyze(state, backtrace.AnalysisReqs{
+			Tag: flags.Tag,
+		})
 		if err != nil {
 			return fmt.Errorf("analysis failed: %v", err)
 		}

--- a/cmd/argot/dependencies/dependencies.go
+++ b/cmd/argot/dependencies/dependencies.go
@@ -110,7 +110,14 @@ func Run(flags Flags) error {
 		LoadTests:     flags.withTest,
 		ApplyRewrites: true,
 	}
-	for targetName, targetFiles := range tools.GetTargets(flags.flagSet.Args(), "", cfg, config.DependenciesTool) {
+	actualTargets, err := tools.GetTargets(cfg, tools.TargetReqs{
+		CmdlineArgs: flags.flagSet.Args(),
+		Tool:        config.DependenciesTool,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get dependencies targets: %s", err)
+	}
+	for targetName, targetFiles := range actualTargets {
 		err = runTarget(cfg, targetName, targetFiles, loadOptions, flags)
 		if err != nil {
 			return err

--- a/cmd/argot/syntactic/syntactic.go
+++ b/cmd/argot/syntactic/syntactic.go
@@ -59,9 +59,24 @@ func Run(flags tools.CommonFlags) error {
 		tmpLogger.Infof("tag specified on command-line, will analyze only problem with tag \"%s\"", flags.Tag)
 	}
 
+	if flags.Targets != "" {
+		tmpLogger.Infof("target specified on command-line, will analyze only for problems with targets in \"%s\"",
+			flags.Targets)
+	}
+
 	failCount := 0
 	overallReport := config.NewReport()
-	for targetName, targetFiles := range tools.GetTargets(flags.FlagSet.Args(), flags.Tag, cfg, config.SyntacticTool) {
+
+	actualTargets, err := tools.GetTargets(cfg, tools.TargetReqs{
+		CmdlineArgs: flags.FlagSet.Args(),
+		Tag:         flags.Tag,
+		Targets:     flags.Targets,
+		Tool:        config.SyntacticTool,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get syntactic targets: %s", err)
+	}
+	for targetName, targetFiles := range actualTargets {
 		report, err := runTarget(cfg, targetName, targetFiles, flags)
 		if err != nil {
 			tmpLogger.Errorf("Analysis for %s failed: %s", targetName, err)

--- a/cmd/argot/taint/taint.go
+++ b/cmd/argot/taint/taint.go
@@ -148,7 +148,9 @@ func runTarget(
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to initialize dataflow state: %s", err)
 	}
-	result, err := taint.Analyze(df)
+	result, err := taint.Analyze(df, taint.AnalysisReqs{
+		Tag: flags.Tag,
+	})
 	duration := time.Since(start)
 	if err != nil {
 		if result.State != nil {

--- a/internal/funcutil/collections.go
+++ b/internal/funcutil/collections.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"golang.org/x/exp/constraints"
+	"golang.org/x/exp/maps"
 )
 
 // Merge merges the two maps into the first map.
@@ -188,4 +189,11 @@ func Reverse[T any](a []T) {
 	for i, j := 0, len(a)-1; i < j; i, j = i+1, j-1 {
 		a[i], a[j] = a[j], a[i]
 	}
+}
+
+// Retain removes all the key-value pairs in m where the key is not in keys.
+func Retain[T comparable, R any](m map[T]R, keys []T) {
+	maps.DeleteFunc(m, func(t T, r R) bool {
+		return !Contains(keys, t)
+	})
 }


### PR DESCRIPTION
This PR adds a new option `-targets` to let the user specify which targets to run  when using a config file. This is useful for large config files with many problems when you want to just run the problems for a single (or a few) targets.

Also fixes the `-tag` option to work properly in the `taint` and `backtrace` tools.
