### PR TITLE
Explicit builtin nodes

### DIFF
--- a/analysis/backtrace/backtrace.go
+++ b/analysis/backtrace/backtrace.go
@@ -513,8 +513,8 @@ func (v *Visitor) visit(s *df.State, entrypoint *df.CallNodeArg) error {
 				logger.Tracef("Adding trace: %v\n", t)
 			}
 
-		// Data flows backwards within the function from the synthetic node.
-		case *df.SyntheticNode:
+		// Data flows backwards within the function from the synthetic node or builtin call node.
+		case *df.SyntheticNode, *df.BuiltinCallNode:
 			for nextNode := range graphNode.In() {
 				nextNodeWithTrace := df.NodeWithTrace{
 					Node:         nextNode,

--- a/analysis/dataflow/builtins.go
+++ b/analysis/dataflow/builtins.go
@@ -14,53 +14,111 @@
 
 package dataflow
 
-import "golang.org/x/tools/go/ssa"
+import (
+	"github.com/awslabs/ar-go-tools/internal/funcutil"
+	"golang.org/x/tools/go/ssa"
+)
 
+// handledBuiltins is the list of builtin function names that are internally handled by the analysis
+var handledBuiltins = []string{
+	"ssa:wrapnilchk",
+	"append",
+	"len",
+	"close",
+	"delete",
+	"println",
+	"print",
+	"recover",
+	"cap",
+	"complex",
+	"imag",
+	"real",
+	"min",
+	"max",
+	"clear",
+	"copy",
+}
+
+// markedBuiltins is the subset of builtins that return values that should be tracked in the analysis
+var markedBuiltins = []string{"ssa:wrapnilchk", "append", "complex", "min", "max", "len", "imag", "real"}
+
+// isHandledBuiltinCall returns true if the call is handled internally by the analysis.
 func isHandledBuiltinCall(instruction ssa.CallInstruction) bool {
 	if instruction.Common().Value != nil {
-		switch instruction.Common().Value.Name() {
-		// for append, copy we simply propagate the taint like in a binary operator
-		case "ssa:wrapnilchk":
+		name := instruction.Common().Value.Name()
+		if funcutil.Contains(handledBuiltins, name) {
 			return true
-		case "append", "len", "close", "delete", "println", "print", "recover", "cap":
+		}
+		// Special case: the call to Error() of the builtin error interface
+		if instruction.Common().IsInvoke() && instruction.Common().Method.Name() == "Error" &&
+			len(instruction.Common().Args) == 0 {
 			return true
-
-		// Complex numbers
-		case "complex", "imag", "real":
-			return true
-
-		// starting from go1.21
-		case "min", "max", "clear":
-			return true
-
-		case "copy":
-			if len(instruction.Common().Args) == 2 {
-				return true
-			}
-			return false
-
-		default:
-			// Special case: the call to Error() of the builtin error interface
-			if instruction.Common().IsInvoke() && instruction.Common().Method.Name() == "Error" &&
-				len(instruction.Common().Args) == 0 {
-				return true
-			}
-			return false
 		}
 	}
 	return false
 }
 
+func makeArgEdges(t *IntraAnalysisState, instruction ssa.CallInstruction, arg ssa.Value) {
+	marks := t.getMarks(instruction, arg, "", false)
+	for _, mark := range marks {
+		t.summary.addBuiltinCallEdge(mark, instruction, nil)
+	}
+}
+
+// makeEdgesAtBuiltinCall updates the state by adding edges from marks reaching the call instruction
+// representing a call to a builtin to the builtin node.
+//
+// The predicate isHandledBuiltinCall should hold on the instruction argument.
+func makeEdgesAtBuiltinCall(t *IntraAnalysisState, instruction ssa.CallInstruction) {
+	callCommon := instruction.Common()
+	if callCommon.Value != nil {
+		if callCommon.Value.Name() == "recover" {
+			// TODO: handle recovers
+			return
+		}
+
+		for _, arg := range callCommon.Args {
+			makeArgEdges(t, instruction, arg)
+		}
+	}
+}
+
 // doBuiltinCall returns true if the call is a builtin that is handled by default, otherwise false.
 // If true is returned, the analysis may ignore the call instruction.
-//
-//gocyclo:ignore
-func doBuiltinCall(t *IntraAnalysisState, callValue ssa.Value, callCommon *ssa.CallCommon,
-	instruction ssa.CallInstruction) bool {
+func markBuiltinCall(t *IntraAnalysisState, value ssa.Value, common *ssa.CallCommon,
+	instr ssa.CallInstruction) bool {
 	// For consistency check that the call is handled first.
-	if !isHandledBuiltinCall(instruction) {
+	if !isHandledBuiltinCall(instr) {
 		return false
 	}
+
+	if common.Value != nil {
+		name := common.Value.Name()
+		if funcutil.Contains(markedBuiltins, name) {
+			for _, mark := range t.marksToAdd(value, instr, common) {
+				t.markValue(instr, value, mark.AccessPath, mark.Mark)
+			}
+			return true
+		}
+
+		// Special case: the call to Error() of the builtin error interface
+		if common.IsInvoke() && common.Method.Name() == "Error" && len(common.Args) == 0 {
+			simpleTransfer(t, instr, common.Value, value)
+		}
+	}
+	return true
+}
+
+// doBuiltinCall returns true if the call is a builtin that is handled by default, otherwise false.
+// If true is returned, the analysis may ignore the call instruction.
+func doBuiltinCall(t *IntraAnalysisState, callValue ssa.Value, callCommon *ssa.CallCommon,
+	instruction ssa.CallInstruction) {
+	// For consistency check that the call is handled first.
+	if !isHandledBuiltinCall(instruction) {
+		return
+	}
+	// Builtins that have no effect here:
+	// "cap", "complex", "min", "max", "len", "imag", "real", "close", "delete", "clear", "println", "print", "recover"
 	if callCommon.Value != nil {
 		switch callCommon.Value.Name() {
 		// for append, copy we simply propagate the taint like in a binary operator
@@ -68,72 +126,27 @@ func doBuiltinCall(t *IntraAnalysisState, callValue ssa.Value, callCommon *ssa.C
 			for _, arg := range callCommon.Args {
 				simpleTransfer(t, instruction, arg, callValue)
 			}
-			return true
 		case "append":
 			if len(callCommon.Args) == 2 {
 				sliceV := callCommon.Args[0]
 				dataV := callCommon.Args[1]
-				simpleTransfer(t, instruction, sliceV, callValue)
 				simpleTransfer(t, instruction, dataV, sliceV)
-				simpleTransfer(t, instruction, dataV, callValue)
-				return true
 			}
-			return false
-
 		case "copy":
 			if len(callCommon.Args) == 2 {
 				src := callCommon.Args[1]
 				dst := callCommon.Args[0]
 				// copy transfers from source to destination
 				simpleTransfer(t, instruction, src, dst)
-				return true
 			}
-			return false
-
-		case "cap":
-			// taking the capacity does not propagate taint
-			return true
-
-		case "complex", "min", "max":
-			if len(callCommon.Args) == 2 {
-				f1 := callCommon.Args[1]
-				f2 := callCommon.Args[0]
-				simpleTransfer(t, instruction, f1, callValue)
-				simpleTransfer(t, instruction, f2, callValue)
-				return true
-			}
-			return false
-
-		// for len, imag, real we also propagate the taint. This may not be necessary
-		case "len", "imag", "real":
-			for _, arg := range callCommon.Args {
-				simpleTransfer(t, instruction, arg, callValue)
-			}
-			return true
-
-		// for close, delete, nothing is propagated
-		case "close", "delete", "clear":
-			return true
-
-		// the builtin println doesn't return anything
-		case "println", "print":
-			return true
-
-		// for recover, we will need some form of panic analysis
-		case "recover":
-			// TODO: handler recovers. Analysis is unsound with recovers.
-			// NOTE: Unsoundness is reported by reportUnsoundFeatures
-			return true
 		default:
 			// Special case: the call to Error() of the builtin error interface
 			if callCommon.IsInvoke() &&
 				callCommon.Method.Name() == "Error" &&
 				len(callCommon.Args) == 0 {
 				simpleTransfer(t, instruction, callCommon.Value, callValue)
-				return true
 			}
-			return false
 		}
 	}
-	return false
+	return
 }

--- a/analysis/dataflow/builtins.go
+++ b/analysis/dataflow/builtins.go
@@ -19,7 +19,11 @@ import (
 	"golang.org/x/tools/go/ssa"
 )
 
-// handledBuiltins is the list of builtin function names that are internally handled by the analysis
+// handledBuiltins is the list of builtin function names that are internally handled by the analysis.
+// You can find a complete list of builtins at:
+// https://pkg.go.dev/builtin
+//
+// Note that new, make and panic are their own SSA instructions.
 var handledBuiltins = []string{
 	"ssa:wrapnilchk",
 	"append",

--- a/analysis/dataflow/code_identifiers.go
+++ b/analysis/dataflow/code_identifiers.go
@@ -152,6 +152,8 @@ func isMatchingCodeID(codeIDOracle func(config.CodeIdentifier) bool, n GraphNode
 		return IsMatchingCodeIDWithCallee(codeIDOracle, callSite.CalleeSummary.Parent, param.Parent())
 	case *CallNode:
 		return IsMatchingCodeIDWithCallee(codeIDOracle, n.Callee(), n.CallSite().(ssa.Node))
+	case *BuiltinCallNode:
+		return codeIDOracle(config.CodeIdentifier{Context: n.parent.Parent.String(), Method: n.name})
 	case *SyntheticNode:
 		return analysisutil.IsEntrypointNode(nil, n.Instr().(ssa.Node), codeIDOracle)
 	case *ReturnValNode, *ClosureNode, *BoundVarNode:

--- a/analysis/dataflow/flow_info.go
+++ b/analysis/dataflow/flow_info.go
@@ -161,8 +161,7 @@ func (fi *FlowInformation) GetInstrPos(i ssa.Instruction) IndexT {
 // representing this mark already exists.
 func (fi *FlowInformation) GetNewMark(node ssa.Node, typ MarkType, qualifier ssa.Value, mi MarkIndex) *Mark {
 	// Validate mark
-	switch typ {
-	case CallReturn:
+	if typ == CallReturn {
 		i, isCall := node.(*ssa.Call)
 		if isCall && mi.Kind == ReturnedTupleIndex {
 			ctyp := i.Common().Signature().Results()

--- a/analysis/dataflow/intra_procedural.go
+++ b/analysis/dataflow/intra_procedural.go
@@ -164,6 +164,7 @@ func (state *IntraAnalysisState) makeEdgesAtInstruction(_ int, instr ssa.Instruc
 // Those are the edges to and from call arguments and to and from the call Value.
 func (state *IntraAnalysisState) makeEdgesAtCallSite(callInstr ssa.CallInstruction) {
 	if isHandledBuiltinCall(callInstr) {
+		makeEdgesAtBuiltinCall(state, callInstr)
 		return
 	}
 	// add call node edges for call instructions whose Value corresponds to a function (i.e. the Method is nil)

--- a/analysis/dataflow/intra_procedural_instruction_ops.go
+++ b/analysis/dataflow/intra_procedural_instruction_ops.go
@@ -47,7 +47,7 @@ func (state *IntraAnalysisState) ChangedOnEndBlock() bool {
 
 // DoCall analyzes a ssa.Call
 func (state *IntraAnalysisState) DoCall(call *ssa.Call) {
-	state.callCommonMark(call, call, call.Common())
+	doBuiltinCall(state, call, call.Common(), call)
 }
 
 // DoDefer analyzes a ssa.Defer. Does nothing - defers are analyzed separately.
@@ -57,7 +57,7 @@ func (state *IntraAnalysisState) DoDefer(_ *ssa.Defer) {
 
 // DoGo analyses a go call like any function call. Use the escape analysis if you care about concurrency.
 func (state *IntraAnalysisState) DoGo(g *ssa.Go) {
-	state.callCommonMark(g.Value(), g, g.Common())
+	doBuiltinCall(state, g.Value(), g.Common(), g)
 }
 
 // DoDebugRef is a no-op
@@ -283,8 +283,7 @@ func (state *IntraAnalysisState) DoTypeAssert(x *ssa.TypeAssert) {
 }
 
 // DoMakeClosure analyzes closures using markClosureNode
-func (state *IntraAnalysisState) DoMakeClosure(x *ssa.MakeClosure) {
-	state.markClosureNode(x)
+func (state *IntraAnalysisState) DoMakeClosure(_ *ssa.MakeClosure) {
 }
 
 // DoPhi transfers marks from all incoming edges to the phi-value

--- a/analysis/dataflow/intra_procedural_test.go
+++ b/analysis/dataflow/intra_procedural_test.go
@@ -520,14 +520,14 @@ func TestFunctionSummaries(t *testing.T) {
 			for _, callee := range summary.Callees {
 				for _, call := range callee {
 					if call.FuncName() == "Source" {
-						hasIf := false
+						flowsToLen := false
 						for out := range call.Out() {
-							if _, ok := out.(*dataflow.IfNode); ok {
-								hasIf = true
+							if _, ok := out.(*dataflow.BuiltinCallNode); ok {
+								flowsToLen = true
 							}
 						}
-						if !hasIf {
-							t.Errorf("in ImplicitFlow, a call to Source() outgoing edge should be an if node")
+						if !flowsToLen {
+							t.Errorf("in ImplicitFlow, a call to Source() outgoing edge should be a bultin")
 						}
 					}
 				}
@@ -536,12 +536,12 @@ func TestFunctionSummaries(t *testing.T) {
 			for _, ifn := range summary.Ifs {
 				hasCallNodeIn := false
 				for in := range ifn.In() {
-					if call, ok := in.(*dataflow.CallNode); ok {
-						hasCallNodeIn = call.FuncName() == "Source"
+					if call, ok := in.(*dataflow.BuiltinCallNode); ok {
+						hasCallNodeIn = call.FuncName() == "len"
 					}
 				}
 				if !hasCallNodeIn {
-					t.Errorf("in ImplicitFlow, an if incoming edge should be a call to Source()")
+					t.Errorf("in ImplicitFlow, an if incoming edge should be a call to len")
 				}
 
 				if len(ifn.Out()) != 0 {

--- a/analysis/taint/dataflow_visitor.go
+++ b/analysis/taint/dataflow_visitor.go
@@ -580,7 +580,7 @@ func (v *Visitor) Visit(s *df.State, source df.NodeWithTrace) {
 		// Synthetic nodes can only be sources and data should only flow from those nodes: we only need to follow the
 		// outgoing edges. This node should only be a start node, unless some functionality is added to the df
 		// graph summaries.
-		case *df.SyntheticNode:
+		case *df.SyntheticNode, *df.BuiltinCallNode:
 			for nextNode, edgeInfos := range graphNode.Out() {
 				for _, edgeInfo := range edgeInfos {
 					nextNodeWithTrace := df.NodeWithTrace{

--- a/analysis/taint/testdata/sanitizers/config.yaml
+++ b/analysis/taint/testdata/sanitizers/config.yaml
@@ -17,3 +17,4 @@ dataflow-problems:
       sanitizers:
         - package: "(sanitizers)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
           method: ".*(s|S)anitize[1-9]?"
+        - method: "^len$" # len can also work as sanitizer: just don't put a package

--- a/analysis/taint/testdata/sanitizers/main.go
+++ b/analysis/taint/testdata/sanitizers/main.go
@@ -115,13 +115,18 @@ func Sanitize2(a A) A {
 
 func sanitizerExample6() {
 	a1 := A{
-		X: len(source1()), // @Source(ex6f1)
+		X: len(source1()), // len is a sanitizer
 		Y: source1(),      // @Source(ex6f2)
 	}
-	sink1(strconv.Itoa(a1.X)) // @Sink(ex6f1)
+	sink1(strconv.Itoa(a1.X))
 	a2 := Sanitize2(a1)
 	i, _ := strconv.Atoi(a2.Y)
 	sink1(i)
+}
+
+func sanitizerExampleLen() {
+	x := len(source1()) // len is a sanitizer
+	sink1(strconv.Itoa(x))
 }
 
 func main() {
@@ -132,4 +137,5 @@ func main() {
 	sanitizerExample4()
 	sanitizerExample5()
 	sanitizerExample6()
+	sanitizerExampleLen()
 }

--- a/analysis/version.go
+++ b/analysis/version.go
@@ -15,4 +15,4 @@
 package analysis
 
 // Version is the last tagged version of the analysis tool
-const Version = "v0.3.3"
+const Version = "v0.3.3-alpha"

--- a/doc/01_taint.md
+++ b/doc/01_taint.md
@@ -80,7 +80,8 @@ dataflow-problems:
         - package: "example1"
           method: "GetSensitiveData"
 ```
-specifies that the method `GetSensitiveData` in package `example1` is a source. This means that the result of calling that function is considered tainted data (and the arguments if the `source-taints-args` option is set to true). There are other possible code identifiers, for example one can view any object of a given type as sources:
+specifies that the method `GetSensitiveData` in package `example1` is a source. This means that the result of calling that function is considered tainted data (and the arguments if the `source-taints-args` option is set to true). The `method` field is generally just the function name; for example, you can even have a code identifier `method: "^len$"` that will exactly capture the len builtin, which could be useful if you want to specify that `len` is a sanitizer.
+There are other possible code identifiers, for example one can view any object of a given type as sources:
 ```yaml
 dataflow-problems:
   taint-tracking:


### PR DESCRIPTION
This PR adds explicit nodes for calls to builtins in the dataflow graph. The effect on dataflow of builtin nodes is still implemented directly in the intraprocedural analysis, but explicit builtin nodes allows user to specify, for example, that `len` can be seen as a sanitizer.

This also extracts some ssa value marking operations out of the monotone dataflow analysis loop. Those marking operations are now moved to initialization, which should result in minor performance improvements.
