### PR TITLE
Extending the IsStatic definition used by the backtrace analysis.

### DIFF
--- a/analysis/backtrace/backtrace.go
+++ b/analysis/backtrace/backtrace.go
@@ -872,12 +872,7 @@ func addTrace(v *Visitor, entrypoint *df.CallNodeArg, trace Trace) {
 func IsStatic(node df.GraphNode) bool {
 	switch node := node.(type) {
 	case *df.CallNodeArg:
-		switch node.Value().(type) {
-		case *ssa.Const:
-			return true
-		default:
-			return false
-		}
+		return lang.IsStaticallyDefinedLocal(node.Value())
 	default:
 		return false
 	}

--- a/analysis/backtrace/backtrace_test.go
+++ b/analysis/backtrace/backtrace_test.go
@@ -18,6 +18,7 @@ import (
 	"embed"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -537,9 +538,15 @@ func TestAnalyze_CheckStatic(t *testing.T) {
 	if len(res.Traces) != 1 {
 		t.Fatalf("expected a single entry point with a trace for check_static")
 	}
+	expected := regexp.MustCompile("Int.return.0.*math/rand/rand.go")
 	for _, traces := range res.Traces {
-		if len(traces) != 1 {
-			t.Fatalf("expected a single trace for check_static")
+		if len(traces) != 2 {
+			t.Fatalf("expected two traces for the entry point for check_static")
+		}
+		for _, trace := range traces {
+			if !expected.MatchString(trace[0].String()) {
+				t.Fatalf("Origin %s of trace doesn't match the expected %s", trace[0], expected)
+			}
 		}
 	}
 }

--- a/analysis/backtrace/testdata/check_static/main.go
+++ b/analysis/backtrace/testdata/check_static/main.go
@@ -25,6 +25,13 @@ import (
 	"regexp"
 )
 
+const somePredefinedPattern = "[a-zA-Z]+"
+const someOtherPattern = "[0-9]*"
+
+var initPattern = regexp.MustCompile(
+	fmt.Sprintf("{{\\s*((?:%s|%s)[\\w-./]+)\\s*}}", somePredefinedPattern, someOtherPattern),
+)
+
 func makesRegex(s string, s2 string) *regexp.Regexp {
 	regex := fmt.Sprintf("%s+%s", s, s2)
 	return regexp.MustCompile(regex)
@@ -39,9 +46,36 @@ func buildRegexWithNonConstant(s string) *regexp.Regexp {
 	return regexp.MustCompile(rval)
 }
 
+func makeRegexFromConst(s string) *regexp.Regexp {
+	pat := fmt.Sprintf("(%s)%s*", s, somePredefinedPattern)
+	return regexp.MustCompile(pat)
+}
+
+func makeRegexFromStaticArray() *regexp.Regexp {
+	x := [2]string{}
+	x[0] = "ok"
+	x[1] = "[A-Z]+"
+	return regexp.MustCompile(fmt.Sprintf("%s\\.%s", x[0], x[1]))
+}
+
+func makeRegexFromStaticArrayNotStaticData(s string) *regexp.Regexp {
+	a := [1]string{}
+	a[0] = fmt.Sprintf("%s-%d", s, rand.Int())
+	x := [2]string{}
+	x[0] = "ok"
+	x[1] = a[0]
+	return regexp.MustCompile(fmt.Sprintf("%s\\.%s", x[0], x[1]))
+}
+
 func main() {
 	regexp.MustCompile("ok")
 	buildRegex("ok")
 	makesRegex("ok", "good")
 	buildRegexWithNonConstant("bad")
+	makeRegexFromConst("ok")
+	makeRegexFromStaticArray()
+	makeRegexFromStaticArrayNotStaticData("test")
+	if initPattern.MatchString("test") {
+		fmt.Println("ok")
+	}
 }

--- a/analysis/version.go
+++ b/analysis/version.go
@@ -15,4 +15,4 @@
 package analysis
 
 // Version is the last tagged version of the analysis tool
-const Version = "v0.3.3-alpha"
+const Version = "v0.3.4-alpha"


### PR DESCRIPTION
This PR extends the function  `IsStatic` in the backtrace analysis that is used to analyze whether the endpoints of the dataflow paths are statically defined data.
This resolves a problem in which definitions like these:
```
const s1 = "foo"
const s2 = "bar"
var s = fmt.Sprintf("%s", s1, s2)
```
usage of `s1, s2` was not captured as "statically defined" because in the SSA form, `s1` and `s2` were grouped into an array first, and then a slice of the array was passed to `fmt.Sprintf`. 
