### PR TITLE
Fix field sensitivity

### DIFF
--- a/analysis/dataflow/function_summary_graph.go
+++ b/analysis/dataflow/function_summary_graph.go
@@ -30,6 +30,8 @@ import (
 	"golang.org/x/tools/go/ssa"
 )
 
+var allAccessPathFlow = map[string]map[string]bool{"*": {"": true}}
+
 // SummaryGraph is the function dataflow summary graph.
 type SummaryGraph struct {
 	// the unique ID of the summary
@@ -932,12 +934,12 @@ func (g *SummaryGraph) addParamEdgeByPos(src int, dest int) bool {
 			if outEdges == nil {
 				outEdges = make([]EdgeInfo, 0, 1)
 			}
-			srcArg.out[destArg] = append(outEdges, EdgeInfo{map[string]map[string]bool{}, 0, nil})
+			srcArg.out[destArg] = append(outEdges, EdgeInfo{allAccessPathFlow, 0, nil})
 
 			if destArg.in == nil {
 				destArg.in = make(map[GraphNode]EdgeInfo)
 			}
-			destArg.in[srcArg] = EdgeInfo{map[string]map[string]bool{}, 0, nil}
+			destArg.in[srcArg] = EdgeInfo{allAccessPathFlow, 0, nil}
 			return true
 		}
 	}
@@ -965,12 +967,12 @@ func (g *SummaryGraph) addReturnEdgeByPos(src int, pos int) bool {
 			if outEdges == nil {
 				outEdges = make([]EdgeInfo, 0, 1)
 			}
-			srcArg.out[retNode[pos]] = append(outEdges, EdgeInfo{map[string]map[string]bool{}, pos, nil})
+			srcArg.out[retNode[pos]] = append(outEdges, EdgeInfo{allAccessPathFlow, pos, nil})
 
 			if retNode[pos].in == nil {
 				retNode[pos].in = make(map[GraphNode]EdgeInfo)
 			}
-			retNode[pos].in[srcArg] = EdgeInfo{map[string]map[string]bool{}, pos, nil}
+			retNode[pos].in[srcArg] = EdgeInfo{allAccessPathFlow, pos, nil}
 			return true
 		}
 	}

--- a/analysis/dataflow/state.go
+++ b/analysis/dataflow/state.go
@@ -55,8 +55,6 @@ type State struct {
 	// BoundingInfo is a map from pointer labels to the closures that bind them. The bounding analysis produces such
 	// a map
 	BoundingInfo BoundingMap
-
-	reachableFunctions map[*ssa.Function]bool
 }
 
 // NewState generates a State from a PointerState
@@ -237,8 +235,8 @@ func (s *State) PopulateBoundingInformation(verbose bool) error {
 // IsReachableFunction returns true if f is reachable according to the pointer analysis, or if the pointer analysis
 // and ReachableFunctions has never been called.
 func (s *State) IsReachableFunction(f *ssa.Function) bool {
-	if s != nil && s.reachableFunctions != nil {
-		return s.reachableFunctions[f]
+	if s != nil && s.ReachableFunctions() != nil {
+		return s.ReachableFunctions()[f]
 	}
 	// If no reachability information has been computed, assume every function is reachable
 	s.Logger.Debugf("No reachability information has been computed")

--- a/analysis/summaries/standard_library.go
+++ b/analysis/summaries/standard_library.go
@@ -243,6 +243,7 @@ var summaryCrypto = map[string]Summary{
 	"crypto/x509.MarshalPKIXPublicKey": SingleVarArgPropagation,
 	"crypto/x509.ParsePKCS1PrivateKey": SingleVarArgPropagation,
 	"crypto/x509.SystemCertPool":       NoDataFlowPropagation,
+	"crypto/sha256.blockGeneric":       NoDataFlowPropagation,
 	"(crypto.Hash).New":                SingleVarArgPropagation,
 	"(*crypto/tls.Config).Clone":       SingleVarArgPropagation,
 	"(*crypto/x509.CertPool).AppendCertsFromPEM": {

--- a/analysis/taint/dataflow_visitor.go
+++ b/analysis/taint/dataflow_visitor.go
@@ -767,8 +767,11 @@ func (v *Visitor) addNext(s *df.State,
 			}
 		}
 	}
-	if len(edgeInfo.RelPath) == 0 || (len(edgeInfo.RelPath) == 1 && edgeInfo.RelPath[""][""]) {
+	if len(edgeInfo.RelPath) == 0 || len(edgeInfo.RelPath) == 1 && edgeInfo.RelPath[""][""] {
 		nextNodeAccessPaths = cur.AccessPaths
+	}
+	if len(edgeInfo.RelPath) == 1 && edgeInfo.RelPath["*"][""] {
+		nextNodeAccessPaths = []string{""}
 	}
 	// No matching access paths for this edge
 	if len(nextNodeAccessPaths) == 0 {

--- a/analysis/taint/testdata/fields/main.go
+++ b/analysis/taint/testdata/fields/main.go
@@ -477,6 +477,15 @@ func testGeneratingPayloadWithTaintedData() {
 	sink(fmt.Sprintf("%s-%s", payload.MessageId, strconv.Itoa(rand.Int()))) // @Sink(testGenPayload)
 }
 
+func testGeneratingPayloadWithTaintedDataThroughEncoding() {
+	taintedId := source() // @Source(testGenPayloadThroughEnc)
+	payload, err := generatePayload(log.Default(), "m-1423", taintedId, "hello")
+	if err != nil {
+		panic("error")
+	}
+	sink(fmt.Sprintf("%s", string(payload.Payload))) //@Sink(testGenPayloadThroughEnc)
+}
+
 func main() {
 	testSimpleField1()
 	testSimpleField2()
@@ -499,4 +508,5 @@ func main() {
 	testTaintStructAsValue()
 	testStructWithFuncs()
 	testGeneratingPayloadWithTaintedData()
+	testGeneratingPayloadWithTaintedDataThroughEncoding()
 }

--- a/analysis/version.go
+++ b/analysis/version.go
@@ -15,4 +15,4 @@
 package analysis
 
 // Version is the last tagged version of the analysis tool
-const Version = "v0.3.4-alpha"
+const Version = "v0.3.5-alpha"


### PR DESCRIPTION
A few fixes for the intra-procedural dataflow and taint analyses:
- fix type used to infer access paths of objects when adding marks,
- special access path for predefined summaries to overapproximate dataflows in the summarize functions,
- fix use of `ReachableFunctions` in the dataflow analysis state.