### PR TITLE
Add support for annotations in backtrace analysis

### DIFF
--- a/analysis/annotations/annotations.go
+++ b/analysis/annotations/annotations.go
@@ -42,6 +42,8 @@ const (
 	Sanitizer
 	// SetOptions is the kind of SetOptions(...) annotations
 	SetOptions
+	// BacktracePoint is the kind of BacktracePoint(...) annotations
+	BacktracePoint
 	// Ignore is an empty annotation for a line
 	Ignore
 )
@@ -76,11 +78,15 @@ var sanitizerRegex = regexp.MustCompile(`.*Sanitizer\(((?:\s*[\w\-]+\s*,?)+)\)`)
 // setOptionsRegex matches annotations of the form @Sanitizer(id1, id2, id3)"
 var setOptionsRegex = regexp.MustCompile(`.*SetOptions\(((?:\s*[\w\-]+=[\w\-]+\s*,?)+)\)`)
 
+// backtraceRegex matches annotations of the form @BacktracePoint(id1, id2, id3)"
+var backtraceRegex = regexp.MustCompile(`.*BacktracePoint\(((?:\s*[\w\-]+\s*,?)+)\)`)
+
 var annotationKindParsers = map[AnnotationKind]*regexp.Regexp{
 	Sink:       sinkRegex,
 	Source:     sourceRegex,
 	Sanitizer:  sanitizerRegex,
 	SetOptions: setOptionsRegex,
+	BacktracePoint: backtraceRegex,
 }
 
 // Annotation contains the parsed content from an annotation component: the kind of the annotation and its arguments

--- a/analysis/backtrace/testdata/annotations/config.json
+++ b/analysis/backtrace/testdata/annotations/config.json
@@ -1,0 +1,28 @@
+{
+  "options": {
+    "log-level": 4,
+    "analysis-options": {
+      "max-depth": 10
+    }
+  },
+  "dataflow-problems": {
+    "backtrace": [
+      {
+        "tag": "test1",
+        "points": [
+          {
+            "method": "sourceValue"
+          }
+        ]
+      },
+      {
+        "tag": "test2",
+        "points": [
+          {
+            "method": "modifyValue"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/analysis/backtrace/testdata/annotations/config.json
+++ b/analysis/backtrace/testdata/annotations/config.json
@@ -2,24 +2,16 @@
   "options": {
     "log-level": 4,
     "analysis-options": {
-      "max-depth": 10
+      "unsafe-max-depth": 10
     }
   },
   "dataflow-problems": {
-    "backtrace": [
+    "slicing": [
       {
         "tag": "test1",
-        "points": [
+        "backtracepoints": [
           {
-            "method": "sourceValue"
-          }
-        ]
-      },
-      {
-        "tag": "test2",
-        "points": [
-          {
-            "method": "modifyValue"
+            "method": "notInSourceOtherMethodsAreAnnotated"
           }
         ]
       }

--- a/analysis/backtrace/testdata/annotations/main.go
+++ b/analysis/backtrace/testdata/annotations/main.go
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+//argot:function BacktracePoint(test1)
+func sourceValue() int {
+	return rand.Int()
+}
+
+//argot:function BacktracePoint(test2)
+func modifyValue(x int) int {
+	return x * 2
+}
+
+func processValue(x int) int {
+	return modifyValue(x) + 1 // Should backtrace through this call
+}
+
+func main() {
+	val := sourceValue()        // @BacktracePoint(test1)
+	result := processValue(val) // Should backtrace through this
+	fmt.Printf("Result: %d\n", result)
+
+	directVal := modifyValue(42) // @BacktracePoint(test2)
+	fmt.Printf("Direct: %d\n", directVal)
+}

--- a/analysis/backtrace/testdata/annotations/main.go
+++ b/analysis/backtrace/testdata/annotations/main.go
@@ -19,12 +19,11 @@ import (
 	"math/rand"
 )
 
-//argot:function BacktracePoint(test1)
-func sourceValue() int {
+func slicingOrigin() int {
 	return rand.Int()
 }
 
-//argot:function BacktracePoint(test2)
+//argot:function BacktracePoint(test1)
 func modifyValue(x int) int {
 	return x * 2
 }
@@ -34,10 +33,9 @@ func processValue(x int) int {
 }
 
 func main() {
-	val := sourceValue()        // @BacktracePoint(test1)
+	val := slicingOrigin()      // @Source(test1)
 	result := processValue(val) // Should backtrace through this
 	fmt.Printf("Result: %d\n", result)
-
-	directVal := modifyValue(42) // @BacktracePoint(test2)
+	directVal := modifyValue(result) // @Sink(test1)
 	fmt.Printf("Direct: %d\n", directVal)
 }

--- a/analysis/dataflow/code_identifiers.go
+++ b/analysis/dataflow/code_identifiers.go
@@ -61,9 +61,11 @@ func IsBacktraceNode(state *State, ss *config.SlicingSpec, n ssa.Node) bool {
 	}
 
 	if ss == nil {
-		return analysisutil.IsEntrypointNode(state.PointerAnalysis, n, state.Config.IsSomeBacktracePoint)
+		return analysisutil.IsEntrypointNode(state.PointerAnalysis, n, state.Config.IsSomeBacktracePoint) ||
+			state.ResolveSsaNode(annotations.BacktracePoint, "_", n)
 	}
-	return analysisutil.IsEntrypointNode(state.PointerAnalysis, n, ss.IsBacktracePoint)
+	return analysisutil.IsEntrypointNode(state.PointerAnalysis, n, ss.IsBacktracePoint) ||
+		state.ResolveSsaNode(annotations.BacktracePoint, ss.Tag, n)
 }
 
 // IsSink returns true if the taint spec identifies n as a sink.


### PR DESCRIPTION
*Issue #, if available: Fixes #104*

*Description of changes: Adds support for annotations in backtrace analysis by adding the calls to state.ResolveSsaNode in analysis/dataflow/code_identifiers.go and the new backtrace annotations in analysis/annotations/annotations.go as outlined in #104
All local tests run OK 😄*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
