### PR TITLE
Filtering types at call edges to handle tuples better.

### DIFF
--- a/analysis/dataflow/code_identifiers.go
+++ b/analysis/dataflow/code_identifiers.go
@@ -16,6 +16,7 @@ package dataflow
 
 import (
 	"go/token"
+	"go/types"
 
 	"github.com/awslabs/ar-go-tools/analysis/annotations"
 	"github.com/awslabs/ar-go-tools/analysis/config"
@@ -119,6 +120,18 @@ func IsFiltered(s *State, ts *config.TaintSpec, n GraphNode) bool {
 		}
 		if f != nil && filter.Method != "" && filter.Package != "" {
 			if filter.MatchPackageAndMethod(f) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsFilteredType returns true if the type is filtered out by the taint analysis specification.
+func IsFilteredType(ts *config.TaintSpec, t types.Type) bool {
+	for _, filter := range ts.Filters {
+		if filter.Type != "" {
+			if filter.MatchType(t) {
 				return true
 			}
 		}

--- a/analysis/taint/dataflow_visitor.go
+++ b/analysis/taint/dataflow_visitor.go
@@ -430,6 +430,11 @@ func (v *Visitor) Visit(s *df.State, source df.NodeWithTrace) {
 			}
 			for nextNode, edgeInfos := range graphNode.Out() {
 				for _, edgeInfo := range edgeInfos {
+					// Filter outgoing edges with a type that is filtered by checking the index of the tuple
+					// The index is an edge property so we can't rely on the node being filtered out.
+					if df.IsFilteredType(v.taintSpec, lang.TryTupleIndexType(graphNode.Type(), edgeInfo.Index)) {
+						continue
+					}
 					nextNodeWithTrace := df.NodeWithTrace{
 						Node:         nextNode,
 						Trace:        trace,

--- a/analysis/taint/testdata/filters/config.yaml
+++ b/analysis/taint/testdata/filters/config.yaml
@@ -6,6 +6,9 @@ dataflow-problems:
         - package: "(filters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
           # Sources can be source1, source2, etc.
           method: "source[1-9]?"
+        - package: "(filters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+            # Sources can be source1, source2, etc.
+          method: "sourceErr"
       sinks:
         - package: "(filters)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
           # Similarly, sinks are sink1 sink2 sink2 ...

--- a/analysis/taint/testdata/filters/main.go
+++ b/analysis/taint/testdata/filters/main.go
@@ -31,6 +31,14 @@ func generateWithError() (string, error) {
 	}
 }
 
+func sourceError() (string, error) {
+	if rand.Int() > 20 {
+		return fmt.Sprintf("x-%d", rand.Int()), nil
+	} else {
+		return "ok", fmt.Errorf("generation failure")
+	}
+}
+
 func generateWithFlag() (string, bool) {
 	if rand.Int() > 20 {
 		return source(), false // @Source(gBool)
@@ -53,6 +61,15 @@ func testErrorFiltered() {
 	}
 	s := sanitize(b)
 	sink(s) // sanitized
+}
+
+// the config contains:
+// filters:
+//   - type: "error"
+func testErrorFilteredImmediate() {
+	s, e := sourceError() // @Source(sourceErr)
+	sink(e)               // error is filtered out
+	sink(s)               // @Sink(sourceErr)
 }
 
 // the config contains:
@@ -80,7 +97,7 @@ func doSth2(b bool, s string) {
 func main() {
 	testErrorFiltered()
 	testBoolFiltered()
-
+	testErrorFilteredImmediate()
 }
 
 func sink(_ ...any) {


### PR DESCRIPTION
This adds a filter check at the level of outgoing edges from a call node, where the tuple index information is present. This allows for more precise filtering. For example, if you specified that a function `source(...) (Value, error)` is a source but also specified that `error` values are filtered out of the dataflow tracking, this will now filter out using the second part of the output tuple of the calls to `source`. 
