### PR TITLE
Adding "platform" to the target specs to allow specifying a platform

### DIFF
--- a/analysis/config/config.go
+++ b/analysis/config/config.go
@@ -53,7 +53,7 @@ func LoadGlobal() (*Config, error) {
 type EscapeConfig struct {
 
 	// Functions controls behavior override, keyed by .String() (e.g. command-line-arguments.main,
-	// (*package.Type).Method, etc). A value of "summarize" means process normally, "unknown" is
+	// (*package.Type).Method, etc.). A value of "summarize" means process normally, "unknown" is
 	// treat as unanalyzed, and "noop" means calls are assumed to have no escape effect (and return
 	// nil if they have a pointer-like return).
 	Functions map[string]string `json:"functions"`
@@ -236,6 +236,8 @@ type TargetSpec struct {
 	Name string
 	// Files identifies the target's files
 	Files []string
+	// Platform identifies the target's platform
+	Platform string
 }
 
 // Options holds the global options for analyses
@@ -613,11 +615,19 @@ func (c Config) ExceedsMaxDepth(d int) bool {
 	return c.UnsafeMaxDepth > 0 && d > c.UnsafeMaxDepth
 }
 
+// TargetInfo is the information needed to build the target
+type TargetInfo struct {
+	// Files in the target
+	Files []string
+	// Platform of the target
+	Platform string
+}
+
 // GetTargetMap returns a map from target names to target files
-func (c Config) GetTargetMap() map[string][]string {
-	targets := map[string][]string{}
+func (c Config) GetTargetMap() map[string]TargetInfo {
+	targets := map[string]TargetInfo{}
 	for _, targetSpec := range c.Targets {
-		targets[targetSpec.Name] = targetSpec.Files
+		targets[targetSpec.Name] = TargetInfo{Files: targetSpec.Files, Platform: targetSpec.Platform}
 	}
 	return targets
 }

--- a/analysis/config/validation.go
+++ b/analysis/config/validation.go
@@ -20,6 +20,12 @@ import (
 	"github.com/awslabs/ar-go-tools/internal/funcutil"
 )
 
+// A list of supported Platforms. We may want to figure out how to get it programmatically, but this should suffice
+// for now.
+// A list of platforms can be found in src/go/build/syslist.go in your go installation source.
+// Alternatively, run go tool dist list, the output shows 'platforms/architecture' supported by go.
+var supportedPlatforms = []string{"linux", "darwin", "windows", "android", "ios", "freebsd", "netbsd", "openbsd"}
+
 // Validate validates the config and returns an error if there is some invalid setting
 func (c Config) Validate() error {
 	if err := c.checkTagsAreUnique(); err != nil {
@@ -29,6 +35,9 @@ func (c Config) Validate() error {
 		return err
 	}
 	if err := c.checkTargetsUniqueAndDefined(); err != nil {
+		return err
+	}
+	if err := c.checkTargetOsesAreValid(); err != nil {
 		return err
 	}
 	return nil
@@ -58,6 +67,15 @@ func (c Config) checkSeveritiesAreValid() error {
 			return fmt.Errorf(
 				"invalid severity label %s (not empty, \"CRITICAL\", \"HIGH\", \"MEDIUM\", or \"LOW\")",
 				taggedSpec.SpecSeverity())
+		}
+	}
+	return nil
+}
+
+func (c Config) checkTargetOsesAreValid() error {
+	for _, target := range c.Targets {
+		if target.Platform != "" && !funcutil.Contains(supportedPlatforms, target.Platform) {
+			return fmt.Errorf("platform %q in target %q is not supported", target.Platform, target.Name)
 		}
 	}
 	return nil

--- a/cmd/argot/backtrace/backtrace.go
+++ b/cmd/argot/backtrace/backtrace.go
@@ -72,16 +72,16 @@ func Run(flags tools.CommonFlags) error {
 	if err != nil {
 		return fmt.Errorf("failed to get backtrace targets: %s", err)
 	}
-	for targetName, targetFiles := range actualTargets {
+	for targetName, target := range actualTargets {
 		start := time.Now()
 		loadOptions := config.LoadOptions{
-			Platform:      "",
 			PackageConfig: nil,
 			BuildMode:     ssa.InstantiateGenerics,
 			LoadTests:     flags.WithTest,
+			Platform:      target.Platform,
 			ApplyRewrites: true,
 		}
-		c := config.NewState(cfg, targetName, targetFiles, loadOptions)
+		c := config.NewState(cfg, targetName, target.Files, loadOptions)
 		ptrState := result.Bind(loadprogram.NewState(c), ptr.NewState) // build pointer analysis info
 		state, err := result.Bind(ptrState, dataflow.NewState).Value()
 		if err != nil {

--- a/cmd/argot/dependencies/dependencies.go
+++ b/cmd/argot/dependencies/dependencies.go
@@ -104,12 +104,6 @@ func Run(flags Flags) error {
 		}
 	}
 
-	loadOptions := config.LoadOptions{
-		PackageConfig: nil,
-		BuildMode:     ssa.InstantiateGenerics,
-		LoadTests:     flags.withTest,
-		ApplyRewrites: true,
-	}
 	actualTargets, err := tools.GetTargets(cfg, tools.TargetReqs{
 		CmdlineArgs: flags.flagSet.Args(),
 		Tool:        config.DependenciesTool,
@@ -117,8 +111,15 @@ func Run(flags Flags) error {
 	if err != nil {
 		return fmt.Errorf("failed to get dependencies targets: %s", err)
 	}
-	for targetName, targetFiles := range actualTargets {
-		err = runTarget(cfg, targetName, targetFiles, loadOptions, flags)
+	for targetName, target := range actualTargets {
+		loadOptions := config.LoadOptions{
+			Platform:      target.Platform,
+			PackageConfig: nil,
+			BuildMode:     ssa.InstantiateGenerics,
+			LoadTests:     flags.withTest,
+			ApplyRewrites: true,
+		}
+		err = runTarget(cfg, targetName, target.Files, loadOptions, flags)
 		if err != nil {
 			return err
 		}

--- a/cmd/argot/syntactic/syntactic.go
+++ b/cmd/argot/syntactic/syntactic.go
@@ -76,8 +76,8 @@ func Run(flags tools.CommonFlags) error {
 	if err != nil {
 		return fmt.Errorf("failed to get syntactic targets: %s", err)
 	}
-	for targetName, targetFiles := range actualTargets {
-		report, err := runTarget(cfg, targetName, targetFiles, flags)
+	for targetName, target := range actualTargets {
+		report, err := runTarget(cfg, targetName, target.Files, target.Platform, flags)
 		if err != nil {
 			tmpLogger.Errorf("Analysis for %s failed: %s", targetName, err)
 			failCount += 1
@@ -96,13 +96,14 @@ func runTarget(
 	cfg *config.Config,
 	targetName string,
 	targetFiles []string,
+	targetPlatform string,
 	flags tools.CommonFlags,
 ) (*config.ReportInfo, error) {
 	loadOptions := config.LoadOptions{
 		BuildMode:     ssa.BuilderMode(0),
 		LoadTests:     flags.WithTest,
 		ApplyRewrites: true,
-		Platform:      "",
+		Platform:      targetPlatform,
 		PackageConfig: nil,
 	}
 	c := config.NewState(cfg, targetName, targetFiles, loadOptions)

--- a/cmd/argot/taint/taint.go
+++ b/cmd/argot/taint/taint.go
@@ -64,6 +64,7 @@ func NewFlags(args []string) (Flags, error) {
 			WithTest:   *flags.WithTest,
 			Tag:        *flags.Tag,
 			Targets:    *flags.Targets,
+			Platform:   *flags.Platform,
 		},
 		maxDepth: *maxDepth,
 		dryRun:   *dryRun,
@@ -107,14 +108,15 @@ func Run(flags Flags) error {
 		CmdlineArgs: flags.FlagSet.Args(),
 		Tag:         flags.Tag,
 		Targets:     flags.Targets,
+		Platform:    flags.Platform,
 		Tool:        config.TaintTool,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get taint targets: %s", err)
 	}
 	// Loop over every target of the taint analysis
-	for targetName, targetFiles := range actualTargets {
-		targetHasFlows, report, err := runTarget(cfg, targetName, targetFiles, flags)
+	for targetName, target := range actualTargets {
+		targetHasFlows, report, err := runTarget(cfg, targetName, target.Files, target.Platform, flags)
 		hasFlows = targetHasFlows || hasFlows
 		if err != nil {
 			return err
@@ -133,12 +135,14 @@ func runTarget(
 	cfg *config.Config,
 	targetName string,
 	targetFiles []string,
+	targetPlatform string,
 	flags Flags,
 ) (bool, *config.ReportInfo, error) {
 	loadOptions := config.LoadOptions{
 		PackageConfig: nil,
 		BuildMode:     ssa.InstantiateGenerics,
 		LoadTests:     flags.WithTest,
+		Platform:      targetPlatform,
 		ApplyRewrites: true,
 	}
 	// Starting the analysis

--- a/cmd/argot/tools/tools.go
+++ b/cmd/argot/tools/tools.go
@@ -34,6 +34,7 @@ type UnparsedCommonFlags struct {
 	Verbose    *bool
 	WithTest   *bool
 	Tag        *string
+	Platform   *string
 	Targets    *string
 }
 
@@ -47,6 +48,7 @@ func NewUnparsedCommonFlags(name config.ToolName) UnparsedCommonFlags {
 	withTest := cmd.Bool("with-test", false, "load tests during analysis")
 	tag := cmd.String("tag", "", "only analyze specific problem with tag")
 	target := cmd.String("targets", "", "only analyze specific target in config")
+	platform := cmd.String("platform", "", "only analyze specific platform")
 	cmd.Var((*buildutil.TagsFlag)(&build.Default.BuildTags), "build-tags", buildutil.TagsFlagDoc)
 	return UnparsedCommonFlags{
 		FlagSet:    cmd,
@@ -54,6 +56,7 @@ func NewUnparsedCommonFlags(name config.ToolName) UnparsedCommonFlags {
 		Verbose:    verbose,
 		WithTest:   withTest,
 		Tag:        tag,
+		Platform:   platform,
 		Targets:    target,
 	}
 }
@@ -69,6 +72,7 @@ type CommonFlags struct {
 	WithTest   bool
 	Tag        string
 	Targets    string
+	Platform   string
 }
 
 // NewCommonFlags returns a parsed flag set with a given name.
@@ -88,6 +92,7 @@ func NewCommonFlags(name config.ToolName, args []string, cmdUsage string) (Commo
 		WithTest:   *flags.WithTest,
 		Tag:        *flags.Tag,
 		Targets:    *flags.Targets,
+		Platform:   *flags.Platform,
 	}, nil
 }
 
@@ -142,6 +147,8 @@ type TargetReqs struct {
 	Tag string
 	// Targets is the options list of targets as a comma-separated string.
 	Targets string
+	// Platform is the optional platform passed to the tool
+	Platform string
 	// Tool is the tool name for this analysis.
 	Tool config.ToolName
 }
@@ -151,9 +158,9 @@ type TargetReqs struct {
 //
 // When args is not empty, only the target "" -> args is returned.
 // When the tool name is not recognized, all the targets in the config file are returned.
-func GetTargets(c *config.Config, reqs TargetReqs) (map[string][]string, error) {
+func GetTargets(c *config.Config, reqs TargetReqs) (map[string]config.TargetInfo, error) {
 	if len(reqs.CmdlineArgs) > 0 {
-		return map[string][]string{"": reqs.CmdlineArgs}, nil
+		return map[string]config.TargetInfo{"": {Files: reqs.CmdlineArgs, Platform: reqs.Platform}}, nil
 	}
 	allTargets := c.GetTargetMap()
 	if reqs.Targets != "" {
@@ -170,25 +177,32 @@ func GetTargets(c *config.Config, reqs TargetReqs) (map[string][]string, error) 
 	}
 	switch reqs.Tool {
 	case config.TaintTool:
-		return targets(c.TaintTrackingProblems, allTargets, reqs.Tag), nil
+		return targets(c.TaintTrackingProblems, allTargets, reqs.Tag, reqs.Platform), nil
 	case config.BacktraceTool:
-		return targets(c.SlicingProblems, allTargets, reqs.Tag), nil
+		return targets(c.SlicingProblems, allTargets, reqs.Tag, reqs.Platform), nil
 	case config.SyntacticTool:
-		return targets(c.SyntacticProblems.StructInitProblems, allTargets, reqs.Tag), nil
+		return targets(c.SyntacticProblems.StructInitProblems, allTargets, reqs.Tag, reqs.Platform), nil
 	default:
 		return allTargets, nil
 	}
 }
 
-func targets[T config.TaggedSpec](problems []T, allTargets map[string][]string, tag string) map[string][]string {
-	targets := map[string][]string{}
+func targets[T config.TaggedSpec](
+	problems []T,
+	allTargets map[string]config.TargetInfo,
+	tag string,
+	platform string,
+) map[string]config.TargetInfo {
+	targets := map[string]config.TargetInfo{}
 	for _, ttp := range problems {
 		if tag != "" && ttp.SpecTag() != tag {
 			continue
 		}
 		for _, target := range ttp.SpecTargets() {
 			if _, ok := allTargets[target]; ok {
-				targets[target] = allTargets[target]
+				if platform == "" || allTargets[target].Platform == platform {
+					targets[target] = allTargets[target]
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Targets can now optionally specify a platform. This is equivalent of adding `GOOS=platform` to built a specific target.