### PR TITLE
Adding -out flag to set output folder from cli.

### DIFF
--- a/analysis/backtrace/backtrace.go
+++ b/analysis/backtrace/backtrace.go
@@ -923,7 +923,7 @@ func isFiltered(ss *config.SlicingSpec, n df.GraphNode) bool {
 			}
 		}
 		if f != nil && filter.Method != "" && filter.Package != "" {
-			if filter.MatchPackageAndMethod(nil, f) {
+			if filter.MatchPackageAndMethod(f) {
 				return true
 			}
 		}

--- a/analysis/config/code_identifier.go
+++ b/analysis/config/code_identifier.go
@@ -226,15 +226,25 @@ func (cid *CodeIdentifier) MatchType(typ types.Type) bool {
 	return cid.Type == typ.String()
 }
 
-// MatchPackageAndMethod checks whether the function f matches the code identifier on the package and method fields and
+// MatchPackageAndMethodWithCaller checks whether the function f matches the code identifier on the package and method fields and
 // the context of the caller.
 // It is safe to call with nil values.
-func (cid *CodeIdentifier) MatchPackageAndMethod(caller *ssa.Function, f *ssa.Function) bool {
+func (cid *CodeIdentifier) MatchPackageAndMethodWithCaller(caller *ssa.Function, f *ssa.Function) bool {
 	if cid == nil {
 		return false
 	}
 	if caller != nil && cid.Context != "" &&
 		cid.computedRegexs != nil && !cid.computedRegexs.contextRegex.MatchString(caller.String()) {
+		return false
+	}
+	return cid.MatchPackageAndMethod(f)
+}
+
+// MatchPackageAndMethod checks whether the function f matches the code identifier on the package and method
+// fields.
+// It is safe to call with nil values.
+func (cid *CodeIdentifier) MatchPackageAndMethod(f *ssa.Function) bool {
+	if cid == nil {
 		return false
 	}
 	if f == nil {

--- a/analysis/config/config.go
+++ b/analysis/config/config.go
@@ -40,13 +40,21 @@ func SetGlobalConfig(filename string) {
 }
 
 // LoadGlobal loads the config file that has been set by SetGlobalConfig
-func LoadGlobal() (*Config, error) {
-	cfg, err := LoadFromFiles(configFile)
+func LoadGlobal(overrides *CmdLineOverrides) (*Config, error) {
+	cfg, err := LoadFromFiles(configFile, overrides)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load global config file %v: %v", configFile, err)
 	}
 
 	return cfg, err
+}
+
+// CmdLineOverrides groups all the config file options that can be overridden by command line arguments.
+type CmdLineOverrides struct {
+	// LogLevel can be overridden (by setting -verbose for example)
+	LogLevel int
+	// ReportsDir can be overridden (by setting -out <out-folder>)
+	ReportsDir string
 }
 
 // EscapeConfig holds the options relative to the escape analysis configuration
@@ -419,13 +427,13 @@ func errorMisconfigurationGracefully(errYaml, errXML, errJson error) error {
 // LoadFromFiles loads a full config from configFileName and the config file's
 // specified escape config file name, reading the files from disk.
 // If the escape config file name is empty, there will be no escape configuration.
-func LoadFromFiles(configFileName string) (*Config, error) {
+func LoadFromFiles(configFileName string, overrides *CmdLineOverrides) (*Config, error) {
 	cfgBytes, err := os.ReadFile(configFileName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file %s: %v", configFileName, err)
 	}
 
-	cfg, err := Load(configFileName, cfgBytes)
+	cfg, err := Load(configFileName, cfgBytes, overrides)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create config file: %v", err)
 	}
@@ -450,7 +458,7 @@ func LoadFromFiles(configFileName string) (*Config, error) {
 // Load constructs a configuration from a byte slice representing the config file.
 //
 //gocyclo:ignore
-func Load(filename string, configBytes []byte) (*Config, error) {
+func Load(filename string, configBytes []byte, cmdLineOverrides *CmdLineOverrides) (*Config, error) {
 	// Get absolute path to config. Other files in config will be relative to where the config is.
 	pathToConfig := filename
 	if !path.IsAbs(filename) {
@@ -470,15 +478,15 @@ func Load(filename string, configBytes []byte) (*Config, error) {
 	// If the project root is unspecified, then set to the directory of the config file
 	if cfg.ProjectRoot == "" {
 		cfg.root = path.Dir(pathToConfig)
-	} else if !path.IsAbs(cfg.ProjectRoot) {
+	} else if !filepath.IsAbs(cfg.ProjectRoot) {
 		// If it's not an absolute path, compute the absolute path
-		cfg.root = path.Join(path.Dir(pathToConfig), cfg.ProjectRoot)
+		cfg.root = filepath.Join(path.Dir(pathToConfig), cfg.ProjectRoot)
 	} else {
 		cfg.root = cfg.ProjectRoot
 	}
 
 	if cfg.ReportPaths || cfg.ReportSummaries || cfg.ReportCoverage || cfg.ReportNoCalleeSites {
-		if err := setReportsDir(cfg); err != nil {
+		if err := setReportsDir(cfg, cmdLineOverrides); err != nil {
 			return nil, fmt.Errorf("failed to set reports dir of config with filename %v: %v", pathToConfig, err)
 		}
 	}
@@ -486,6 +494,11 @@ func Load(filename string, configBytes []byte) (*Config, error) {
 	// If logLevel has not been specified (i.e. it is 0) set the default to Info
 	if cfg.LogLevel == 0 {
 		cfg.LogLevel = int(InfoLevel)
+	}
+
+	// is the log-level is overridden on the cmd line, set it
+	if cmdLineOverrides != nil && cmdLineOverrides.LogLevel > 0 {
+		cfg.LogLevel = cmdLineOverrides.LogLevel
 	}
 
 	// Set the UnsafeMaxDepth default if it is <= 0
@@ -587,7 +600,17 @@ func LoadEscape(c *Config, escapeConfigBytes []byte) error {
 	return nil
 }
 
-func setReportsDir(c *Config) error {
+func setReportsDir(c *Config, cmdLineOverride *CmdLineOverrides) error {
+	if cmdLineOverride != nil && cmdLineOverride.ReportsDir != "" {
+		err := os.Mkdir(cmdLineOverride.ReportsDir, 0750)
+		if err != nil && !os.IsExist(err) {
+			return fmt.Errorf("could not create reports dir passed on commandline, and it doesn't exist")
+		}
+		// no attempt is made to check the path is absolute or needs to be relative to root
+		c.ReportsDir = cmdLineOverride.ReportsDir
+		return nil
+	}
+
 	if c.ReportsDir == "" {
 		tmpdir, err := os.MkdirTemp(c.root, "*-report")
 		if err != nil {
@@ -604,7 +627,7 @@ func setReportsDir(c *Config) error {
 			reportFile.Close() // the file will be reopened as needed
 		}
 	} else {
-		c.ReportsDir = path.Join(c.root, c.ReportsDir)
+		c.ReportsDir = filepath.Join(c.root, c.ReportsDir)
 		err := os.Mkdir(c.ReportsDir, 0750)
 		if err != nil {
 			if !os.IsExist(err) {
@@ -627,7 +650,7 @@ func (c Config) Root() string {
 
 // RelPath returns the path of the filename path relative to the root
 func (c Config) RelPath(filename string) string {
-	return path.Join(c.root, filename)
+	return filepath.Join(c.root, filename)
 }
 
 // MatchPkgFilter returns true if the package name pkgname matches the package filter set in the config file. If no

--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -89,13 +89,13 @@ func mkConfig(sanitizers []CodeIdentifier, sinks []CodeIdentifier, sources []Cod
 	return *c
 }
 
-func loadFromTestDir(filename string) (string, *Config, error) {
+func loadFromTestDir(filename string, overrides *CmdLineOverrides) (string, *Config, error) {
 	filename = filepath.Join("testdata", filename)
 	b, err := testfsys.ReadFile(filename)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to read file %v: %v", filename, err)
 	}
-	config, err := Load(filename, b)
+	config, err := Load(filename, b, overrides)
 	if err != nil {
 		return filename, nil, fmt.Errorf("failed to load file %v: %v", filename, err)
 	}
@@ -107,7 +107,7 @@ func testLoadOneFile(t *testing.T, filename string, expected Config) {
 	if expected.LogLevel == 0 {
 		expected.LogLevel = int(InfoLevel)
 	}
-	configFileName, config, err := loadFromTestDir(filename)
+	configFileName, config, err := loadFromTestDir(filename, nil)
 	if err != nil {
 		t.Errorf("Error loading %q: %v", configFileName, err)
 	}
@@ -141,7 +141,7 @@ func TestLoadNonExistentFileReturnsError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read file %v: %v", name, err)
 	}
-	c, err := Load(name, b)
+	c, err := Load(name, b, nil)
 	if c != nil || err == nil {
 		t.Errorf("Expected error and nil value when trying to load non existent file.")
 	}
@@ -153,7 +153,7 @@ func TestLoadBadFormatFileReturnsError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read file %v: %v", name, err)
 	}
-	config, err := Load(name, b)
+	config, err := Load(name, b, nil)
 	if config != nil || err == nil {
 		t.Errorf("Expected error and nil value when trying to load a badly formatted file.")
 	}
@@ -165,7 +165,7 @@ func TestLoadDuplicateTagsReturnsError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read file %v: %v", name, err)
 	}
-	_, err = Load(name, b)
+	_, err = Load(name, b, nil)
 	if err == nil {
 		t.Fatalf("Expected error and nil value when trying to load a config with duplicate problem tags.")
 	}
@@ -180,7 +180,7 @@ func TestLoadInvalidSeverityReturnsError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read file %v: %v", name, err)
 	}
-	_, err = Load(name, b)
+	_, err = Load(name, b, nil)
 	if err == nil {
 		t.Fatalf("Expected error and nil value when trying to load a config with duplicate problem tags.")
 	}
@@ -190,14 +190,14 @@ func TestLoadInvalidSeverityReturnsError(t *testing.T) {
 }
 
 func TestLoadWithProjectRoot(t *testing.T) {
-	_, config, err := loadFromTestDir("test_project_root_loading.yaml")
+	_, config, err := loadFromTestDir("test_project_root_loading.yaml", nil)
 	if config == nil || err != nil {
 		t.Fatalf("encountered error when loading config with project root specified: %s", err)
 	}
 }
 
 func TestLoadWithUndefinedTargetReturnsError(t *testing.T) {
-	_, _, err := loadFromTestDir("config_undefined_target.yaml")
+	_, _, err := loadFromTestDir("config_undefined_target.yaml", nil)
 	if err == nil {
 		t.Fatalf("expected error when loading config with undefined target")
 	}
@@ -207,7 +207,7 @@ func TestLoadWithUndefinedTargetReturnsError(t *testing.T) {
 }
 
 func TestLoadVersionBefore_v0_3_0_Errors(t *testing.T) {
-	_, config, err := loadFromTestDir("config_before_v0_3_0.yaml")
+	_, config, err := loadFromTestDir("config_before_v0_3_0.yaml", nil)
 	if config != nil || err == nil {
 		t.Fatalf("Expected error and nil value when trying to load config with bad format")
 	}
@@ -216,7 +216,7 @@ func TestLoadVersionBefore_v0_3_0_Errors(t *testing.T) {
 		t.Errorf("Error message:\n%s\nshould contain %s", err, msg1)
 	}
 
-	_, configJson, errJson := loadFromTestDir("config_before_v0_3_0.json")
+	_, configJson, errJson := loadFromTestDir("config_before_v0_3_0.json", nil)
 	if configJson != nil || errJson == nil {
 		t.Fatalf("Expected error and nil value when trying to load config with bad format")
 	}
@@ -238,7 +238,7 @@ func TestLoadWithReports(t *testing.T) {
 }
 
 func TestLoadWithReportNoDirReturnsError(t *testing.T) {
-	_, config, err := loadFromTestDir("config_with_reports_bad_dir.yaml")
+	_, config, err := loadFromTestDir("config_with_reports_bad_dir.yaml", nil)
 	if config != nil || err == nil {
 		t.Errorf("Expected error and nil value when trying to load config with a report dir that has a non-existing" +
 			"directory name")
@@ -246,7 +246,7 @@ func TestLoadWithReportNoDirReturnsError(t *testing.T) {
 }
 
 func TestLoadWithNoSpecifiedReportsDir(t *testing.T) {
-	fileName, config, err := loadFromTestDir("config_with_reports_no_dir_spec.yaml")
+	fileName, config, err := loadFromTestDir("config_with_reports_no_dir_spec.yaml", nil)
 	if config == nil || err != nil {
 		t.Errorf("Could not load %q", fileName)
 		return
@@ -265,8 +265,27 @@ func TestLoadWithNoSpecifiedReportsDir(t *testing.T) {
 	os.Remove(config.ReportsDir)
 }
 
+func TestLoadWithReportsDirOverride(t *testing.T) {
+	reportsDir := "test-cmdline-dir"
+	fileName, config, err := loadFromTestDir("config_with_reports_dir.yaml", &CmdLineOverrides{
+		LogLevel:   0,
+		ReportsDir: reportsDir,
+	})
+	if config == nil || err != nil {
+		t.Errorf("Could not load %q", fileName)
+		return
+	}
+	if config.ReportsDir != reportsDir {
+		t.Errorf("Expected reports-dir to be %s after loading config %q with override, not %s",
+			reportsDir, fileName, config.ReportsDir)
+	}
+	// Remove temporary files
+	os.Remove(config.nocalleereportfile)
+	os.Remove(config.ReportsDir)
+}
+
 func TestLoadSyntacticConfigYaml(t *testing.T) {
-	fileName, config, err := loadFromTestDir("syntactic-config.yaml")
+	fileName, config, err := loadFromTestDir("syntactic-config.yaml", nil)
 	if config == nil || err != nil {
 		t.Errorf("could not load %s", fileName)
 		return
@@ -313,7 +332,7 @@ func TestLoadSyntacticConfigYaml(t *testing.T) {
 
 //gocyclo:ignore
 func TestLoadFullConfigYaml(t *testing.T) {
-	fileName, config, err := loadFromTestDir("full-config.yaml")
+	fileName, config, err := loadFromTestDir("full-config.yaml", nil)
 	if config == nil || err != nil {
 		t.Errorf("Could not load %s: %s", fileName, err)
 		return
@@ -403,8 +422,8 @@ func TestLoadFullConfigYaml(t *testing.T) {
 }
 
 func TestLoadFullConfigYamlEqualsJson(t *testing.T) {
-	_, yamlConfig, yamlErr := loadFromTestDir("full-config.yaml")
-	_, jsonConfig, jsonErr := loadFromTestDir("full-config.json")
+	_, yamlConfig, yamlErr := loadFromTestDir("full-config.yaml", nil)
+	_, jsonConfig, jsonErr := loadFromTestDir("full-config.json", nil)
 	if jsonErr != nil {
 		t.Fatalf("failed to load json config")
 	}

--- a/analysis/config/repr_drawio_test.go
+++ b/analysis/config/repr_drawio_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 func TestSimpleFlowWithOption(t *testing.T) {
-	_, config, err := loadFromTestDir("example.drawio.xml")
-	_, config2, err2 := loadFromTestDir("example.drawio.yaml")
+	_, config, err := loadFromTestDir("example.drawio.xml", nil)
+	_, config2, err2 := loadFromTestDir("example.drawio.yaml", nil)
 	if config == nil || err != nil || config2 == nil || err2 != nil {
 		t.Fatalf("error: %v, %v", err, err2)
 	}

--- a/analysis/config/testdata/config_with_reports_dir.yaml
+++ b/analysis/config/testdata/config_with_reports_dir.yaml
@@ -1,0 +1,4 @@
+options:
+    reports-dir: test
+    report-paths: true
+    report-no-callee-sites: true

--- a/analysis/dataflow/code_identifiers.go
+++ b/analysis/dataflow/code_identifiers.go
@@ -119,7 +119,7 @@ func IsFiltered(s *State, ts *config.TaintSpec, n GraphNode) bool {
 			f = n2.ParentNode().Callee()
 		}
 		if f != nil && filter.Method != "" && filter.Package != "" {
-			if filter.MatchPackageAndMethod(n.Graph().Parent, f) {
+			if filter.MatchPackageAndMethodWithCaller(n.Graph().Parent, f) {
 				return true
 			}
 		}

--- a/analysis/loadprogram/load_program_test.go
+++ b/analysis/loadprogram/load_program_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestLoadWithProjectRoot(t *testing.T) {
 	configFile := filepath.Join("testdata", "state_load_config.yaml")
-	cfg, err := tools.LoadConfig(configFile)
+	cfg, err := tools.LoadConfig(tools.CommonFlags{ConfigPath: configFile}, false)
 	if err != nil {
 		t.Fatalf("failed to load config")
 	}

--- a/analysis/syntactic/preconditions/precond_check.go
+++ b/analysis/syntactic/preconditions/precond_check.go
@@ -111,19 +111,30 @@ func analyzeSpec(state *ptr.State, spec config.CondCheckSpec) ([]token.Position,
 	return locs, nil
 }
 
+type resAndGuards struct {
+	res    bool
+	guards [][]string
+}
+
 func analyzeFunc(state *ptr.State, spec config.CondCheckSpec, f *ssa.Function) ([]token.Position, error) {
 	state.Logger.Infof("Checking %s which calls a function matching a call identified in %s",
 		f.Name(), spec.Tag)
 	var locs []token.Position
+
 	for _, blk := range f.Blocks {
-		guardStrs := computeBlockGuards(blk)
-		check := sync.OnceValue(func() bool { return checkGuard(spec, guardStrs) })
+		// Wrap in OnceValue to execute only once, and maybe never if no instruction requires a guard
+		check := sync.OnceValue(func() resAndGuards {
+			guardStrs := computeBlockGuards(blk)
+			res := checkGuard(spec, guardStrs)
+			return resAndGuards{res, guardStrs}
+		})
 		for _, instr := range blk.Instrs {
 			if instrRequiresGuard(state, spec, instr) {
 				state.Logger.Debugf("Check %s", instr)
-				if !check() {
+				c := check()
+				if !c.res {
 					state.Logger.Errorf("Preconditions not satisfied in call %s", instr)
-					state.Logger.Errorf("Preconditions is: %s", guardToString(guardStrs))
+					state.Logger.Errorf("Preconditions is: %s", guardToString(c.guards))
 					state.Logger.Errorf("Position: %s", state.Program.Fset.Position(instr.Pos()))
 					locs = append(locs, state.Program.Fset.Position(instr.Pos()))
 				} else {
@@ -207,6 +218,9 @@ func computePathCond(blocks []*ssa.BasicBlock) []string {
 	for i := 0; i < len(blocks)-1; i++ {
 		maybeCond := blockCond(blocks[i])
 		if maybeCond.IsSome() {
+			// Check which branch the next block corresponds to: if 0, the condition is true, otherwise it is false
+			// This is by construction of the SSA and branching blocks (note that maybeCond being some value guarantees
+			// that the i-th block is a branching block).
 			if blocks[i].Succs[0].Index == blocks[i+1].Index {
 				cond = append(cond, maybeCond.Value())
 			} else {
@@ -237,7 +251,7 @@ func instrRequiresGuard(state *ptr.State, spec config.CondCheckSpec, instr ssa.I
 	}
 	for callee := range callees {
 		if fn.Exists(spec.Call, func(c config.CodeIdentifier) bool {
-			return c.MatchPackageAndMethod(instr.Parent(), callee)
+			return c.MatchPackageAndMethodWithCaller(instr.Parent(), callee)
 		}) {
 			return true
 		}

--- a/analysis/syntactic/preconditions/testdata/func-cond/config.yaml
+++ b/analysis/syntactic/preconditions/testdata/func-cond/config.yaml
@@ -9,5 +9,6 @@ syntactic-problems:
         - method: ^FooFunc$
       preconditions: # either guard must hold when calling the function in call
         - precondition: ["!(ResourceCheck(...)#1 != nil:error)", "ResourceCheck(...)#0"]
+        - precondition: [ "ResourceCheck(...)#1 == nil:error", "ResourceCheck(...)#0"] # this is equivalent to above but we don't reason about atomic props
         - precondition: ["FooPreCheck(...)"]
         - precondition: ["Check(...)"]

--- a/analysis/syntactic/preconditions/testdata/func-cond/main.go
+++ b/analysis/syntactic/preconditions/testdata/func-cond/main.go
@@ -166,6 +166,84 @@ func callFooWrongCheckInLoop() {
 	}
 }
 
+func callFooCheckInLoopWithContinue() {
+	for i := 0; i < rand.Int(); i++ {
+		b, e := ResourceCheck()
+		if !b || e != nil {
+			continue
+		}
+		FooFunc(G{}) // Fine because of the continue statement
+	}
+}
+
+func callFooCheckInLoopWithBreak() {
+	for i := 0; i < rand.Int(); i++ {
+		b, e := ResourceCheck()
+		if !b || e != nil {
+			break
+		}
+		FooFunc(G{}) // Fine because of the break statement
+	}
+}
+
+func callFooCheckInLoopWithBreakLabelled() {
+OUTERLOOP:
+	for i := 0; i < rand.Int(); i++ {
+		for j := 0; j < rand.Int(); j++ {
+			b, e := ResourceCheck()
+			if !b || e != nil {
+				break OUTERLOOP
+			}
+			FooFunc(G{}) // Breaking out of enclosing loop is also fine
+		}
+		// Some paths don't satisfy the condition here
+		FooFunc(G{}) // @InvalidCall(funcCond)
+	}
+}
+
+func callFooCheckInLoopWithContinueAndBreakWrongCheck() {
+	for i := 0; i < rand.Int(); i++ {
+		b, e := ResourceCheck()
+		if !b {
+			break
+		}
+		if e == nil { // wrong check
+			continue
+		}
+		FooFunc(G{}) // @InvalidCall(funcCond)
+	}
+}
+
+func callFooCheckInLoopWithCrazyGoto() {
+	for i := 0; i < rand.Int(); i++ {
+		b, e := ResourceCheck()
+		if !b {
+			break
+		}
+		if e == nil {
+			goto FINISH
+		}
+	}
+	return
+FINISH:
+	FooFunc(G{})
+}
+
+func callFooCheckInLoopWithCrazyGotoWrongCheck() {
+	for i := 0; i < rand.Int(); i++ {
+		b, e := ResourceCheck()
+		if b {
+			break
+		}
+		if e == nil {
+			goto FINISH
+		}
+	}
+	return
+FINISH:
+	FooFunc(G{}) // @InvalidCall(funcCond)
+}
+
 func callFooInSelect(input1, input2 chan int, done chan bool, timeout time.Duration) {
 	timer := time.NewTimer(timeout)
 
@@ -208,7 +286,13 @@ func main() {
 	callFooCheckedWithInterface(G{})
 	callFooResourceCheckTwoConds()
 	callFooResourceCheckTwoCondsSwap()
+	callFooCheckInLoopWithBreak()
+	callFooCheckInLoopWithBreakLabelled()
+	callFooCheckInLoopWithContinue()
+	callFooCheckInLoopWithContinueAndBreakWrongCheck()
 	callFooResourceCheckTwoCondsRev()
+	callFooCheckInLoopWithCrazyGoto()
+	callFooCheckInLoopWithCrazyGotoWrongCheck()
 	callFooResourceCheckTwoCondsWrong()
 	callFooDoubleChecked()
 	callFooCheckInLoop()

--- a/analysis/syntactic/structinit/structinit.go
+++ b/analysis/syntactic/structinit/structinit.go
@@ -725,7 +725,7 @@ func findMethod(program *ssa.Program, valCi config.CodeIdentifier) (*ssa.Functio
 	for _, pkg := range pkgs {
 		for _, mem := range pkg.Members {
 			if f, ok := mem.(*ssa.Function); ok {
-				if valCi.MatchPackageAndMethod(nil, f) && f != nil {
+				if valCi.MatchPackageAndMethod(f) && f != nil {
 					return f, true
 				}
 			}
@@ -787,7 +787,7 @@ func isFiltered(spec config.StructInitSpec, f *ssa.Function) bool {
 		}
 
 		if filter.Method != "" && filter.Package != "" {
-			if filter.MatchPackageAndMethod(nil, f) {
+			if filter.MatchPackageAndMethod(f) {
 				return true
 			}
 		}

--- a/cmd/argot/backtrace/backtrace.go
+++ b/cmd/argot/backtrace/backtrace.go
@@ -39,18 +39,13 @@ Usage:
 
 // Run runs the backtrace analysis on flags.
 func Run(flags tools.CommonFlags) error {
-	cfg, err := tools.LoadConfig(flags.ConfigPath)
+	cfg, err := tools.LoadConfig(flags, false)
 	if err != nil {
 		return fmt.Errorf("failed to load config file: %v", err)
 	}
 	tmpLogger := config.NewLogGroup(cfg)
 	tmpLogger.Infof(formatutil.Faint("Argot backtrace tool - " + analysis.Version))
 
-	// Override config parameters with command-line parameters
-	if flags.Verbose {
-		tmpLogger.Infof("verbose command line flag overrides config file log-level %d", cfg.LogLevel)
-		cfg.LogLevel = int(config.DebugLevel)
-	}
 	if flags.Tag != "" {
 		tmpLogger.Infof("tag specified on command-line, will analyze only problem with tag \"%s\"", flags.Tag)
 	}

--- a/cmd/argot/cli/cli.go
+++ b/cmd/argot/cli/cli.go
@@ -128,7 +128,7 @@ func seekConfig(configPath string, args []string) (*config.Config, bool, error) 
 	pConfig := config.NewDefault()
 	if configPath != "" {
 		config.SetGlobalConfig(configPath)
-		pConfig, err = config.LoadGlobal()
+		pConfig, err = config.LoadGlobal(nil)
 		state.ConfigPath = configPath
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "could not load config %q\n", configPath)
@@ -149,7 +149,7 @@ func seekConfig(configPath string, args []string) (*config.Config, bool, error) 
 func attemptSettingConfig(pConfig **config.Config, dir string, filename string) error {
 	configFile := path.Join(dir, filename)
 	config.SetGlobalConfig(configFile)
-	tmpConfig, err := config.LoadGlobal()
+	tmpConfig, err := config.LoadGlobal(nil)
 	if err != nil {
 		// Reset and ignore
 		config.SetGlobalConfig("")

--- a/cmd/argot/cli/program.go
+++ b/cmd/argot/cli/program.go
@@ -120,11 +120,11 @@ func cmdReconfig(tt *term.Terminal, c *dataflow.State, command Command, _ bool) 
 
 	if len(command.Args) < 1 {
 		// No arguments: reload the current config file.
-		newConfig, err = config.LoadGlobal()
+		newConfig, err = config.LoadGlobal(nil)
 	} else {
 		// Argument specified: set state.ConfigPath to the new config file's path, if the file exists
 		filename := strings.TrimSpace(command.Args[0])
-		newConfig, err = config.LoadFromFiles(filename)
+		newConfig, err = config.LoadFromFiles(filename, nil)
 		if err == nil {
 			config.SetGlobalConfig(filename)
 			state.ConfigPath = filename

--- a/cmd/argot/compare/compare.go
+++ b/cmd/argot/compare/compare.go
@@ -104,8 +104,9 @@ func Run(flags Flags) error {
 	}
 
 	var cfg *config.Config
-	if err := setConfig(flags.ConfigPath, &cfg); err != nil {
-		return fmt.Errorf("error setting config: %v", err)
+	cfg, err := tools.LoadConfig(flags.CommonFlags, true)
+	if err != nil {
+		return fmt.Errorf("error loading config: %v", err)
 	}
 	fmt.Fprintf(os.Stderr, formatutil.Faint("Reading sources")+"\n")
 	loadOptions := config.LoadOptions{
@@ -149,24 +150,6 @@ func Run(flags Flags) error {
 		reportUncoveredDynamicEdges(state.Program, cg, callsites)
 	}
 
-	return nil
-}
-
-func setConfig(configPath string, cfg **config.Config) error {
-	// check that the pointer to pointer is non-nil, because we'll dereference it
-	if cfg == nil {
-		return nil
-	}
-	if configPath == "" {
-		fmt.Fprintf(os.Stderr, "config path empty: loading default config")
-		*cfg = config.NewDefault()
-	} else {
-		var err error
-		*cfg, err = config.LoadFromFiles(configPath)
-		if err != nil {
-			return fmt.Errorf("failed to load config from file %s", configPath)
-		}
-	}
 	return nil
 }
 

--- a/cmd/argot/dependencies/dependencies.go
+++ b/cmd/argot/dependencies/dependencies.go
@@ -46,7 +46,7 @@ Examples:
 
 // Flags represents the flags for the dependencies sub-command.
 type Flags struct {
-	configPath     string
+	common         tools.CommonFlags
 	coverPath      string
 	graphPath      string
 	csvPath        string
@@ -54,7 +54,6 @@ type Flags struct {
 	includeStdlib  bool
 	usageThreshold float64
 	locThreshold   int
-	withTest       bool
 	flagSet        *flag.FlagSet
 }
 
@@ -78,7 +77,10 @@ func NewFlags(args []string) (Flags, error) {
 	}
 
 	return Flags{
-		configPath:     *configPath,
+		common: tools.CommonFlags{
+			ConfigPath: *configPath,
+			WithTest:   *withTest,
+		},
 		coverPath:      *coverPath,
 		graphPath:      *graphPath,
 		csvPath:        *csvPath,
@@ -86,22 +88,15 @@ func NewFlags(args []string) (Flags, error) {
 		includeStdlib:  *includeStdlib,
 		usageThreshold: *usageThreshold,
 		locThreshold:   *locThreshold,
-		withTest:       *withTest,
 		flagSet:        cmd,
 	}, nil
 }
 
 // Run runs the analysis.
 func Run(flags Flags) error {
-	var err error
-	var cfg *config.Config
-	if flags.configPath == "" {
-		cfg = config.NewDefault()
-	} else {
-		cfg, err = config.LoadFromFiles(flags.configPath)
-		if err != nil {
-			return fmt.Errorf("failed to load config %s: %s", flags.configPath, err)
-		}
+	cfg, err := tools.LoadConfig(flags.common, true)
+	if err != nil {
+		return fmt.Errorf("failed to load config file: %v", err)
 	}
 
 	actualTargets, err := tools.GetTargets(cfg, tools.TargetReqs{
@@ -116,7 +111,7 @@ func Run(flags Flags) error {
 			Platform:      target.Platform,
 			PackageConfig: nil,
 			BuildMode:     ssa.InstantiateGenerics,
-			LoadTests:     flags.withTest,
+			LoadTests:     flags.common.WithTest,
 			ApplyRewrites: true,
 		}
 		err = runTarget(cfg, targetName, target.Files, loadOptions, flags)

--- a/cmd/argot/reachability/reachability.go
+++ b/cmd/argot/reachability/reachability.go
@@ -81,7 +81,7 @@ func Run(flags Flags) error {
 	if flags.ConfigPath == "" {
 		cfg = config.NewDefault()
 	} else {
-		cfg, err = config.LoadFromFiles(flags.ConfigPath)
+		cfg, err = tools.LoadConfig(flags.CommonFlags, true)
 		if err != nil {
 			return fmt.Errorf("failed to load config %s: %s", flags.ConfigPath, err)
 		}

--- a/cmd/argot/render/frontend.go
+++ b/cmd/argot/render/frontend.go
@@ -105,7 +105,7 @@ func Run(flags Flags) error {
 	renderConfig := config.NewDefault() // empty default config
 	if flags.ConfigPath != "" {
 		config.SetGlobalConfig(flags.ConfigPath)
-		renderConfig, err = config.LoadGlobal()
+		renderConfig, err = config.LoadGlobal(nil)
 		if err != nil {
 			return fmt.Errorf("could not load config %q", flags.ConfigPath)
 		}

--- a/cmd/argot/syntactic/syntactic.go
+++ b/cmd/argot/syntactic/syntactic.go
@@ -38,18 +38,11 @@ Examples:
 
 // Run runs the syntactic analyses.
 func Run(flags tools.CommonFlags) error {
-	cfg, err := tools.LoadConfig(flags.ConfigPath)
+	cfg, err := tools.LoadConfig(flags, false)
 	if err != nil {
 		return err
 	}
 	tmpLogger := config.NewLogGroup(cfg)
-
-	// Override config parameters with command-line parameters
-	if flags.Verbose {
-		tmpLogger.Infof("verbose command line flag overrides config file log-level %d", cfg.LogLevel)
-		cfg.LogLevel = int(config.DebugLevel)
-		tmpLogger = config.NewLogGroup(cfg)
-	}
 
 	if len(cfg.SyntacticProblems.StructInitProblems) == 0 && len(cfg.SyntacticProblems.CondCheckSpecs) == 0 {
 		tmpLogger.Warnf("No syntactic problems in config file.")

--- a/cmd/argot/taint/taint.go
+++ b/cmd/argot/taint/taint.go
@@ -65,6 +65,7 @@ func NewFlags(args []string) (Flags, error) {
 			Tag:        *flags.Tag,
 			Targets:    *flags.Targets,
 			Platform:   *flags.Platform,
+			Out:        *flags.Out,
 		},
 		maxDepth: *maxDepth,
 		dryRun:   *dryRun,
@@ -73,18 +74,13 @@ func NewFlags(args []string) (Flags, error) {
 
 // Run runs the taint analysis with flags.
 func Run(flags Flags) error {
-	cfg, err := tools.LoadConfig(flags.ConfigPath)
+	cfg, err := tools.LoadConfig(flags.CommonFlags, false)
 	if err != nil {
 		return err
 	}
 	tmpLogger := config.NewLogGroup(cfg)
 	tmpLogger.Infof(formatutil.Faint("Argot taint tool - " + analysis.Version))
 	// Override config parameters with command-line parameters
-	if flags.Verbose {
-		tmpLogger.Infof("verbose command line flag overrides config file log-level %d", cfg.LogLevel)
-		cfg.LogLevel = int(config.DebugLevel)
-		tmpLogger = config.NewLogGroup(cfg)
-	}
 	if flags.maxDepth > 0 {
 		cfg.UnsafeMaxDepth = flags.maxDepth
 		tmpLogger.Warnf("%s %d\n", "UNSAFE config max data-flow depth set to: %s", flags.maxDepth)

--- a/cmd/argot/tools/tools.go
+++ b/cmd/argot/tools/tools.go
@@ -32,6 +32,7 @@ type UnparsedCommonFlags struct {
 	FlagSet    *flag.FlagSet
 	ConfigPath *string
 	Verbose    *bool
+	Out        *string
 	WithTest   *bool
 	Tag        *string
 	Platform   *string
@@ -49,6 +50,7 @@ func NewUnparsedCommonFlags(name config.ToolName) UnparsedCommonFlags {
 	tag := cmd.String("tag", "", "only analyze specific problem with tag")
 	target := cmd.String("targets", "", "only analyze specific target in config")
 	platform := cmd.String("platform", "", "only analyze specific platform")
+	out := cmd.String("out", "", "override the output folder of the config")
 	cmd.Var((*buildutil.TagsFlag)(&build.Default.BuildTags), "build-tags", buildutil.TagsFlagDoc)
 	return UnparsedCommonFlags{
 		FlagSet:    cmd,
@@ -58,13 +60,14 @@ func NewUnparsedCommonFlags(name config.ToolName) UnparsedCommonFlags {
 		Tag:        tag,
 		Platform:   platform,
 		Targets:    target,
+		Out:        out,
 	}
 }
 
 // CommonFlags represents a parsed CLI sub-command flags.
 // E.g., for the command `argot taint ...`, "taint" is the sub-command.
 // This is only for sub-commands that have common flags
-// (config, verbose, with-test, and build-tags).
+// (config, verbose, with-test, out and build-tags).
 type CommonFlags struct {
 	FlagSet    *flag.FlagSet
 	ConfigPath string
@@ -73,6 +76,7 @@ type CommonFlags struct {
 	Tag        string
 	Targets    string
 	Platform   string
+	Out        string
 }
 
 // NewCommonFlags returns a parsed flag set with a given name.
@@ -93,6 +97,7 @@ func NewCommonFlags(name config.ToolName, args []string, cmdUsage string) (Commo
 		Tag:        *flags.Tag,
 		Targets:    *flags.Targets,
 		Platform:   *flags.Platform,
+		Out:        *flags.Out,
 	}, nil
 }
 
@@ -125,15 +130,32 @@ func (e *ExcludePaths) Set(value string) error {
 	return nil
 }
 
-// LoadConfig loads the config file from configPath.
-func LoadConfig(configPath string) (*config.Config, error) {
-	if configPath == "" {
+// LoadConfig loads the config file from the common flags. The flags parameter specifies where the config is and
+// possible overrides on the command line. The returnDefaultIfNoPath parameter signals whether the function should
+// return a "default" config when the path a config file is not specified.
+func LoadConfig(flags CommonFlags, returnDefaultIfNoPath bool) (*config.Config, error) {
+	if flags.ConfigPath == "" {
+		if returnDefaultIfNoPath {
+			fmt.Fprintf(os.Stderr, "config path empty: loading default config")
+			return config.NewDefault(), nil
+		}
 		return nil, fmt.Errorf("file not specified")
 	}
-	config.SetGlobalConfig(configPath)
-	cfg, err := config.LoadGlobal()
+	config.SetGlobalConfig(flags.ConfigPath)
+
+	// Override config parameters with command-line parameters
+	overrides := &config.CmdLineOverrides{
+		LogLevel:   0,
+		ReportsDir: flags.Out,
+	}
+	if flags.Verbose {
+		fmt.Printf("verbose command line flag overrides config file log-level")
+		overrides.LogLevel = int(config.DebugLevel)
+	}
+	cfg, err := config.LoadGlobal(overrides)
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to load config file %s: %v", configPath, err)
+		return nil, fmt.Errorf("failed to load config file %s: %v", flags.ConfigPath, err)
 	}
 
 	return cfg, nil

--- a/internal/analysistest/analysistest.go
+++ b/internal/analysistest/analysistest.go
@@ -107,11 +107,11 @@ func LoadTest(
 
 	// Look for a yaml config file first
 	configFileName := filepath.Join(dir, "config.yaml")
-	cfg, err := config.LoadFromFiles(configFileName)
+	cfg, err := config.LoadFromFiles(configFileName, nil)
 	if err != nil {
 		// Look for a json config file if the yaml couldn't be loaded
 		configFileNameJson := filepath.Join(dir, "config.json")
-		cfgJson, errJson := config.LoadFromFiles(configFileNameJson)
+		cfgJson, errJson := config.LoadFromFiles(configFileNameJson, nil)
 		if errJson != nil {
 			return result.Err[loadprogram.State](
 				fmt.Errorf("failed to read config file %v (%v) and %v (%v)",


### PR DESCRIPTION
This PR adds a `-out` flag to the common flag. This allows users to specify the output folder for the analyses from the command line as opposed to the config file, so that different output folders can be used depending on the environment without having to change the config file.