### PR TITLE
Fix misuse of reachable functions instead of all functions in cli list

### DIFF
--- a/cmd/argot/cli/defs.go
+++ b/cmd/argot/cli/defs.go
@@ -23,6 +23,7 @@ import (
 	"github.com/awslabs/ar-go-tools/analysis/dataflow"
 	"golang.org/x/term"
 	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
 )
 
 const (
@@ -96,7 +97,7 @@ func funcsMatchingCommand(tt *term.Terminal, c *dataflow.State, command Command)
 
 func findFunc(c *dataflow.State, target *regexp.Regexp) []*ssa.Function {
 	var funcs []*ssa.Function
-	for f := range c.ReachableFunctions() {
+	for f := range ssautil.AllFunctions(c.Program) {
 		if target.MatchString(f.String()) {
 			funcs = append(funcs, f)
 		}


### PR DESCRIPTION
Fixes a small problem where the `list` command of the cli was showing only reachable functions even without the `-r` flag.
Now it does:
<img width="451" alt="Screenshot 2025-01-22 at 3 44 41 PM" src="https://github.com/user-attachments/assets/ae2229ba-836f-4d48-ae75-cecfc446d281" />
