### PR TITLE
Adding src command to argot cli to show source code.

### DIFF
--- a/.github/workflows/license-scanning.yml
+++ b/.github/workflows/license-scanning.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
@@ -34,7 +34,7 @@ jobs:
         run: |
           go-licenses report --include_tests ./analysis ./internal/* ./cmd/* > licenses_report.csv
       - name: Archive license report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: licenses-report
           retention-days: 3

--- a/cmd/argot/cli/analysis.go
+++ b/cmd/argot/cli/analysis.go
@@ -17,6 +17,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"go/printer"
 	"os"
 	"os/exec"
 	"regexp"
@@ -29,6 +30,7 @@ import (
 	"github.com/awslabs/ar-go-tools/analysis/render"
 	"github.com/awslabs/ar-go-tools/analysis/summaries"
 	"github.com/awslabs/ar-go-tools/analysis/taint"
+	"github.com/awslabs/ar-go-tools/internal/formatutil"
 	ftu "github.com/awslabs/ar-go-tools/internal/formatutil"
 	"github.com/awslabs/ar-go-tools/internal/funcutil"
 	"golang.org/x/term"
@@ -212,6 +214,58 @@ func cmdSummary(tt *term.Terminal, c *dataflow.State, command Command, _ bool) b
 			WriteSuccess(tt, "No summaries found. Consider building summaries (summarize).")
 		} else {
 			WriteSuccess(tt, "No matching functions.")
+		}
+	}
+	return false
+}
+
+// cmdShowSource prints the source (AST representation) of all the functions matching a given regex
+func cmdSrc(tt *term.Terminal, c *dataflow.State, command Command, withTest bool) bool {
+	if c == nil {
+		writeFmt(tt, "\t- %s%s%s : print the source code of a function.\n"+
+			"\t  src regex prints the AST representation of the function matching the regex\n"+
+			"\t  Example:\n", tt.Escape.Blue, cmdSrcName, tt.Escape.Reset)
+		writeFmt(tt, "\t  > %s command-line-arguments.main\n", cmdSrcName)
+		return false
+	}
+
+	if len(command.Args) < 1 {
+		if state.CurrentFunction != nil {
+			astNode := state.CurrentFunction.Syntax()
+			if astNode == nil {
+				WriteErr(tt, "%s has no syntax.", formatutil.Bold(state.CurrentFunction.String()))
+			} else {
+				WriteSuccess(tt, "<<< Source for %s", formatutil.Bold(state.CurrentFunction.String()))
+				printer.Fprint(tt, c.Program.Fset, astNode)
+				writeFmt(tt, "\n")
+				WriteSuccess(tt, "End of source for %s >>>", state.CurrentFunction.String())
+				writeFmt(tt, "\n")
+			}
+
+		} else {
+			WriteErr(tt, "Need at least one function to show source for.")
+			cmdSrc(tt, nil, command, withTest)
+		}
+
+		return false
+	}
+	target, err := regexp.Compile(command.Args[0])
+	if err != nil {
+		regexErr(tt, command.Args[0], err)
+		return false
+	}
+
+	funcs := findFunc(c, target)
+	for _, f := range funcs {
+		astNode := f.Syntax()
+		if astNode == nil {
+			WriteErr(tt, "%s has no syntax.", formatutil.Bold(f.String()))
+		} else {
+			WriteSuccess(tt, "<<< Source for %s", formatutil.Bold(f.String()))
+			printer.Fprint(tt, c.Program.Fset, astNode)
+			writeFmt(tt, "\n")
+			WriteSuccess(tt, "End of source for %s >>>", f.String())
+			writeFmt(tt, "\n")
 		}
 	}
 	return false

--- a/cmd/argot/cli/cli.go
+++ b/cmd/argot/cli/cli.go
@@ -60,6 +60,7 @@ var commands = map[string]func(tt *term.Terminal, s *dataflow.State, command Com
 	cmdShowSsaName:      cmdShowSsa,
 	cmdShowEscapeName:   cmdShowEscape,
 	cmdShowDataflowName: cmdShowDataflow,
+	cmdSrcName:          cmdSrc,
 	cmdSsaInstrName:     cmdSsaInstr,
 	cmdSsaValueName:     cmdSsaValue,
 	cmdStateName:        cmdState,

--- a/cmd/argot/cli/defs.go
+++ b/cmd/argot/cli/defs.go
@@ -47,6 +47,7 @@ const (
 	cmdShowDataflowName = "showdataflow"
 	cmdShowEscapeName   = "showescape"
 	cmdShowSsaName      = "showssa"
+	cmdSrcName          = "src"
 	cmdSsaInstrName     = "ssainstr"
 	cmdSsaValueName     = "ssaval"
 	cmdStateName        = "state?"


### PR DESCRIPTION
Adding a `src` command to show the source code of a function from the cli. This can help quickly getting source code and ssa alongside each other.

<img width="692" alt="Screenshot 2025-01-23 at 11 46 35 AM" src="https://github.com/user-attachments/assets/099088e6-2833-41da-8aa5-d1fdeb414537" />
