### PR TITLE
Fix calls to summarize functions that are not reachable

### DIFF
--- a/analysis/dataflow/inter_procedural.go
+++ b/analysis/dataflow/inter_procedural.go
@@ -607,11 +607,15 @@ func UnwindCallStackToFunc(stack *CallStack, f *ssa.Function) *CallStack {
 // the summary is constructed by running the intra-procedural dataflow analysis.
 // If the summary was not already in the flow graph of the state, it creates a new summary, adds it to the flow graph
 // and then runs the intra-procedural dataflow analysis.
+//
+// BuildSummary expects to be called only on reachable functions, because the analyses usually instantiate the summaries
+// only for those functions.
 func BuildSummary(s *State, function *ssa.Function) *SummaryGraph {
 	summary := s.FlowGraph.Summaries[function]
 	if summary != nil && summary.Constructed {
 		return summary
 	}
+	// nil summaries should only happen for functions that should have an internally defined summary, i.e. standard library.
 	if summary == nil {
 		id := GetUniqueFunctionID()
 		summary = NewPredefinedSummary(function, id)
@@ -619,6 +623,11 @@ func BuildSummary(s *State, function *ssa.Function) *SummaryGraph {
 			s.FlowGraph.Summaries[function] = summary
 		}
 	}
+	// Summary is still nil, we should panic now.
+	if summary == nil {
+		panic(fmt.Errorf("summary for function %v is nil", function))
+	}
+
 	logger := s.Logger
 
 	logger.Debugf("BuildSummary: Constructing summary for %v...\n", function)

--- a/analysis/dataflow/intra_procedural.go
+++ b/analysis/dataflow/intra_procedural.go
@@ -87,6 +87,9 @@ func IntraProceduralAnalysis(state *State,
 // RunIntraProcedural does not add any nod except bound label nodes to the summary graph, it only updates information
 // related to the edges.
 func RunIntraProcedural(a *State, sm *SummaryGraph) (time.Duration, error) {
+	if sm == nil {
+		return 0, fmt.Errorf("summary graph is nil")
+	}
 	start := time.Now()
 	flowInfo := NewFlowInfo(a.Config, sm.Parent)
 	// This is the only place an IntraAnalysisState is initialized

--- a/analysis/summaries/standard_library.go
+++ b/analysis/summaries/standard_library.go
@@ -287,9 +287,22 @@ var summaryEncoding = map[string]Summary{
 	},
 	// func NewDecoder(r io.Reader) *Decoder
 	"encoding/json.NewDecoder": SingleVarArgPropagation,
+	// func (dec *Decoder) Buffered() io.Reader
+	"(*encoding/json.Decoder).Buffered": SingleVarArgPropagation,
+	// func (dec *Decoder) Decode(v any) error {
 	"(*encoding/json.Decoder).Decode": {
 		[][]int{{0}, {0, 1}},
 		[][]int{{0}, {0}},
+	},
+	"(*encoding/json.Decoder).DisallowUnknownFields": NoDataFlowPropagation,
+	// func (dec *Decoder) InputOffset() int64 {
+	"(*encoding/json.Decoder).InputOffset": SingleVarArgPropagation,
+	// func (dec *Decoder) More() bool
+	"(*encoding/json.Decoder).More": SingleVarArgPropagation,
+	// func (dec *Decoder) Token() (Token, error)
+	"(*encoding/json.Decoder).Token": {
+		[][]int{{0}},
+		[][]int{{0, 1}},
 	},
 	"(*encoding/json.Decoder).UseNumber": {
 		[][]int{{0}},
@@ -301,6 +314,11 @@ var summaryEncoding = map[string]Summary{
 	"(*encoding/json.Encoder).Encode": {
 		[][]int{{0}, {0, 1}},
 		[][]int{{0}, {0}},
+	},
+	// func (enc *Encoder) SetEscapeHTML(on bool)
+	"(*encoding/json.Encoder).SetEscapeHTML": {
+		[][]int{{0}, {0, 1}},
+		[][]int{{}, {}},
 	},
 	// func (enc *Encoder) SetIndent(prefix, indent string)
 	"(*encoding/json.Encoder).SetIndent": {
@@ -324,7 +342,27 @@ var summaryEncoding = map[string]Summary{
 }
 
 var summaryErrors = map[string]Summary{
+	// func (e *errorString) Error() string
+	"(*errors.errorString).Error": SingleVarArgPropagation,
+	// func (e *joinError) Error() string
+	"(*errors.joinError).Error": SingleVarArgPropagation,
+	// func (e *joinError) Unwrap() []error
+	"(*errors.joinError).Unwrap": SingleVarArgPropagation,
+	// func (i Code) String() string
+	"(internal/types/errors.Code).String": SingleVarArgPropagation,
+	// func As(err error, target any) bool
+	"errors.As": {
+		[][]int{{0, 1}, {0}},
+		[][]int{{0}, {0}},
+	},
+	// func Is(err, target error) bool
+	"errors.Is": TwoArgPropagation,
+	// func Join(errs ...error) error
+	"errors.Join": SingleVarArgPropagation,
+	// func New(text string) error {
 	"errors.New": SingleVarArgPropagation,
+	// func Unwrap(err error) error
+	"errors.Unwrap": SingleVarArgPropagation,
 }
 
 var summaryExpVar = map[string]Summary{}
@@ -586,6 +624,8 @@ var summaryMath = map[string]Summary{
 	"math/rand.NewSource":          SingleVarArgPropagation,
 	"math/rand.Seed":               NoDataFlowPropagation,
 	"math/rand.Float32":            NoDataFlowPropagation,
+	"(*math/big.Int).Mul":          TwoArgPropagation,
+	"(*math/big.Int).SetInt64":     TwoArgReceivePropagation,
 	"(*math/big.Float).Set":        TwoArgPropagation,
 	"(*math/big.Float).SetFloat64": TwoArgPropagation,
 	"(*math/big.Float).SetInf":     TwoArgPropagation,
@@ -752,6 +792,7 @@ var summaryPath = map[string]Summary{
 	"path.Join":           SingleVarArgPropagation,
 	"path.Base":           SingleVarArgPropagation,
 	"path.Clean":          SingleVarArgPropagation,
+	"path/filepath.Abs":   SingleVarArgTwoRetsPropagation,
 	"path/filepath.Base":  SingleVarArgPropagation,
 	"path/filepath.Clean": SingleVarArgPropagation,
 	"path/filepath.Dir":   SingleVarArgPropagation,
@@ -912,6 +953,16 @@ var summaryRegexp = map[string]Summary{
 		[][]int{{0}, {1}, {2}},
 		[][]int{{0}, {0}, {0}},
 	},
+	// func (re *Regexp).FindAllSubmatchIndex(b []byte, n int) [][]int
+	"(*regexp.Regexp).FindAllSubmatchIndex": {
+		[][]int{{0}, {1}, {2}},
+		[][]int{{0}, {0}, {0}},
+	},
+	// func (re *Regexp).FindAllStringIndex(s string, n int) [][]int
+	"(*regexp.Regexp).FindAllStringIndex": {
+		[][]int{{0}, {1}, {2}},
+		[][]int{{0}, {0}, {0}},
+	},
 }
 
 var summaryRuntime = map[string]Summary{
@@ -1058,6 +1109,19 @@ var summaryStrings = map[string]Summary{
 	"strings.TrimSpace": {
 		[][]int{{0}},
 		[][]int{{0}},
+	},
+	// func (b *Builder) WriteString(s string) (int, error)
+	// WriteString appends the contents of s to b's buffer.
+	// It returns the length of s and a nil error.
+	/* func (b *Builder) WriteString(s string) (int, error) {
+		b.copyCheck()
+		b.buf = append(b.buf, s...)
+		return len(s), nil
+	} */
+	"(*strings.Builder).WriteString": {
+		[][]int{{0}, {1, 0}}, // input taints receiver
+		[][]int{{}, {0}},     // receiver doesn't flow to results,
+		//input flows only to first element of returned tuple
 	},
 	// func (r *Reader) Len() int
 	"(*strings.Reader).Len": {

--- a/analysis/summaries/summary.go
+++ b/analysis/summaries/summary.go
@@ -42,13 +42,21 @@ type Summary struct {
 // sanitized value.
 var NoDataFlowPropagation = Summary{Rets: [][]int{}, Args: [][]int{}}
 
-// SingleVarArgPropagation is a summary for functions that have a single variadic argument (func f(arg ..any) {...})
+// SingleVarArgPropagation is a summary for functions that have a single (possibly variadic) argument (func f(arg ..any) any {...})
 // This will propagate the data flow to the return value.
 var SingleVarArgPropagation = Summary{Args: [][]int{{0}}, Rets: [][]int{{0}}}
+
+// SingleVarArgTwoRetsPropagation is a summary for functions that have a single variadic argument (func f(arg ..any) (any,any) {...})
+// This will propagate the data flow to both return values.
+var SingleVarArgTwoRetsPropagation = Summary{Args: [][]int{{0}}, Rets: [][]int{{0, 1}}}
 
 // TwoArgPropagation is a summary for functions that have two arguments and both propagate their data to the return
 // value, but there is no dataflow between arguments.
 var TwoArgPropagation = Summary{Args: [][]int{{0}, {1}}, Rets: [][]int{{0}, {0}}}
+
+// TwoArgReceivePropagation is a summary for functions that have two arguments and both propagate their data to the return
+// value, and the second argument propagates to the first (typically, functions where the first argument is the receiver)
+var TwoArgReceivePropagation = Summary{Args: [][]int{{0}, {1}}, Rets: [][]int{{0}, {0}}}
 
 // FormatterPropagation is a summary for functions like Printf where the first and second arguments might be tainted,
 // and this will taint the returned value (for example: an error, a string with Sprintf).

--- a/analysis/taint/dataflow_visitor.go
+++ b/analysis/taint/dataflow_visitor.go
@@ -284,7 +284,8 @@ func (v *Visitor) Visit(s *df.State, source df.NodeWithTrace) {
 				if callSite.Callee() == nil {
 					panic("callsite has no callee")
 				}
-				// the callee summary may not have been created yet
+				// the callee summary may not have been created yet, but if it's reachable then we should panic
+				// because we cannot handle this case soundly.
 				if s.IsReachableFunction(callSite.Callee()) {
 					panic(fmt.Sprintf("unexpected missing callee summary for reachable function %s",
 						callSite.Callee()))
@@ -547,6 +548,12 @@ func (v *Visitor) Visit(s *df.State, source df.NodeWithTrace) {
 				if len(graphNode.Graph().ReferringMakeClosures) == 0 {
 					// Summarize the free variable's closure's parent function if there is one
 					f := graphNode.Graph().Parent.Parent()
+					if !s.IsReachableFunction(f) {
+						// we're not even in a reachable function, so the data cannot be flowing here
+						// we might have reached this point by moving throught bound variables/global variables
+						// but the function is not actually reachable.
+						break
+					}
 					if f != nil {
 						df.BuildSummary(s, f)
 					}
@@ -641,7 +648,13 @@ func (v *Visitor) Visit(s *df.State, source df.NodeWithTrace) {
 			}
 			destClosureSummary := graphNode.DestClosure()
 			if destClosureSummary == nil {
-				destClosureSummary = df.BuildSummary(s, graphNode.DestInfo().MakeClosure.Fn.(*ssa.Function))
+				closureFn := graphNode.DestInfo().MakeClosure.Fn.(*ssa.Function)
+				// The function that created the closure is not reachable, so it can't be the case
+				// that the data would flow from that closure creation site.
+				if !s.IsReachableFunction(closureFn) {
+					break
+				}
+				destClosureSummary = df.BuildSummary(s, closureFn)
 				graphNode.SetDestClosure(destClosureSummary)
 				s.FlowGraph.Sync()
 			}

--- a/analysis/version.go
+++ b/analysis/version.go
@@ -15,4 +15,4 @@
 package analysis
 
 // Version is the last tagged version of the analysis tool
-const Version = "v0.4.1-alpha"
+const Version = "v0.4.2-alpha"

--- a/cmd/argot/tools/tools.go
+++ b/cmd/argot/tools/tools.go
@@ -149,7 +149,7 @@ func LoadConfig(flags CommonFlags, returnDefaultIfNoPath bool) (*config.Config, 
 		ReportsDir: flags.Out,
 	}
 	if flags.Verbose {
-		fmt.Printf("verbose command line flag overrides config file log-level")
+		fmt.Printf("verbose command line flag overrides config file log-level\n")
 		overrides.LogLevel = int(config.DebugLevel)
 	}
 	cfg, err := config.LoadGlobal(overrides)


### PR DESCRIPTION
Adding checks that the function is reachable before trying to summarize it avoids getting in a situation where we are trying to summarize a function that does not have an instantiated summary.
This PR also adds a few predefined summaries for standard library functions.

