### PR TITLE
Fix tag support in syntactic analysis.

### DIFF
--- a/analysis/syntactic/preconditions/precond_check.go
+++ b/analysis/syntactic/preconditions/precond_check.go
@@ -31,6 +31,7 @@ import (
 
 // An AnalysisResult of the condition checking analysis returns the list of location where unchecked calls occur.
 type AnalysisResult struct {
+	NumSpecs      int
 	UncheckedLocs map[string][]token.Position
 }
 
@@ -43,10 +44,12 @@ type AnalysisReqs struct {
 // Analyze runs the analysis on the program wrapped in the pointer state.
 func Analyze(state *ptr.State, reqs AnalysisReqs) (AnalysisResult, error) {
 	locs := map[string][]token.Position{}
+	analyzed := 0
 	for _, spec := range state.Config.SyntacticProblems.CondCheckSpecs {
 		// Check if the spec applies (tag and target)
 		if (reqs.Tag == "" || spec.SpecTag() == reqs.Tag) &&
 			(fn.Contains(spec.Targets, state.Target) || state.Target == "") {
+			analyzed += 1
 			state.Logger.Infof("checking tag \"%s\"", formatutil.Bold(spec.Tag))
 			specResult, err := analyzeSpec(state, spec)
 			if err != nil {
@@ -62,11 +65,14 @@ func Analyze(state *ptr.State, reqs AnalysisReqs) (AnalysisResult, error) {
 			})
 		}
 	}
-	return AnalysisResult{UncheckedLocs: locs}, nil
+	return AnalysisResult{NumSpecs: analyzed, UncheckedLocs: locs}, nil
 }
 
 // ReportResults writes res to a string and returns true if the analysis has findings.
 func ReportResults(res AnalysisResult) (string, bool) {
+	if res.NumSpecs == 0 {
+		return "precondition analysis didn't run; check the tags if you expected a result", false
+	}
 	w := &strings.Builder{}
 	w.WriteString("\nprecondition analysis results:\n")
 	w.WriteString("-----------------------------\n")

--- a/analysis/syntactic/structinit/structinit.go
+++ b/analysis/syntactic/structinit/structinit.go
@@ -30,6 +30,12 @@ import (
 	"golang.org/x/tools/go/ssa"
 )
 
+// AnalysisReqs groups the options of the analysis together
+type AnalysisReqs struct {
+	// Tag is the tag of the problem to analyze
+	Tag string
+}
+
 // AnalysisResult is the result of the struct-init analysis.
 type AnalysisResult struct {
 	// InitInfos is a mapping from the named struct type to its initialization
@@ -77,15 +83,20 @@ type InvalidWrite struct {
 }
 
 // Analyze runs the analysis on prog.
-func Analyze(state *ptr.State) (AnalysisResult, error) {
+func Analyze(state *ptr.State, reqs AnalysisReqs) (AnalysisResult, error) {
 	program := state.Program
 	fns := state.ReachableFunctions()
 	if len(fns) == 0 {
 		return AnalysisResult{}, fmt.Errorf("no functions found")
 	}
-	specs := structInitSpecs(state.Config, state.Target)
+	specs := structInitSpecs(state.Config, state.Target, reqs.Tag)
 	state.Logger.Infof("%d struct-init specs to check: %s", len(specs), strings.Join(
 		funcutil.Map(specs, func(ss config.StructInitSpec) string { return ss.Tag }), ","))
+	if len(specs) == 0 {
+		// If there is no specs here, it's like because of the tags being filtered out by structInitSpecs
+		state.Logger.Infof("No struct-init specs matching configuration; check the tags if you expected a result")
+		return AnalysisResult{}, nil
+	}
 	for fn := range fns {
 		if funcutil.Exists(specs, func(s config.StructInitSpec) bool { return isFiltered(s, fn) }) {
 			delete(fns, fn)
@@ -202,10 +213,11 @@ func debug(logger *config.LogGroup, res AnalysisResult, structToNamed map[*types
 	}
 }
 
-func structInitSpecs(cfg *config.Config, target string) []config.StructInitSpec {
+func structInitSpecs(cfg *config.Config, target string, tag string) []config.StructInitSpec {
 	var res []config.StructInitSpec
 	for _, stspec := range cfg.SyntacticProblems.StructInitProblems {
-		if target == "" || funcutil.Contains(stspec.Targets, target) {
+		if (target == "" || funcutil.Contains(stspec.Targets, target)) &&
+			(tag == "" || stspec.Tag == tag) {
 			res = append(res, stspec)
 		}
 	}

--- a/analysis/syntactic/structinit/structinit_test.go
+++ b/analysis/syntactic/structinit/structinit_test.go
@@ -96,7 +96,7 @@ func runAnalysis(t *testing.T, dirName string) (*loadprogram.State, structinit.A
 	if err != nil {
 		t.Fatalf("failed to load : %s", err)
 	}
-	result, err := structinit.Analyze(state)
+	result, err := structinit.Analyze(state, structinit.AnalysisReqs{})
 	if err != nil {
 		t.Fatalf("struct-init analysis failed: %v", err)
 	}

--- a/cmd/argot/syntactic/syntactic.go
+++ b/cmd/argot/syntactic/syntactic.go
@@ -71,6 +71,10 @@ func Run(flags tools.CommonFlags) error {
 	if err != nil {
 		return fmt.Errorf("failed to get syntactic targets: %s", err)
 	}
+	if len(actualTargets) == 0 {
+		tmpLogger.Warnf("No syntactic targets found.")
+		return nil
+	}
 	for targetName, target := range actualTargets {
 		_, report, err := runTarget(cfg, targetName, target.Files, target.Platform, flags)
 		if err != nil {
@@ -110,18 +114,21 @@ func runTarget(
 	// struct analysis
 	structAnalysisFailed := false
 	if len(cfg.SyntacticProblems.StructInitProblems) > 0 {
+		start := time.Now()
 		c.Logger.Infof("starting struct init analysis...\n")
-		structInitRes, err := structinit.Analyze(state)
+		structInitRes, err := structinit.Analyze(state, structinit.AnalysisReqs{Tag: flags.Tag})
 		if err != nil {
 			return false, nil, fmt.Errorf("struct init analysis error: %v", err)
 		}
 		var s string
 		s, structAnalysisFailed = structinit.ReportResults(structInitRes)
+		c.Logger.Infof("Struct analysis done (%.3f s)", time.Since(start).Seconds())
 		c.Logger.Infof(s)
 	}
 	// condition check analysis
 	preconditionAnalysisFailed := false
 	if len(cfg.SyntacticProblems.CondCheckSpecs) > 0 {
+		start := time.Now()
 		c.Logger.Infof("starting precondition analysis...\n")
 		precondCheckRes, err := preconditions.Analyze(state, preconditions.AnalysisReqs{Tag: flags.Tag})
 		if err != nil {
@@ -129,28 +136,12 @@ func runTarget(
 		}
 		var s string
 		s, preconditionAnalysisFailed = preconditions.ReportResults(precondCheckRes)
+		c.Logger.Infof("Precondition analysis done (%.3f s)", time.Since(start).Seconds())
 		c.Logger.Infof(s)
 	}
 	// Failure for all syntactic analyses
 	if structAnalysisFailed || preconditionAnalysisFailed {
 		return false, state.Report, fmt.Errorf("syntactic analysis found problems, inspect logs for more information")
-	}
-	return RunSyntactic(targetName, state)
-}
-
-// RunSyntactic runs the syntactic analysis on the pointer state
-func RunSyntactic(targetName string, state *ptr.State) (bool, *config.ReportInfo, error) {
-	start := time.Now()
-	state.Logger.Infof("starting struct init analysis for %s...\n", targetName)
-	res, err := structinit.Analyze(state)
-	if err != nil {
-		return false, nil, fmt.Errorf("struct init analysis error: %v", err)
-	}
-	s, failed := structinit.ReportResults(res)
-	state.Logger.Infof("Struct analysis done (%.3f s)", time.Since(start).Seconds())
-	state.Logger.Infof(s)
-	if failed {
-		return false, state.Report, fmt.Errorf("struct init analysis found problems, inspect logs for more information")
 	}
 	return false, state.Report, nil
 }

--- a/cmd/argot/tools/tools.go
+++ b/cmd/argot/tools/tools.go
@@ -201,13 +201,11 @@ func GetTargets(c *config.Config, reqs TargetReqs) (map[string]config.TargetInfo
 	switch reqs.Tool {
 	case config.TaintTool:
 		addTargets(targetsToAnalyze, c.TaintTrackingProblems, allTargets, reqs.Tag, reqs.Platform)
-		break
 	case config.BacktraceTool:
 		addTargets(targetsToAnalyze, c.SlicingProblems, allTargets, reqs.Tag, reqs.Platform)
-		break
 	case config.SyntacticTool:
 		addTargets(targetsToAnalyze, c.SyntacticProblems.StructInitProblems, allTargets, reqs.Tag, reqs.Platform)
-		break
+		addTargets(targetsToAnalyze, c.SyntacticProblems.CondCheckSpecs, allTargets, reqs.Tag, reqs.Platform)
 	default:
 		return allTargets, nil
 	}


### PR DESCRIPTION
The `syntactic` tool did not support tags like the `backtrace` and the `taint` analysis tool, despite having analysis problem that can be tagged in the config file.
This adds support for tags in the tool. Problems that don't have the correct tag will be ignored during the analyses by both the `struct-init` and `cond-check` analyses. 