### PR TITLE
Change backtrace report format to match taint

### DIFF
--- a/analysis/backtrace/backtrace.go
+++ b/analysis/backtrace/backtrace.go
@@ -39,7 +39,7 @@ type AnalysisResult struct {
 	Graph df.InterProceduralFlowGraph
 
 	// Traces represents all the paths where data flows out from the analysis entry points for each problem tag.
-	Traces map[string]map[df.GraphNode][]Trace
+	Traces map[string]map[df.NodeWithTrace][]Trace
 }
 
 // AnalysisReqs provides constraints on the backtrace analysis to run.
@@ -71,7 +71,7 @@ func Analyze(state *df.State, reqs AnalysisReqs) (AnalysisResult, error) {
 	})
 
 	var errs []error
-	allTraces := make(map[string]map[df.GraphNode][]Trace)
+	allTraces := make(map[string]map[df.NodeWithTrace][]Trace)
 	for _, ps := range state.Config.SlicingProblems {
 		errs = runTag(state, reqs, ps, allTraces, errs)
 	}
@@ -79,7 +79,7 @@ func Analyze(state *df.State, reqs AnalysisReqs) (AnalysisResult, error) {
 	return AnalysisResult{Graph: *state.FlowGraph, Traces: allTraces}, errors.Join(errs...)
 }
 
-func runTag(state *df.State, reqs AnalysisReqs, ps config.SlicingSpec, allTraces map[string]map[df.GraphNode][]Trace, errs []error) []error {
+func runTag(state *df.State, reqs AnalysisReqs, ps config.SlicingSpec, allTraces map[string]map[df.NodeWithTrace][]Trace, errs []error) []error {
 	state.Logger.PushContext(formatutil.Yellow(ps.Tag))
 	defer state.Logger.PopContext()
 	// Check the tag must be analyzed
@@ -108,26 +108,24 @@ func runTag(state *df.State, reqs AnalysisReqs, ps config.SlicingSpec, allTraces
 		ps.AnalysisProblemOptions = &config.AnalysisProblemOptions{}
 	}
 
-	visitor := &Visitor{
-		SlicingSpec: &ps,
-		Traces:      make(map[df.GraphNode][]Trace),
-	}
+	visitor := NewVisitor(ps)
 	df.RunInterProcedural(state, visitor, df.ScanningSpec{
 		IsEntryPointSsa: func(node ssa.Node) bool {
-			return df.IsBacktraceNode(state, visitor.SlicingSpec, node)
+			return df.IsBacktraceNode(state, &visitor.SlicingSpec, node)
 		},
 	})
 	// filter unwanted nodes
 	resTraces := filterResultTraces(state, visitor)
 	if len(resTraces) > 0 {
 		allTraces[ps.Tag] = resTraces
+		logTraces(state, resTraces)
 		state.Report.AddEntry(
 			state,
 			config.ReportDesc{
 				Tool:     config.BacktraceTool,
 				Tag:      ps.Tag,
 				Severity: ps.Severity,
-				Content:  report(state, resTraces, &ps),
+				Content:  report(state, resTraces, ps),
 			},
 		)
 
@@ -149,13 +147,13 @@ func runTag(state *df.State, reqs AnalysisReqs, ps config.SlicingSpec, allTraces
 	return errs
 }
 
-func filterResultTraces(state *df.State, visitor *Visitor) map[df.GraphNode][]Trace {
-	resTraces := make(map[df.GraphNode][]Trace)
+func filterResultTraces(state *df.State, visitor *Visitor) map[df.NodeWithTrace][]Trace {
+	resTraces := make(map[df.NodeWithTrace][]Trace)
 	for entry, traces := range visitor.Traces {
 		for _, trace := range traces {
 			vTrace := Trace{}
 			for _, node := range trace {
-				if isFiltered(visitor.SlicingSpec, node.GraphNode) {
+				if isFiltered(visitor.SlicingSpec, node.Node) {
 					state.Logger.Tracef("FILTERED: %v\n", node)
 					state.Logger.Tracef("\t%v\n", vTrace)
 					vTrace = nil
@@ -174,18 +172,24 @@ func filterResultTraces(state *df.State, visitor *Visitor) map[df.GraphNode][]Tr
 // Visitor implements the dataflow.Visitor interface and holds the specification of the problem to solve in the
 // SlicingSpec as well as the set of traces.
 type Visitor struct {
-	SlicingSpec   *config.SlicingSpec
-	Traces        map[df.GraphNode][]Trace
+	SlicingSpec   config.SlicingSpec
+	Traces        map[df.NodeWithTrace][]Trace
 	Errs          []error
 	prevEdgeInfos map[*df.CallNodeArg][]df.EdgeInfo
 }
 
+// NewVisitor constructs a Visitor from spec.
+func NewVisitor(spec config.SlicingSpec) *Visitor {
+	return &Visitor{
+		SlicingSpec:   spec,
+		Traces:        make(map[df.NodeWithTrace][]Trace),
+		Errs:          nil,
+		prevEdgeInfos: make(map[*df.CallNodeArg][]df.EdgeInfo),
+	}
+}
+
 // Visit runs an inter-procedural backwards analysis to add any detected backtraces to v.Traces.
 func (v *Visitor) Visit(s *df.State, entrypoint df.NodeWithTrace) {
-	if v.prevEdgeInfos == nil {
-		v.prevEdgeInfos = make(map[*df.CallNodeArg][]df.EdgeInfo)
-	}
-
 	// this is needed because for some reason isBacktracePoint returns true for
 	// some synthetic nodes
 	call, ok := entrypoint.Node.(*df.CallNode)
@@ -196,16 +200,18 @@ func (v *Visitor) Visit(s *df.State, entrypoint df.NodeWithTrace) {
 	// the analysis operates on data originating from every argument in every
 	// call to an entrypoint
 	for _, arg := range call.Args() {
-		if err := v.visit(s, arg); err != nil {
+		nt := df.NodeWithTrace{
+			Node:         arg,
+			Trace:        entrypoint.Trace,
+			ClosureTrace: entrypoint.ClosureTrace,
+		}
+		if err := v.visit(s, nt); err != nil {
 			v.Errs = append(v.Errs, err)
 		}
 
 		// report traces from entrypoint:
-		logger := s.Logger
-		traces := v.Traces[arg]
+		traces := v.Traces[nt]
 		for i, trace := range traces {
-			logger.Infof("%v\n", trace.String())
-
 			// Stop if there is a limit on number of alarms (representing number of traces to report), and it has been reached.
 			if s.Config.MaxAlarms > 0 && i >= s.Config.MaxAlarms {
 				break
@@ -219,18 +225,19 @@ func (v *Visitor) Visit(s *df.State, entrypoint df.NodeWithTrace) {
 }
 
 //gocyclo:ignore
-func (v *Visitor) visit(s *df.State, entrypoint *df.CallNodeArg) error {
+func (v *Visitor) visit(s *df.State, entrypoint df.NodeWithTrace) error {
 	logger := s.Logger
 
-	pos := entrypoint.Position(s)
+	pos := entrypoint.Node.Position(s)
+	entryArg := entrypoint.Node.(*df.CallNodeArg) // should never panic
 	if !pos.IsValid() {
-		pos = entrypoint.ParentNode().Position(s)
+		pos = entryArg.ParentNode().Position(s)
 	}
 
 	// Skip entrypoint if it is in a dependency or in the Go standard library/runtime
 	// TODO make this an option in the config
 	if strings.Contains(pos.Filename, "vendor") || strings.Contains(pos.Filename, runtime.GOROOT()) {
-		logger.Debugf("%s %v\n", formatutil.Red("Skipping entrypoint"), entrypoint.String())
+		logger.Debugf("%s %v\n", formatutil.Red("Skipping entrypoint"), entrypoint.Node.String())
 		return nil
 	}
 
@@ -238,16 +245,14 @@ func (v *Visitor) visit(s *df.State, entrypoint *df.CallNodeArg) error {
 	// sufficient to see that >0 entry points have been detected.
 	logger.Debugf("")
 	logger.Debugf(" entrypoint: %s\n",
-		formatutil.Blue(entrypoint.String()))
+		formatutil.Blue(entrypoint.Node.String()))
 	logger.Debugf("   %s %s\n", formatutil.Green("Found at"), pos)
-	logger.PushContext(formatutil.Faint(entrypoint.LongID()))
+	logger.PushContext(formatutil.Faint(entrypoint.Node.LongID()))
 	defer logger.PopContext()
-	var trace *df.NodeTree[*df.CallNode]
-	entry := df.NodeWithTrace{Node: entrypoint, Trace: trace}
 	seen := make(map[df.KeyType]bool)
 	goroutines := make(map[*ssa.Go]bool)
 	root := &df.VisitorNode{
-		NodeWithTrace: entry,
+		NodeWithTrace: entrypoint,
 		AccessPaths:   []string{""},
 		Prev:          nil,
 		Depth:         0,
@@ -277,16 +282,17 @@ func (v *Visitor) visit(s *df.State, entrypoint *df.CallNodeArg) error {
 
 		// Base case: add the trace if there are no more (intra- or inter-procedural) incoming edges from the node
 		if isBaseCase(cur.Node, s.Config) {
-			t := findTrace(s, cur)
-			addTrace(v, entrypoint, t)
-
+			t := findTrace(cur)
+			added := addTrace(v, entrypoint, t)
 			logger.Tracef("Base case reached...")
-			logger.Tracef("Adding trace: %v\n", t)
+			if added {
+				logger.Tracef("Adding trace: %v\n", t)
+			}
 			continue
 		}
 
 		if s.Config.ExceedsMaxDepth(cur.Depth) {
-			t := findTrace(s, cur)
+			t := findTrace(cur)
 			addTrace(v, entrypoint, t)
 			err := fmt.Errorf("call trace %w: %d", ErrMaxDepth, cur.Depth)
 			s.Report.AddError("max-depth", err)
@@ -323,7 +329,7 @@ func (v *Visitor) visit(s *df.State, entrypoint *df.CallNodeArg) error {
 					s.Report.AddError("argument at call site "+graphNode.String(), err)
 					// TODO fix bug that leads to panic
 					// report trace in the error as well
-					t := findTrace(s, cur)
+					t := findTrace(cur)
 					return fmt.Errorf("[Context] no arg at call site %v when visiting node %v: %v\n\t%v", callSite, graphNode, err, t)
 					// panic(fmt.Errorf("[Context] no arg at call site %v when visiting node %v: %v", callSite, graphNode, err))
 				}
@@ -465,10 +471,12 @@ func (v *Visitor) visit(s *df.State, entrypoint *df.CallNodeArg) error {
 			// - value is not bound, and
 			// - no more incoming edges from the arg
 			if prevStackLen == len(stack) {
-				t := findTrace(s, cur)
-				addTrace(v, entrypoint, t)
+				t := findTrace(cur)
+				added := addTrace(v, entrypoint, t)
 				logger.Tracef("CallNodeArg base case reached...")
-				logger.Tracef("Adding trace: %v\n", t)
+				if added {
+					logger.Tracef("Adding trace: %v\n", t)
+				}
 			}
 
 		// Data flows backwards within the function from the return statement.
@@ -548,10 +556,12 @@ func (v *Visitor) visit(s *df.State, entrypoint *df.CallNodeArg) error {
 			// - no new (non-visited) matching return, and
 			// - no more incoming edges from the call
 			if prevStackLen == len(stack) {
-				t := findTrace(s, cur)
-				addTrace(v, entrypoint, t)
+				t := findTrace(cur)
+				added := addTrace(v, entrypoint, t)
 				logger.Tracef("CallNode base case reached...")
-				logger.Tracef("Adding trace: %v\n", t)
+				if added {
+					logger.Tracef("Adding trace: %v\n", t)
+				}
 			}
 
 		// Data flows backwards within the function from the synthetic node or builtin call node.
@@ -654,7 +664,7 @@ func (v *Visitor) visit(s *df.State, entrypoint *df.CallNodeArg) error {
 					bv := bvs[graphNode.Index()]
 					nextNodeWithTrace := df.NodeWithTrace{
 						Node:         bv,
-						Trace:        trace,
+						Trace:        cur.Trace,
 						ClosureTrace: cur.ClosureTrace.Parent,
 					}
 					status := df.VisitorNodeStatus{
@@ -705,10 +715,12 @@ func (v *Visitor) visit(s *df.State, entrypoint *df.CallNodeArg) error {
 			// Free var base case:
 			// - no new matching bound variables
 			if prevStackLen == len(stack) {
-				t := findTrace(s, cur)
-				addTrace(v, entrypoint, t)
+				t := findTrace(cur)
+				added := addTrace(v, entrypoint, t)
 				logger.Tracef("Free var base case reached...")
-				logger.Tracef("Adding trace: %v\n", t)
+				if added {
+					logger.Tracef("Adding trace: %v\n", t)
+				}
 			}
 
 		case *df.ClosureNode:
@@ -851,26 +863,22 @@ func isBaseCase(node df.GraphNode, cfg *config.Config) bool {
 }
 
 // findTrace returns a slice of all the nodes in the trace starting from end.
-func findTrace(s *df.State, end *df.VisitorNode) Trace {
+func findTrace(end *df.VisitorNode) Trace {
 	trace := Trace{}
 	cur := end
 	for cur != nil {
-		node := TraceNode{
-			GraphNode: cur.Node,
-			Pos:       cur.Node.Position(s),
-		}
-		trace = append(trace, node)
+		trace = append(trace, cur)
 		cur = cur.Prev
 	}
 
 	return trace
 }
 
-func addTrace(v *Visitor, entrypoint *df.CallNodeArg, trace Trace) {
+func addTrace(v *Visitor, entrypoint df.NodeWithTrace, trace Trace) bool {
 	end := trace[0]
 	// Don't add traces when the tool is looking for flows that violate must-be-static constraint
-	if v.SlicingSpec.MustBeStatic && IsStatic(end.GraphNode) {
-		return
+	if v.SlicingSpec.MustBeStatic && IsStatic(end.Node) {
+		return false
 	}
 	// don't add trace if it's already in v.Traces
 	for _, t := range v.Traces[entrypoint] {
@@ -884,12 +892,13 @@ func addTrace(v *Visitor, entrypoint *df.CallNodeArg, trace Trace) {
 				}
 			}
 			if same {
-				return
+				return false
 			}
 		}
 	}
 
 	v.Traces[entrypoint] = append(v.Traces[entrypoint], trace)
+	return true
 }
 
 // IsStatic returns true if node is a constant value.
@@ -914,10 +923,10 @@ func traceNode(s *df.State, node *df.VisitorNode) {
 	logger.Tracef("Element status: %v\n", node.Status)
 	logger.Tracef("Element trace: %s\n", node.Trace.String())
 	logger.Tracef("Element closure trace: %s\n", node.ClosureTrace.String())
-	logger.Tracef("Element backtrace: %v\n", findTrace(s, node))
+	logger.Tracef("Element backtrace: %v\n", findTrace(node))
 }
 
-func isFiltered(ss *config.SlicingSpec, n df.GraphNode) bool {
+func isFiltered(ss config.SlicingSpec, n df.GraphNode) bool {
 	var f *ssa.Function
 	switch node := n.(type) {
 	case *df.CallNode:
@@ -952,14 +961,14 @@ func validateTrace(trace Trace) error {
 		}
 		next := trace[j]
 
-		switch cur := cur.GraphNode.(type) {
+		switch cur := cur.Node.(type) {
 		case *df.CallNodeArg:
-			if arg, ok := next.GraphNode.(*df.CallNodeArg); ok && arg.ParentName() != cur.ParentName() {
-				return fmt.Errorf("two interprocedural call args in a row: %v -> %v", cur, next.GraphNode)
+			if arg, ok := next.Node.(*df.CallNodeArg); ok && arg.ParentName() != cur.ParentName() {
+				return fmt.Errorf("two interprocedural call args in a row: %v -> %v", cur, next.Node)
 			}
 		case *df.ParamNode:
-			if param, ok := next.GraphNode.(*df.ParamNode); ok && param.ParentName() != cur.ParentName() {
-				return fmt.Errorf("two interprocedural params in a row: %v -> %v", cur, next.GraphNode)
+			if param, ok := next.Node.(*df.ParamNode); ok && param.ParentName() != cur.ParentName() {
+				return fmt.Errorf("two interprocedural params in a row: %v -> %v", cur, next.Node)
 			}
 		}
 	}

--- a/analysis/backtrace/backtrace_taint_test.go
+++ b/analysis/backtrace/backtrace_taint_test.go
@@ -126,7 +126,7 @@ func runBacktraceTest(t *testing.T, test testDef, isOnDemand bool) {
 	// 	t.Log(trace)
 	// }
 
-	reached := reachedSinkPositions(t, state, res)
+	reached := reachedSinkPositions(state, res)
 	if len(reached) == 0 {
 		t.Fatal("expected reached sink positions to be present")
 	}
@@ -187,13 +187,13 @@ func isExpected(expected analysistest.TargetToSources, sourcePos analysistest.LP
 
 // reachedSinkPositions translates a list of traces in a program to a map from positions to set of positions,
 // where the map associates sink positions to sets of source positions that reach it.
-func reachedSinkPositions(t *testing.T, s *dataflow.State, res backtrace.AnalysisResult) map[token.Position]map[token.Position]bool {
+func reachedSinkPositions(s *dataflow.State, res backtrace.AnalysisResult) map[token.Position]map[token.Position]bool {
 	positions := make(map[token.Position]map[token.Position]bool)
 	prog := s.Program
 	for _, traceSet := range res.Traces {
 		for sink, traces := range traceSet {
 			// sink is the analysis entrypoint
-			si := dataflow.Instr(sink)
+			si := dataflow.Instr(sink.Node)
 			if si == nil {
 				continue
 			}
@@ -210,15 +210,15 @@ func reachedSinkPositions(t *testing.T, s *dataflow.State, res backtrace.Analysi
 
 			for _, trace := range traces {
 				for _, node := range trace {
-					instr := dataflow.Instr(node.GraphNode)
+					instr := dataflow.Instr(node.Node)
 					if instr == nil {
 						continue
 					}
 
-					sn := sourceNode(node.GraphNode)
+					sn := sourceNode(node.Node)
 
 					// Source nodes are slicing points, and we have a special slicingOrigin to test directly slicing
-					if dataflow.IsSourceNode(s, nil, sn) || strings.Contains(node.String(), "slicingOrigin") {
+					if dataflow.IsSourceNode(s, nil, sn) || strings.Contains(node.Node.String(), "slicingOrigin") {
 						sourcePos := instr.Pos()
 						sourceFile := prog.Fset.File(sourcePos)
 						if sourcePos == token.NoPos || sourceFile == nil {

--- a/analysis/backtrace/backtrace_test.go
+++ b/analysis/backtrace/backtrace_test.go
@@ -139,8 +139,6 @@ func testAnalyze(t *testing.T, lp *loadprogram.State) {
 			// "(SA)call: os/exec.Command("ls":string, nil:[]string...) in main [#580.5]: @arg 1:nil:[]string [#580.7]" at -
 			matches: []match{
 				{arg, argval{`nil:[]string`, 1}, 26},
-				{param, `parameter arg : []string`, -1}, // line -1 means ignore position
-				{arg, argval{`nil:[]string`, 1}, 26},
 			},
 		},
 		{
@@ -219,8 +217,6 @@ func testAnalyze(t *testing.T, lp *loadprogram.State) {
 				// TODO detect the mutation inside the function to make this more precise
 				{arg, argval{`nil:[]string`, 1}, 36},
 				{param, `parameter args : []string`, 71},
-				{arg, argval{`nil:[]string`, 1}, 36},
-				{param, `parameter args : []string`, 71},
 				{arg, argval{`args`, 1}, 72},
 			},
 		},
@@ -241,8 +237,6 @@ func testAnalyze(t *testing.T, lp *loadprogram.State) {
 			// "[#582.0] parameter name : string of runcmd [0]" at /Volumes/workplace/argot/testdata/src/backtrace/main.go:71:13
 			// "(SA)call: os/exec.Command(name, args...) in runcmd [#582.3]: @arg 0:name [#582.4]" at /Volumes/workplace/argot/testdata/src/backtrace/main.go:71:13
 			matches: []match{
-				{arg, argval{`nil:[]string`, 1}, 39},
-				{param, `parameter args : []string`, 71},
 				{arg, argval{`nil:[]string`, 1}, 39},
 				{param, `parameter args : []string`, 71},
 				{arg, argval{`args`, 1}, 72},
@@ -292,8 +286,6 @@ func testAnalyze(t *testing.T, lp *loadprogram.State) {
 			// "[#578.1] parameter args : []string of runcmd [1]" at /Volumes/workplace/argot/testdata/src/backtrace/main.go:71:26
 			// "(SA)call: os/exec.Command(name, args...) in runcmd [#578.3]: @arg 1:args [#578.5]" at /Volumes/workplace/argot/testdata/src/backtrace/main.go:71:26
 			matches: []match{
-				{arg, argval{`nil:[]string`, 1}, 55},
-				{param, `parameter args : []string`, 71},
 				{arg, argval{`nil:[]string`, 1}, 55},
 				{param, `parameter args : []string`, 71},
 				{arg, argval{`args`, 1}, 72},
@@ -368,7 +360,7 @@ func testAnalyze(t *testing.T, lp *loadprogram.State) {
 			t.Parallel()
 
 			if !funcutil.Exists(traces, func(trace backtrace.Trace) bool {
-				ok, err := matchTrace(trace, test.matches)
+				ok, err := matchTrace(state, trace, test.matches)
 				_ = err
 				// // NOTE commented out for debugging
 				// if err != nil {
@@ -384,7 +376,7 @@ func testAnalyze(t *testing.T, lp *loadprogram.State) {
 
 	t.Run(`trace to bar("x") should not exist`, func(t *testing.T) {
 		if funcutil.Exists(traces, func(trace backtrace.Trace) bool {
-			arg, ok := trace[0].GraphNode.(*dataflow.CallNodeArg)
+			arg, ok := trace[0].Node.(*dataflow.CallNodeArg)
 			if !ok {
 				return false
 			}
@@ -546,7 +538,7 @@ func testAnalyzeClosures(t *testing.T, lp *loadprogram.State) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if !funcutil.Exists(traces, func(trace backtrace.Trace) bool {
-				ok, err := matchTrace(trace, test.matches)
+				ok, err := matchTrace(state, trace, test.matches)
 				_ = err
 				// // NOTE commented out for debugging
 				// if err != nil {
@@ -567,8 +559,7 @@ func TestAnalyze_CheckStatic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lp.Config.SummarizeOnDemand = true
-	lp.Config.LogLevel = int(config.InfoLevel) // increasing to level > InfoLevel throws off IDE
+	setupConfig(lp, true)
 	state, err := result.Bind(ptr.NewState(lp), dataflow.NewState).Value()
 	if err != nil {
 		t.Fatalf("failed to load state: %s", err)
@@ -580,14 +571,14 @@ func TestAnalyze_CheckStatic(t *testing.T) {
 	if len(res.Traces) != 1 {
 		t.Fatalf("expected a single entry point with a trace for check_static")
 	}
-	expected := regexp.MustCompile("Int.return.0.*math/rand/rand.go")
+	expected := regexp.MustCompile(".*Int.return.0")
 	for _, traces := range res.Traces {
 		if len(traces) != 2 {
 			t.Fatalf("expected two traces for the entry point for check_static")
 		}
 		for _, trace := range traces {
-			if !expected.MatchString(trace[0].String()) {
-				t.Fatalf("Origin %s of trace doesn't match the expected %s", trace[0], expected)
+			if !expected.MatchString(trace[0][0].Node.String()) {
+				t.Fatalf("Origin %s of trace doesn't match the expected %s", trace[0][0].Node, expected)
 			}
 		}
 	}
@@ -618,7 +609,7 @@ type match struct {
 	line int // 0 is invalid, 1+ is valid
 }
 
-func matchTrace(trace backtrace.Trace, matches []match) (bool, error) {
+func matchTrace(state *dataflow.State, trace backtrace.Trace, matches []match) (bool, error) {
 	ignoreCount := 0
 	for _, m := range matches {
 		if m == ignoreMatch {
@@ -636,8 +627,8 @@ func matchTrace(trace backtrace.Trace, matches []match) (bool, error) {
 		}
 
 		// line: -1 means ignore position
-		if (trace[i].Pos.Line != m.line) && (m.line != -1) {
-			return false, fmt.Errorf("wrong line number: want %d, got %d", m.line, trace[i].Pos.Line)
+		if (trace[i].Node.Position(state).Line != m.line) && (m.line != -1) {
+			return false, fmt.Errorf("wrong line number: want %d, got %d", m.line, trace[i].Node.Position(state).Line)
 		}
 
 		ok, err := matchNode(trace[i], m)
@@ -650,8 +641,8 @@ func matchTrace(trace backtrace.Trace, matches []match) (bool, error) {
 }
 
 //gocyclo:ignore
-func matchNode(tnode backtrace.TraceNode, m match) (bool, error) {
-	switch node := tnode.GraphNode.(type) {
+func matchNode(tnode *dataflow.VisitorNode, m match) (bool, error) {
+	switch node := tnode.Node.(type) {
 	case *dataflow.CallNodeArg:
 		mval := m.val.(argval)
 		val := mval.val == node.Value().Name() || (mval.val == nil && !backtrace.IsStatic(node))
@@ -711,7 +702,7 @@ func setupConfig(lp *loadprogram.State, summarizeOnDemand bool) {
 
 	cfg := lp.Config
 	cfg.Options.ReportCoverage = false
-	cfg.Options.ReportPaths = false
+	cfg.Options.ReportPaths = false // change this as needed for debugging
 	cfg.Options.ReportSummaries = false
 	cfg.Options.ReportsDir = ""
 	cfg.LogLevel = int(level)

--- a/analysis/backtrace/report.go
+++ b/analysis/backtrace/report.go
@@ -17,6 +17,7 @@ package backtrace
 import (
 	"github.com/awslabs/ar-go-tools/analysis/config"
 	"github.com/awslabs/ar-go-tools/analysis/dataflow"
+	"github.com/awslabs/ar-go-tools/internal/formatutil"
 	"github.com/awslabs/ar-go-tools/internal/funcutil"
 )
 
@@ -29,22 +30,71 @@ type FlowReports struct {
 
 // report generates a json report for a specific data flow
 func report(s *dataflow.State,
-	traces map[dataflow.GraphNode][]Trace,
-	ss *config.SlicingSpec) FlowReports {
+	traces map[dataflow.NodeWithTrace][]Trace,
+	ss config.SlicingSpec) FlowReports {
 	traceMap := make(map[string][][]dataflow.ReportNodeInfo)
 	for entryPt, tracesFromEntryPt := range traces {
 		reportTraces :=
 			funcutil.Map(tracesFromEntryPt, func(trace Trace) []dataflow.ReportNodeInfo {
 				return funcutil.Map(trace,
-					func(x TraceNode) dataflow.ReportNodeInfo {
-						return dataflow.GetReportNodeInfo(dataflow.NodeWithTrace{Node: x.GraphNode}, s)
+					func(x *dataflow.VisitorNode) dataflow.ReportNodeInfo {
+						return dataflow.GetReportNodeInfo(x.NodeWithTrace, s)
 					})
 			})
-		traceMap[entryPt.String()] = reportTraces
+		traceMap[entryPt.Node.String()] = reportTraces
 	}
 
 	return FlowReports{
 		Tag:    ss.Tag,
 		Traces: traceMap,
+	}
+}
+
+// logTraces logs resTraces using the state's logger.
+func logTraces(s *dataflow.State, resTraces map[dataflow.NodeWithTrace][]Trace) {
+	for entry, traces := range resTraces {
+		s.Logger.Infof("Found %d data flow(s) from backtrace-point: %v\n",
+			len(traces), dataflow.TermNodeSummary(entry.Node))
+		// - Context [<calling context string>] Pos: <position in source code>
+		s.Logger.Infof("%s - Context [%s]\n",
+			" |",
+			dataflow.FuncNames(entry.Trace, s.Logger.LogsDebug()))
+		s.Logger.Infof("%s - %s %s\n",
+			" |",
+			formatutil.Yellow("At"),
+			entry.Node.Position(s).String())
+		for _, trace := range traces {
+			logTrace(s, trace)
+		}
+	}
+}
+
+// logTrace logs the trace using the state's logger.
+func logTrace(s *dataflow.State, trace Trace) {
+	if len(trace) == 0 {
+		return
+	}
+
+	first := trace[0]
+	last := trace[len(trace)-1]
+	s.Logger.Infof(" Flow:")
+	s.Logger.Infof("  |- Data at %s (%s)", last.Node.Position(s), formatutil.Green(last.Node.String()))
+	s.Logger.Infof("  |- Originates from data at %s (%s)\n", first.Node.Position(s), formatutil.Red(first.Node.String()))
+
+	if s.Config.ReportPaths {
+		for _, node := range trace {
+			s.Logger.Infof("%s - %s",
+				formatutil.Blue("  |- TRACE"),
+				dataflow.TermNodeSummary(node.Node))
+			// - Context [<calling context string>] Pos: <position in source code>
+			s.Logger.Infof("%s - Context [%s]\n",
+				"  |  ",
+				dataflow.FuncNames(node.Trace, s.Logger.LogsDebug()))
+			s.Logger.Infof("%s - %s %s\n",
+				"  |  ",
+				formatutil.Yellow("At"),
+				node.Node.Position(s).String())
+		}
+		s.Logger.Infof("")
 	}
 }

--- a/analysis/backtrace/testdata/backtrace/config.yaml
+++ b/analysis/backtrace/testdata/backtrace/config.yaml
@@ -1,3 +1,6 @@
+options:
+  report-paths: true
+
 dataflow-problems:
   slicing:
     - backtracepoints:

--- a/analysis/backtrace/trace.go
+++ b/analysis/backtrace/trace.go
@@ -15,12 +15,9 @@
 package backtrace
 
 import (
-	"fmt"
-	"go/token"
 	"strings"
 
 	df "github.com/awslabs/ar-go-tools/analysis/dataflow"
-	"github.com/awslabs/ar-go-tools/internal/formatutil"
 )
 
 // Trace represents a dataflow path (sequence of nodes) out of an analysis
@@ -30,62 +27,14 @@ import (
 //
 // The last node in the trace is an argument to the backtrace entrypoint function
 // defined in the config.
-type Trace []TraceNode
-
-func (t Trace) String() string {
-	if len(t) == 0 {
-		return "<empty trace>"
-	}
-
-	first := fmt.Sprintf("%v from %v:\n", formatutil.Bold("Trace"), t[0].String())
-	var rest []TraceNode
-	if len(t) > 1 {
-		rest = t[1:]
-	}
-
-	b := &strings.Builder{}
-	if _, err := b.WriteString(first); err != nil {
-		panic(fmt.Errorf("failed to write first node to trace string: %v", err))
-	}
-	for i, tn := range rest {
-		if _, err := b.WriteString("\t"); err != nil {
-			panic(fmt.Errorf("failed to write to trace string: %v", err))
-		}
-		if _, err := b.WriteString(tn.String()); err != nil {
-			panic(fmt.Errorf("failed to write trace node %v to string: %v", tn, err))
-		}
-
-		if i == len(rest)-1 {
-			continue
-		}
-		if _, err := b.WriteString("\n"); err != nil {
-			panic(fmt.Errorf("failed to write to trace string: %v", err))
-		}
-	}
-
-	return b.String()
-}
+type Trace []*df.VisitorNode
 
 // Key generates a unique key for trace t.
 func (t Trace) Key() df.KeyType {
 	keys := make([]string, 0, len(t))
 	for _, node := range t {
-		keys = append(keys, node.LongID())
+		keys = append(keys, string(node.Key()))
 	}
 
 	return strings.Join(keys, "_")
-}
-
-// TraceNode represents a node in the trace.
-type TraceNode struct {
-	df.GraphNode
-	Pos token.Position
-}
-
-func (n TraceNode) String() string {
-	if n.GraphNode == nil {
-		return ""
-	}
-
-	return fmt.Sprintf("%v at %v", n.GraphNode.String(), n.Pos)
 }

--- a/analysis/dataflow/function_summary_graph_nodes.go
+++ b/analysis/dataflow/function_summary_graph_nodes.go
@@ -197,7 +197,7 @@ func TermNodeSummary(g GraphNode) string {
 	case *FreeVarNode:
 		return fmt.Sprintf("Free variable #%s of %q", formatutil.Green(x.fvPos), x.ssaNode.Parent().String())
 	case *AccessGlobalNode:
-		return fmt.Sprintf("Global variable %q", formatutil.Red(x.Global.String()))
+		return fmt.Sprintf("Global variable %s", formatutil.Red(x.Global.String()))
 	}
 	return ""
 }

--- a/cmd/argot/cli/analysis.go
+++ b/cmd/argot/cli/analysis.go
@@ -484,8 +484,7 @@ func cmdBacktrace(tt *term.Terminal, c *dataflow.State, _ Command, _ bool) bool 
 
 	var traces []backtrace.Trace
 	for _, ps := range c.Config.SlicingProblems {
-		visitor := &backtrace.Visitor{}
-		visitor.SlicingSpec = &ps
+		visitor := backtrace.NewVisitor(ps)
 		c.FlowGraph.RunVisitorOnEntryPoints(
 			visitor,
 			dataflow.ScanningSpec{


### PR DESCRIPTION
The new format makes it clear which flows are from which backtrace-point and also includes information about the calling context.

*Issue #, if available:*

*Description of changes:*
Example output with the new format:
```
[INFO].. Found 2 data flow(s) from backtrace-point: Argument #1 (type []string) in call to Command
[INFO]..  | - Context [Command]
[INFO]..  | - At argot/analysis/backtrace/testdata/backtrace/main.go:31:22
[INFO]..  Flow:
[INFO]..   |- Data at argot/analysis/backtrace/testdata/backtrace/main.go:31:22 ("[#772.9] @arg 1:slice t7[1:int:] in [#772.7] (SA)call: os/exec.Command(t6, t8...) in main ")
[INFO]..   |- Originates from data at argot/analysis/backtrace/testdata/backtrace/main.go:31:38 ("[#772.33] global:os.Args in *os.Args (read)")
[INFO]..   |- TRACE - Global variable "defglobal: os.Args"
[INFO]..   |   - Context []
[INFO]..   |   - At argot/analysis/backtrace/testdata/backtrace/main.go:31:38
[INFO]..   |- TRACE - Argument #1 (type []string) in call to Command
[INFO]..   |   - Context [Command]
[INFO]..   |   - At argot/analysis/backtrace/testdata/backtrace/main.go:31:22
[INFO]..
[INFO]..  Flow:
[INFO]..   |- Data at argot/analysis/backtrace/testdata/backtrace/main.go:31:22 ("[#772.9] @arg 1:slice t7[1:int:] in [#772.7] (SA)call: os/exec.Command(t6, t8...) in main ")
[INFO]..   |- Originates from data at argot/analysis/backtrace/testdata/backtrace/main.go:31:26 ("[#772.32] global:os.Args in *os.Args (read)")
[INFO]..   |- TRACE - Global variable "defglobal: os.Args"
[INFO]..   |   - Context []
[INFO]..   |   - At argot/analysis/backtrace/testdata/backtrace/main.go:31:26
[INFO]..   |- TRACE - Argument #1 (type []string) in call to Command
[INFO]..   |   - Context [Command]
[INFO]..   |   - At argot/analysis/backtrace/testdata/backtrace/main.go:31:22
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
