### PR TITLE
Detecting usages of unsafe through SSA builtins

### DIFF
--- a/analysis/dataflow/builtins.go
+++ b/analysis/dataflow/builtins.go
@@ -24,33 +24,47 @@ import (
 // https://pkg.go.dev/builtin
 //
 // Note that new, make and panic are their own SSA instructions.
-var handledBuiltins = []string{
-	"ssa:wrapnilchk",
-	"append",
-	"len",
-	"close",
-	"delete",
-	"println",
-	"print",
-	"recover",
-	"cap",
-	"complex",
-	"imag",
-	"real",
-	"min",
-	"max",
-	"clear",
-	"copy",
+var handledBuiltins = map[string]bool{
+	"ssa:wrapnilchk": true,
+	"append":         true,
+	"len":            true,
+	"close":          true,
+	"delete":         true,
+	"println":        true,
+	"print":          true,
+	"recover":        true,
+	"cap":            true,
+	"complex":        true,
+	"imag":           true,
+	"real":           true,
+	"min":            true,
+	"max":            true,
+	"clear":          true,
+	"copy":           true,
 }
 
 // markedBuiltins is the subset of builtins that return values that should be tracked in the analysis
 var markedBuiltins = []string{"ssa:wrapnilchk", "append", "complex", "min", "max", "len", "imag", "real"}
 
+// The builtins that are from the unsafe package
+var unsafeBuiltins = map[string]bool{
+	"Alignof":     true,
+	"Offsetof":    true,
+	"Sizeof":      true,
+	"Pointer":     true,
+	"SliceData":   true,
+	"String":      true,
+	"StringData":  true,
+	"Slice":       true,
+	"Add":         true,
+	"IntegerType": true,
+}
+
 // isHandledBuiltinCall returns true if the call is handled internally by the analysis.
 func isHandledBuiltinCall(instruction ssa.CallInstruction) bool {
 	if instruction.Common().Value != nil {
 		name := instruction.Common().Value.Name()
-		if funcutil.Contains(handledBuiltins, name) {
+		if handledBuiltins[name] {
 			return true
 		}
 		// Special case: the call to Error() of the builtin error interface

--- a/analysis/dataflow/report.go
+++ b/analysis/dataflow/report.go
@@ -207,16 +207,19 @@ func FindUnsoundFeatures(f *ssa.Function) UnsoundFeaturesMap {
 			}
 
 			var pkg string
-			if f, okF := callCommon.Value.(*ssa.Function); okF {
-				pkg = lang.PackageNameFromFunction(f)
-			}
-			if strings.HasPrefix(pkg, "unsafe") {
-				unsafeUsages[iPos] = fmt.Sprintf("Calling %s from unsafe package.", callCommon.Value.Name())
-				return
-			}
-			if strings.HasPrefix(pkg, "reflect") {
-				reflectUsages[iPos] = fmt.Sprintf("Calling %s from reflect package.", callCommon.Value.Name())
-				return
+			switch callVal := callCommon.Value.(type) {
+			case *ssa.Function:
+				pkg = lang.PackageNameFromFunction(callVal)
+				if strings.HasPrefix(pkg, "unsafe") {
+					unsafeUsages[iPos] = fmt.Sprintf("Calling %s from unsafe package.", callCommon.Value.Name())
+					return
+				}
+				if strings.HasPrefix(pkg, "reflect") {
+					reflectUsages[iPos] = fmt.Sprintf("Calling %s from reflect package.", callCommon.Value.Name())
+					return
+				}
+			case *ssa.Builtin:
+				detectUnsafeBuiltinUsage(callVal, unsafeUsages, iPos)
 			}
 
 		case *ssa.Alloc:
@@ -241,4 +244,19 @@ func FindUnsoundFeatures(f *ssa.Function) UnsoundFeaturesMap {
 		}
 	})
 	return UnsoundFeaturesMap{recovers, unsafeUsages, reflectUsages}
+}
+
+func detectUnsafeBuiltinUsage(callVal *ssa.Builtin, unsafeUsages map[token.Position]string, iPos token.Position) {
+	if handledBuiltins[callVal.Name()] {
+		return
+	}
+	if unsafeBuiltins[callVal.Name()] {
+		// It's a recognized unsafe function that the SSA implements as a builtin
+		unsafeUsages[iPos] = fmt.Sprintf("Calling unsafe function %s.", callVal.Name())
+		return
+	}
+	// It's not a handled builting, but we're not sure it's safe
+	// Report it in the unsafe usages without calling it a function
+	unsafeUsages[iPos] = fmt.Sprintf("Calling builtin %s.", callVal.Name())
+	return
 }

--- a/analysis/dataflow/testdata/unsound-features/main.go
+++ b/analysis/dataflow/testdata/unsound-features/main.go
@@ -57,6 +57,9 @@ func usingUnsafe() {
 	e := unsafe.Pointer(uintptr(unsafe.Pointer(&x[0])) + i*unsafe.Sizeof(x[0]))
 
 	fmt.Println(e, f)
+
+	y := unsafe.StringData(s.f)
+	fmt.Println(unsafe.String(y, len(s.f)))
 }
 
 func usingReflect() {

--- a/analysis/dataflow/unsound_features_test.go
+++ b/analysis/dataflow/unsound_features_test.go
@@ -41,8 +41,8 @@ func TestUnsoundFeatures(t *testing.T) {
 		if strings.Contains(f.Name(), "usingUnsafe") {
 
 			uf := dataflow.FindUnsoundFeatures(f)
-			if len(uf.UnsafeUsages) <= 2 {
-				t.Errorf("Did not detect enough usages of unsage in usingUnsafe")
+			if len(uf.UnsafeUsages) <= 5 {
+				t.Errorf("Did not detect enough usages of unsafe in usingUnsafe")
 			}
 			unsafeChecked = true
 		}

--- a/analysis/version.go
+++ b/analysis/version.go
@@ -15,4 +15,4 @@
 package analysis
 
 // Version is the last tagged version of the analysis tool
-const Version = "v0.4.3-alpha"
+const Version = "v0.4.4-alpha"


### PR DESCRIPTION
Some `unsafe` functions such as `StringValue` and `String` do not appear as functions from the `unsafe` package in the SSA but as builtins. This adds the necessary functionality to detect those usages.
