### PR TITLE
Support tracking specific args in backtrace

### DIFF
--- a/analysis/backtrace/backtrace.go
+++ b/analysis/backtrace/backtrace.go
@@ -27,6 +27,7 @@ import (
 	"github.com/awslabs/ar-go-tools/analysis/config"
 	df "github.com/awslabs/ar-go-tools/analysis/dataflow"
 	"github.com/awslabs/ar-go-tools/analysis/lang"
+	"github.com/awslabs/ar-go-tools/internal/analysisutil"
 	"github.com/awslabs/ar-go-tools/internal/formatutil"
 	"golang.org/x/tools/go/ssa"
 )
@@ -67,7 +68,12 @@ func Analyze(state *df.State, reqs AnalysisReqs) (AnalysisResult, error) {
 
 	df.RunIntraProceduralPass(state, numRoutines, df.IntraAnalysisParams{
 		ShouldBuildSummary: df.ShouldBuildSummary,
-		ShouldTrack:        df.IsNodeOfInterest,
+		ShouldTrack: func(state *df.State, n ssa.Node) bool {
+			if _, ok := analysisutil.IsEntrypointNode(state.PointerAnalysis, n, state.Config.IsSomeBacktracePoint); ok {
+				return true
+			}
+			return false
+		},
 	})
 
 	var errs []error
@@ -110,9 +116,41 @@ func runTag(state *df.State, reqs AnalysisReqs, ps config.SlicingSpec, allTraces
 
 	visitor := NewVisitor(ps)
 	df.RunInterProcedural(state, visitor, df.ScanningSpec{
-		IsEntryPointSsa: func(node ssa.Node) bool {
+		IsEntryPointGraph: func(node df.GraphNode) (config.CodeIdentifier, bool) {
+			if arg, ok := node.(*df.CallNodeArg); ok {
+				callee := arg.ParentNode().Callee()
+				if callee == nil {
+					return config.CodeIdentifier{}, false
+				}
+				pkg := callee.Package()
+				if pkg == nil {
+					return config.CodeIdentifier{}, false
+				}
+				cid := config.CodeIdentifier{
+					Target: config.Target{
+						Kind:    config.CallKind,
+						Package: callee.Package().Pkg.Path(),
+						Method:  callee.Name(),
+						Objects: []config.TargetObject{
+							{
+								Kind:  config.ArgumentKind,
+								Name:  arg.ParamName(),
+								Index: uint(arg.Index()),
+								Type:  arg.Type().String(),
+							},
+						},
+					},
+				}
+
+				return visitor.SlicingSpec.IsBacktracePoint(cid)
+			}
+
+			return config.CodeIdentifier{}, false
+		},
+		IsEntryPointSsa: func(node ssa.Node) (config.CodeIdentifier, bool) {
 			return df.IsBacktraceNode(state, &visitor.SlicingSpec, node)
 		},
+		ScanCallArgsOnly: true,
 	})
 	// filter unwanted nodes
 	resTraces := filterResultTraces(state, visitor)
@@ -190,18 +228,30 @@ func NewVisitor(spec config.SlicingSpec) *Visitor {
 
 // Visit runs an inter-procedural backwards analysis to add any detected backtraces to v.Traces.
 func (v *Visitor) Visit(s *df.State, entrypoint df.NodeWithTrace) {
-	// this is needed because for some reason isBacktracePoint returns true for
-	// some synthetic nodes
-	call, ok := entrypoint.Node.(*df.CallNode)
-	if !ok {
-		return
+	if v.prevEdgeInfos == nil {
+		v.prevEdgeInfos = make(map[*df.CallNodeArg][]df.EdgeInfo)
 	}
 
-	// the analysis operates on data originating from every argument in every
-	// call to an entrypoint
-	for _, arg := range call.Args() {
+	switch node := entrypoint.Node.(type) {
+	case *df.CallNode:
+		// The analysis operates on data originating from every argument in every
+		// call to an entrypoint
+		for _, arg := range node.Args() {
+			nt := df.NodeWithTrace{
+				Node:         arg,
+				Trace:        entrypoint.Trace,
+				ClosureTrace: entrypoint.ClosureTrace,
+			}
+			if err := v.visit(s, nt); err != nil {
+				v.Errs = append(v.Errs, err)
+			}
+
+			traces := v.Traces[nt]
+			validateTraces(s, traces)
+		}
+	case *df.CallNodeArg:
 		nt := df.NodeWithTrace{
-			Node:         arg,
+			Node:         node,
 			Trace:        entrypoint.Trace,
 			ClosureTrace: entrypoint.ClosureTrace,
 		}
@@ -209,18 +259,8 @@ func (v *Visitor) Visit(s *df.State, entrypoint df.NodeWithTrace) {
 			v.Errs = append(v.Errs, err)
 		}
 
-		// report traces from entrypoint:
 		traces := v.Traces[nt]
-		for i, trace := range traces {
-			// Stop if there is a limit on number of alarms (representing number of traces to report), and it has been reached.
-			if s.Config.MaxAlarms > 0 && i >= s.Config.MaxAlarms {
-				break
-			}
-
-			if err := validateTrace(trace); err != nil {
-				panic(fmt.Errorf("invalid trace: %v", err))
-			}
-		}
+		validateTraces(s, traces)
 	}
 }
 
@@ -383,7 +423,12 @@ func (v *Visitor) visit(s *df.State, entrypoint df.NodeWithTrace) error {
 							callSite.CalleeSummary = df.NewSummaryGraph(s,
 								callSite.Callee(),
 								df.GetUniqueFunctionID(),
-								func(s *df.State, n ssa.Node) bool { return df.IsBacktraceNode(s, nil, n) },
+								func(s *df.State, n ssa.Node) bool {
+									if _, ok := df.IsBacktraceNode(s, nil, n); ok {
+										return true
+									}
+									return false
+								},
 								nil)
 							v.onDemandIntraProcedural(s, callSite.CalleeSummary)
 						}
@@ -949,6 +994,19 @@ func isFiltered(ss config.SlicingSpec, n df.GraphNode) bool {
 		}
 	}
 	return false
+}
+
+func validateTraces(s *df.State, traces []Trace) {
+	for i, trace := range traces {
+		// Stop if there is a limit on number of alarms (representing number of traces to report), and it has been reached.
+		if s.Config.MaxAlarms > 0 && i >= s.Config.MaxAlarms {
+			break
+		}
+
+		if err := validateTrace(trace); err != nil {
+			panic(fmt.Errorf("invalid trace: %v", err))
+		}
+	}
 }
 
 // validateTrace validates trace.

--- a/analysis/backtrace/backtrace.go
+++ b/analysis/backtrace/backtrace.go
@@ -126,18 +126,14 @@ func runTag(state *df.State, reqs AnalysisReqs, ps config.SlicingSpec, allTraces
 				if pkg == nil {
 					return config.CodeIdentifier{}, false
 				}
+				param := lang.GetParams(arg.ParentNode().CallSite())[arg.Index()]
 				cid := config.CodeIdentifier{
 					Target: config.Target{
 						Kind:    config.CallKind,
 						Package: callee.Package().Pkg.Path(),
 						Method:  callee.Name(),
 						Objects: []config.TargetObject{
-							{
-								Kind:  config.ArgumentKind,
-								Name:  arg.ParamName(),
-								Index: uint(arg.Index()),
-								Type:  arg.Type().String(),
-							},
+							analysisutil.NewParamTargetObject(param, arg.Index(), arg.Value()),
 						},
 					},
 				}

--- a/analysis/backtrace/backtrace_taint_test.go
+++ b/analysis/backtrace/backtrace_taint_test.go
@@ -218,7 +218,7 @@ func reachedSinkPositions(s *dataflow.State, res backtrace.AnalysisResult) map[t
 					sn := sourceNode(node.Node)
 
 					// Source nodes are slicing points, and we have a special slicingOrigin to test directly slicing
-					if dataflow.IsSourceNode(s, nil, sn) || strings.Contains(node.Node.String(), "slicingOrigin") {
+					if _, ok := dataflow.IsSourceNode(s, nil, sn); ok || strings.Contains(node.Node.String(), "slicingOrigin") {
 						sourcePos := instr.Pos()
 						sourceFile := prog.Fset.File(sourcePos)
 						if sourcePos == token.NoPos || sourceFile == nil {

--- a/analysis/backtrace/backtrace_test.go
+++ b/analysis/backtrace/backtrace_test.go
@@ -70,6 +70,56 @@ func TestAnalyze_OnDemand(t *testing.T) {
 	testAnalyze(t, lp)
 }
 
+// TestAnalyze_SpecificObjs tests the new config code identifier format that
+// enables specific objects (e.g. a single argument) to be a backtrace-point
+// instead of all arguments of a call.
+func TestAnalyze_SpecificObjs(t *testing.T) {
+	dir := filepath.Join("./testdata", "trace-specific")
+	lp, err := analysistest.LoadTest(testfsys, dir, []string{}, analysistest.LoadTestOptions{ApplyRewrite: true}).Value()
+	if err != nil {
+		t.Fatal(err)
+	}
+	setupConfig(lp, true)
+	state, err := result.Bind(ptr.NewState(lp), dataflow.NewState).Value()
+	if err != nil {
+		t.Fatalf("failed to load state: %s", err)
+	}
+	res, err := backtrace.Analyze(state, backtrace.AnalysisReqs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []traceTest{
+		{
+			name: `trace to trackSecondArg arg 1 in main from main`,
+			matches: []match{
+				{arg, argval{`"test":string`, 1}, 19},
+			},
+		},
+		{
+			name: `trace to trackSecondAndThirdArg arg 1 in main from main`,
+			matches: []match{
+				{arg, argval{`1:uint`, 1}, 21},
+			},
+		},
+		{
+			name: `trace to trackSecondAndThirdArg arg 2 in main from main`,
+			matches: []match{
+				{arg, argval{`"test2":string`, 2}, 21},
+			},
+		},
+	}
+
+	checkTraces(t, res, tests)
+
+	// Make sure no extra traces are reported by, for example,
+	// analyzing an un-configured entrypoint
+	traces := mergeTraces(res)
+	if len(traces) != len(tests) {
+		t.Errorf("want only %d traces, got %d", len(tests), len(traces))
+	}
+}
+
 // TestAnalyze_MaxDepth tests that the unsafe-max-depth config option results in
 // an error if the max depth is exceeded while computing a trace.
 func TestAnalyze_MaxDepth(t *testing.T) {
@@ -123,10 +173,7 @@ func testAnalyze(t *testing.T, lp *loadprogram.State) {
 		t.Fatal(err)
 	}
 
-	tests := []struct {
-		name    string
-		matches []match
-	}{
+	tests := []traceTest{
 		{
 			name: `trace to os/exec.Command arg 0 in main from os/exec.Command arg 0 in main`,
 			// "(SA)call: os/exec.Command("ls":string, nil:[]string...) in main [#576.5]: @arg 0:"ls":string [#576.6]" at -
@@ -343,37 +390,9 @@ func testAnalyze(t *testing.T, lp *loadprogram.State) {
 		},
 	}
 
+	checkTraces(t, res, tests)
+
 	traces := mergeTraces(res)
-	if len(traces) < len(tests) {
-		t.Fatalf("analysis did not find enough traces: want at least %d, got %d", len(tests), len(traces))
-	}
-
-	// // NOTE Uncomment to debug
-	// t.Log("TRACES:")
-	// for _, trace := range res.Traces {
-	// 	t.Log(trace)
-	// }
-
-	for _, test := range tests {
-		test := test // needed for t.Parallel()
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
-			if !funcutil.Exists(traces, func(trace backtrace.Trace) bool {
-				ok, err := matchTrace(state, trace, test.matches)
-				_ = err
-				// // NOTE commented out for debugging
-				// if err != nil {
-				// 	t.Errorf("failed match: %v in trace: %v", err, trace)
-				// }
-
-				return ok
-			}) {
-				t.Error("no match")
-			}
-		})
-	}
-
 	t.Run(`trace to bar("x") should not exist`, func(t *testing.T) {
 		if funcutil.Exists(traces, func(trace backtrace.Trace) bool {
 			arg, ok := trace[0].Node.(*dataflow.CallNodeArg)
@@ -426,10 +445,7 @@ func testAnalyzeClosures(t *testing.T, lp *loadprogram.State) {
 		t.Fatal(err)
 	}
 
-	tests := []struct {
-		name    string
-		matches []match
-	}{
+	tests := []traceTest{
 		{
 			name: `trace to source in example1 from sink arg 0 in example1`,
 			// "[#471.0] source.return" at /Volumes/workplace/argot/testdata/src/taint/closures/helpers.go:23:6
@@ -525,32 +541,7 @@ func testAnalyzeClosures(t *testing.T, lp *loadprogram.State) {
 		},
 	}
 
-	traces := mergeTraces(res)
-	if len(traces) < len(tests) {
-		t.Fatalf("analysis did not find enough traces: want at least %d, got %d", len(tests), len(traces))
-	}
-
-	t.Log("TRACES:")
-	for _, trace := range traces {
-		t.Log(trace)
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if !funcutil.Exists(traces, func(trace backtrace.Trace) bool {
-				ok, err := matchTrace(state, trace, test.matches)
-				_ = err
-				// // NOTE commented out for debugging
-				// if err != nil {
-				// 	t.Errorf("failed match: %v in trace: %v", err, trace)
-				// }
-
-				return ok
-			}) {
-				t.Error("no match")
-			}
-		})
-	}
+	checkTraces(t, res, tests)
 }
 
 func TestAnalyze_CheckStatic(t *testing.T) {
@@ -581,6 +572,44 @@ func TestAnalyze_CheckStatic(t *testing.T) {
 				t.Fatalf("Origin %s of trace doesn't match the expected %s", trace[0][0].Node, expected)
 			}
 		}
+	}
+}
+
+type traceTest struct {
+	name    string
+	matches []match
+}
+
+func checkTraces(t *testing.T, res backtrace.AnalysisResult, tests []traceTest) {
+	traces := mergeTraces(res)
+	if len(traces) < len(tests) {
+		t.Fatalf("analysis did not find enough traces: want at least %d, got %d", len(tests), len(traces))
+	}
+
+	// // NOTE Uncomment to debug
+	// t.Log("TRACES:")
+	// for _, trace := range res.Traces {
+	// 	t.Log(trace)
+	// }
+
+	for _, test := range tests {
+		test := test // needed for t.Parallel()
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if !funcutil.Exists(traces, func(trace backtrace.Trace) bool {
+				ok, err := matchTrace(res.Graph.AnalyzerState, trace, test.matches)
+				_ = err
+				// // NOTE commented out for debugging
+				// if err != nil {
+				// 	t.Errorf("failed match: %v in trace: %v", err, trace)
+				// }
+
+				return ok
+			}) {
+				t.Error("no match")
+			}
+		})
 	}
 }
 

--- a/analysis/backtrace/backtrace_test.go
+++ b/analysis/backtrace/backtrace_test.go
@@ -108,6 +108,12 @@ func TestAnalyze_SpecificObjs(t *testing.T) {
 				{arg, argval{`"test2":string`, 2}, 21},
 			},
 		},
+		{
+			name: `trace to trackOnlyVariadic arg 1 in main from main`,
+			matches: []match{
+				{arg, argval{`t5`, 1}, -1},
+			},
+		},
 	}
 
 	checkTraces(t, res, tests)

--- a/analysis/backtrace/testdata/src/backtrace/config.yaml
+++ b/analysis/backtrace/testdata/src/backtrace/config.yaml
@@ -1,7 +1,16 @@
 slicing-problems:
   - backtracepoints:
-    - package: "os/exec"
-      method: "^Command$"
+      - package: "os/exec"
+        method: "^Command$"
+      - target:
+          kind: "call"
+          package: "command-line-arguments"
+          method: "trackArg"
+          objects:
+            - kind: "argument"
+              name: "y"
+              index: 1
+              type: "string"
 
 options:
-    log-level: 5 # trace logging
+  log-level: 5 # trace logging

--- a/analysis/backtrace/testdata/src/backtrace/main.go
+++ b/analysis/backtrace/testdata/src/backtrace/main.go
@@ -49,6 +49,9 @@ func main() {
 	runcmd(bar("ls3"))
 
 	runglobal()
+
+	data := "test"
+	trackArg(0, data)
 }
 
 func foo() {
@@ -87,4 +90,7 @@ func write() string {
 		global = baz("hello2")
 	}
 	return global
+}
+
+func trackArg(x int, y string) {
 }

--- a/analysis/backtrace/testdata/trace-specific/config.yaml
+++ b/analysis/backtrace/testdata/trace-specific/config.yaml
@@ -1,0 +1,25 @@
+dataflow-problems:
+  slicing:
+    - backtracepoints:
+        - target:
+            kind: "call"
+            package: "github.com/awslabs/ar-go-tools/analysis/backtrace/testdata/trace-specific"
+            method: "trackSecondArg"
+            objects:
+              - kind: "argument"
+                name: "y"
+                index: 1
+                type: "string"
+        - target:
+            kind: "call"
+            package: "github.com/awslabs/ar-go-tools/analysis/backtrace/testdata/trace-specific"
+            method: "trackSecondAndThirdArg"
+            objects:
+              - kind: "argument"
+                name: "y"
+                index: 1
+                type: "uint"
+              - kind: "argument"
+                name: "z"
+                index: 2
+                type: "string"

--- a/analysis/backtrace/testdata/trace-specific/config.yaml
+++ b/analysis/backtrace/testdata/trace-specific/config.yaml
@@ -23,3 +23,12 @@ dataflow-problems:
                 name: "z"
                 index: 2
                 type: "string"
+        - target:
+            kind: "call"
+            package: "github.com/awslabs/ar-go-tools/analysis/backtrace/testdata/trace-specific"
+            method: "trackOnlyVariadic"
+            objects:
+              - kind: "argument"
+                name: "ys"
+                index: 1
+                type: "...string"

--- a/analysis/backtrace/testdata/trace-specific/main.go
+++ b/analysis/backtrace/testdata/trace-specific/main.go
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+func main() {
+	data := "test"
+	trackSecondArg(0, data)
+
+	trackSecondAndThirdArg(0, 1, "test2")
+}
+
+func trackSecondArg(x int, y string) {
+}
+
+func trackSecondAndThirdArg(x int, y uint, z string) {
+}

--- a/analysis/backtrace/testdata/trace-specific/main.go
+++ b/analysis/backtrace/testdata/trace-specific/main.go
@@ -19,10 +19,15 @@ func main() {
 	trackSecondArg(0, data)
 
 	trackSecondAndThirdArg(0, 1, "test2")
+
+	trackOnlyVariadic(3, "test3", "test4")
 }
 
 func trackSecondArg(x int, y string) {
 }
 
 func trackSecondAndThirdArg(x int, y uint, z string) {
+}
+
+func trackOnlyVariadic(x int, ys ...string) {
 }

--- a/analysis/config/code_identifier.go
+++ b/analysis/config/code_identifier.go
@@ -269,6 +269,7 @@ func compileRegexes(cid CodeIdentifier) CodeIdentifier {
 //gocyclo:ignore
 func (cid *CodeIdentifier) equalOnNonEmptyFields(cidRef CodeIdentifier) bool {
 	if isNewFormat(cidRef) {
+		// Returns false if cid is not in the new format as well
 		return cid.equalNewFormat(cidRef)
 	}
 
@@ -301,8 +302,7 @@ func (cid *CodeIdentifier) equalOnNonEmptyFields(cidRef CodeIdentifier) bool {
 //
 //gocyclo:ignore
 func (cid *CodeIdentifier) equalNewFormat(cidRef CodeIdentifier) bool {
-	// If cidRef is in the new format, cid will also be in the new format
-	if cidRef.Target.Kind != cid.Target.Kind {
+	if cid == nil || !isNewFormat(*cid) {
 		return false
 	}
 	switch cidRef.Target.Kind {

--- a/analysis/config/code_identifier.go
+++ b/analysis/config/code_identifier.go
@@ -70,6 +70,104 @@ type CodeIdentifier struct {
 	// computedRegexs is not part of the yaml config, but contains the compiled regex version of the code identifier
 	// elements that are parsed as regexes.
 	computedRegexs *codeIdentifierRegex
+
+	// --- Fields for the new format: ---
+
+	// Target identifies a program value that the analysis should analyze as an
+	// entrypoint.
+	// It can be "narrowed" further if needed to match specific objects that are
+	// part of the target.
+	Target Target
+
+	// Enclosing specifies the calling context of the target (only for method targets).
+	Enclosing CallingContext
+}
+
+// Target matches a specific program value to be analyzed as an
+// entrypoint.
+type Target struct {
+	// Kind is the kind of target.
+	// Supported kinds:
+	// - "call"
+	Kind TargetKind
+
+	// Package is the name of the package that the method belongs to.
+	Package string
+
+	// Method is the name of the method or function.
+	Method string
+
+	// Objects are the specific objects (values) in the target that the analysis
+	// should analyze as an entrypoints.
+	//
+	// A "target object" can be an argument, return value, etc.
+	// The supported kinds of objects depend on the kind of the target.
+	Objects []TargetObject
+}
+
+// CallingContext matches a function/method that specifies the calling context
+// of the target.
+type CallingContext struct {
+	Package        string
+	PackageRegex   string `xml:"package-regex,attr" yaml:"package~" json:"package~"`
+	Method         string
+	MethodRegex    string `xml:"method-regex,attr" yaml:"method~" json:"method~"`
+	computedRegexs *callingContextRegex
+}
+
+type callingContextRegex struct {
+	packageRegex *regexp.Regexp
+	methodRegex  *regexp.Regexp
+}
+
+// TargetKind is the kind of target.
+type TargetKind string
+
+const (
+	// CallKind indicates a function/method call target.
+	CallKind TargetKind = "call"
+)
+
+// TargetObject is a specific object value in the target that the analysis
+// should analyze as an entrypoint.
+type TargetObject struct {
+	// Kind is the kind of entrypoint.
+	//
+	// Supported Kinds:
+	// - "argument"
+	Kind ObjectKind
+
+	// Name is the (optional) name of the entrypoint.
+	//
+	// For example, if the Kind is an argument, `Name` should be set to the
+	// parameter name in the function.
+	Name string
+
+	// Index is the index of the entrypoint.
+	//
+	// If the Kind is an argument, Index is the argument index.
+	// If the Kind is a return value, Index specifies which returned tuple
+	// element is the entrypoint.
+	Index uint
+
+	// Type is the type of the entrypoint.
+	Type string
+}
+
+// ObjectKind is the kind of entrypoint object.
+type ObjectKind string
+
+const (
+	// ArgumentKind indicates an function call argument entrypoint.
+	ArgumentKind ObjectKind = "argument"
+	// ReturnKind indicates a return value entrypoint.
+	// TODO implement support
+	// ReturnKind ObjectKind = "return"
+)
+
+// isNewFormat returns true if cid is specified using the new format.
+func isNewFormat(cid CodeIdentifier) bool {
+	return cid.Target.Kind != ""
 }
 
 // NewCodeIdentifier properly intializes cid.
@@ -94,6 +192,27 @@ type codeIdentifierRegex struct {
 // @ensures cid.computedRegexs == null || cid.computedRegexs.(*) != null
 // TODO improve error handling
 func compileRegexes(cid CodeIdentifier) CodeIdentifier {
+	if isNewFormat(cid) {
+		// Enclosing is the only object that may contain regexes (for now)
+		cid.Enclosing.computedRegexs = &callingContextRegex{}
+		if cid.Enclosing.PackageRegex != "" {
+			packageRegex, err := regexp.Compile(cid.Enclosing.PackageRegex)
+			if err != nil {
+				fmt.Printf("[WARN] failed to compile enclosing package regex %v: %v\n", cid.Enclosing.PackageRegex, err)
+			}
+			cid.Enclosing.computedRegexs.packageRegex = packageRegex
+		}
+		if cid.Enclosing.MethodRegex != "" {
+			methodRegex, err := regexp.Compile(cid.Enclosing.MethodRegex)
+			if err != nil {
+				fmt.Printf("[WARN] failed to compile enclosing method regex %v: %v\n", cid.Enclosing.MethodRegex, err)
+			}
+			cid.Enclosing.computedRegexs.methodRegex = methodRegex
+		}
+
+		return cid
+	}
+
 	contextRegex, err := regexp.Compile(cid.Context)
 	if err != nil {
 		fmt.Printf("[WARN] failed to compile context regex %v: %v\n", cid.Context, err)
@@ -149,6 +268,10 @@ func compileRegexes(cid CodeIdentifier) CodeIdentifier {
 //
 //gocyclo:ignore
 func (cid *CodeIdentifier) equalOnNonEmptyFields(cidRef CodeIdentifier) bool {
+	if isNewFormat(cidRef) {
+		return cid.equalNewFormat(cidRef)
+	}
+
 	if cidRef.computedRegexs != nil {
 		return ((cidRef.computedRegexs.contextRegex.MatchString(cid.Context)) || (cidRef.Context == "")) &&
 			((cidRef.computedRegexs.packageRegex.MatchString(cid.Package)) || (cidRef.Package == "")) &&
@@ -171,6 +294,68 @@ func (cid *CodeIdentifier) equalOnNonEmptyFields(cidRef CodeIdentifier) bool {
 		((cid.Type == cidRef.Type) || (cidRef.Type == "")) &&
 		((cid.ValueMatch == cidRef.ValueMatch) || (cidRef.ValueMatch == "")) &&
 		(cidRef.Kind == cid.Kind)
+}
+
+// equalNewFormat returns true if cidRef's fields are equal to cid in the new
+// code identifier format.
+//
+//gocyclo:ignore
+func (cid *CodeIdentifier) equalNewFormat(cidRef CodeIdentifier) bool {
+	// If cidRef is in the new format, cid will also be in the new format
+	if cidRef.Target.Kind != cid.Target.Kind {
+		return false
+	}
+	switch cidRef.Target.Kind {
+	case CallKind:
+		// package and method must match
+		if cidRef.Target.Package != cid.Target.Package {
+			return false
+		}
+		if cidRef.Target.Method != cid.Target.Method {
+			return false
+		}
+		// If cidRef (config cid) does not have any objects specified, then don't check them
+		if len(cidRef.Target.Objects) > 0 {
+			// every object in cid must be present in cidRef
+			for _, obj := range cid.Target.Objects {
+				found := false
+				for _, objRef := range cidRef.Target.Objects {
+					if obj.Kind == objRef.Kind && obj.Name == objRef.Name && obj.Type == objRef.Type && obj.Index == objRef.Index {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return false
+				}
+			}
+		}
+	}
+	// Enclosing (calling context) does not need to be specified
+	if cidRef.Enclosing.Package != "" {
+		if cidRef.Enclosing.computedRegexs.packageRegex != nil {
+			if !cidRef.Enclosing.computedRegexs.packageRegex.MatchString(cid.Enclosing.Package) {
+				return false
+			}
+		} else {
+			if cidRef.Enclosing.Package != cid.Enclosing.Package {
+				return false
+			}
+		}
+	}
+	if cidRef.Enclosing.Method != "" {
+		if cidRef.Enclosing.computedRegexs.methodRegex != nil {
+			if !cidRef.Enclosing.computedRegexs.methodRegex.MatchString(cid.Enclosing.Method) {
+				return false
+			}
+		} else {
+			if cidRef.Enclosing.Method != cid.Enclosing.Method {
+				return false
+			}
+		}
+	}
+
+	return true
 }
 
 // ExistsCid is true if there is some x in a such that f(x) is true.

--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -44,37 +44,37 @@ func checkNotEqualOnNonEmptyFields(t *testing.T, cid1 CodeIdentifier, cid2 CodeI
 }
 
 func TestCodeIdentifier_equalOnNonEmptyFields_selfEquals(t *testing.T) {
-	cid1 := CodeIdentifier{"", "a", "", "b", "", "", "", "", "", "", "", nil}
+	cid1 := CodeIdentifier{"", "a", "", "b", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
 	checkEqualOnNonEmptyFields(t, cid1, cid1)
 }
 
 func TestCodeIdentifier_equalOnNonEmptyFields_emptyMatchesAny(t *testing.T) {
-	cid1 := CodeIdentifier{"", "a", "b", "i", "c", "d", "e", "", "", "", "", nil}
-	cid2 := CodeIdentifier{"", "de", "234jbn", "ef", "23kjb", "d", "234", "", "", "", "", nil}
+	cid1 := CodeIdentifier{"", "a", "b", "i", "c", "d", "e", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid2 := CodeIdentifier{"", "de", "234jbn", "ef", "23kjb", "d", "234", "", "", "", "", nil, Target{}, CallingContext{}}
 	cidEmpty := CodeIdentifier{}
 	checkEqualOnNonEmptyFields(t, cid1, cidEmpty)
 	checkEqualOnNonEmptyFields(t, cid2, cidEmpty)
 }
 
 func TestCodeIdentifier_equalOnNonEmptyFields_oneDiff(t *testing.T) {
-	cid1 := CodeIdentifier{"", "a", "b", "", "", "", "", "", "", "", "", nil}
-	cid2 := CodeIdentifier{"", "a", "", "", "", "", "", "", "", "", "", nil}
+	cid1 := CodeIdentifier{"", "a", "b", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid2 := CodeIdentifier{"", "a", "", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
 	checkEqualOnNonEmptyFields(t, cid1, cid2)
 	checkNotEqualOnNonEmptyFields(t, cid2, cid1)
 }
 
 func TestCodeIdentifier_equalOnNonEmptyFields_regexes(t *testing.T) {
-	cid1 := CodeIdentifier{"", "main", "b", "", "", "", "", "", "", "", "", nil}
-	cid1bis := CodeIdentifier{"", "command-line-arguments", "b", "", "", "", "", "", "", "", "", nil}
-	cid2 := CodeIdentifier{"", "(main)|(command-line-arguments)$", "", "", "", "", "", "", "", "", "", nil}
+	cid1 := CodeIdentifier{"", "main", "b", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid1bis := CodeIdentifier{"", "command-line-arguments", "b", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid2 := CodeIdentifier{"", "(main)|(command-line-arguments)$", "", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
 	checkEqualOnNonEmptyFields(t, cid1, cid2)
 	checkEqualOnNonEmptyFields(t, cid1bis, cid2)
 }
 
 func TestCodeIdentifier_equalOnNonEmptyFields_regexes_withContexts(t *testing.T) {
-	cid1 := CodeIdentifier{"main-package", "main", "", "b", "", "", "", "", "", "", "", nil}
-	cid1bis := CodeIdentifier{"main", "command-line-arguments", "", "b", "", "", "", "", "", "", "", nil}
-	cid2 := CodeIdentifier{"mai.*", "(main)|(command-line-arguments)$", "", "", "", "", "", "", "", "", "", nil}
+	cid1 := CodeIdentifier{"main-package", "main", "", "b", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid1bis := CodeIdentifier{"main", "command-line-arguments", "", "b", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid2 := CodeIdentifier{"mai.*", "(main)|(command-line-arguments)$", "", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
 	checkEqualOnNonEmptyFields(t, cid1, cid2)
 	checkEqualOnNonEmptyFields(t, cid1bis, cid2)
 }
@@ -447,8 +447,8 @@ func TestLoadMisc(t *testing.T) {
 		t,
 		"config.yaml",
 		mkConfig(
-			[]CodeIdentifier{{"", "a", "", "b", "", "", "", "", "", "", "", nil}},
-			[]CodeIdentifier{{"", "c", "", "d", "", "", "", "", "", "", "", nil}},
+			[]CodeIdentifier{{"", "a", "", "b", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
+			[]CodeIdentifier{{"", "c", "", "d", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
 			[]CodeIdentifier{},
 		),
 	)
@@ -456,20 +456,20 @@ func TestLoadMisc(t *testing.T) {
 	testLoadOneFile(t,
 		"config2.json",
 		mkConfig(
-			[]CodeIdentifier{{"", "x", "", "a", "", "b", "", "", "", "", "", nil}},
-			[]CodeIdentifier{{"", "y", "", "b", "", "", "", "", "", "", "", nil}},
-			[]CodeIdentifier{{"", "p", "", "a", "", "", "", "", "", "", "", nil},
-				{"", "p2", "", "a", "", "", "", "", "", "", "", nil}},
+			[]CodeIdentifier{{"", "x", "", "a", "", "b", "", "", "", "", "", nil, Target{}, CallingContext{}}},
+			[]CodeIdentifier{{"", "y", "", "b", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
+			[]CodeIdentifier{{"", "p", "", "a", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}},
+				{"", "p2", "", "a", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
 		),
 	)
 	//
 	testLoadOneFile(t,
 		"config2.yaml",
 		mkConfig(
-			[]CodeIdentifier{{"", "x", "", "a", "", "b", "", "", "", "", "", nil}},
-			[]CodeIdentifier{{"", "y", "", "b", "", "", "", "", "", "", "", nil}},
-			[]CodeIdentifier{{"", "p", "", "a", "", "", "", "", "", "", "", nil},
-				{"", "p2", "", "a", "", "", "", "", "", "", "", nil}},
+			[]CodeIdentifier{{"", "x", "", "a", "", "b", "", "", "", "", "", nil, Target{}, CallingContext{}}},
+			[]CodeIdentifier{{"", "y", "", "b", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
+			[]CodeIdentifier{{"", "p", "", "a", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}},
+				{"", "p2", "", "a", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
 		),
 	)
 	//
@@ -479,14 +479,14 @@ func TestLoadMisc(t *testing.T) {
 			DataflowProblems: DataflowProblems{
 				TaintTrackingProblems: []TaintSpec{
 					{
-						Sanitizers: []CodeIdentifier{{"", "pkg1", "", "Foo", "Obj", "", "", "", "", "", "", nil}},
-						Sinks: []CodeIdentifier{{"", "y", "", "b", "", "", "", "", "", "", "", nil},
-							{"", "x", "", "", "Obj1", "", "", "", "", "", "", nil}},
+						Sanitizers: []CodeIdentifier{{"", "pkg1", "", "Foo", "Obj", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
+						Sinks: []CodeIdentifier{{"", "y", "", "b", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}},
+							{"", "x", "", "", "Obj1", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
 						Sources: []CodeIdentifier{
-							{"", "some/package", "", "SuperMethod", "", "", "", "", "", "", "", nil},
+							{"", "some/package", "", "SuperMethod", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}},
 
-							{"", "some/other/package", "", "", "", "OneField", "ThatStruct", "", "", "", "", nil},
-							{"", "some/other/package", "Interface", "", "", "", "", "", "", "", "", nil},
+							{"", "some/other/package", "", "", "", "OneField", "ThatStruct", "", "", "", "", nil, Target{}, CallingContext{}},
+							{"", "some/other/package", "Interface", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}},
 						},
 						FailOnImplicitFlow: false,
 					},
@@ -505,8 +505,63 @@ func TestLoadMisc(t *testing.T) {
 		},
 	)
 	// Test configuration file for static-commands
-	osExecCid := CodeIdentifier{"", "os/exec", "", "Command", "", "", "", "", "", "", "", nil}
+	osExecCid := CodeIdentifier{"", "os/exec", "", "Command", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
 	cfg := NewDefault()
 	cfg.StaticCommandsProblems = []StaticCommandsSpec{{[]CodeIdentifier{osExecCid}}}
 	testLoadOneFile(t, "config-find-osexec.yaml", *cfg)
+}
+
+// TestLoadNew tests loading the new code identifier format.
+func TestLoadNew(t *testing.T) {
+	want := NewDefault()
+	want.DataflowProblems = DataflowProblems{
+		SlicingProblems: []SlicingSpec{
+			{
+				Tag:         "tag-name",
+				Description: "Sample description",
+				BacktracePoints: []CodeIdentifier{
+					{
+						Target: Target{
+							Kind:    CallKind,
+							Package: "os",
+							Method:  "Mkdir",
+							Objects: []TargetObject{
+								{
+									Kind:  ArgumentKind,
+									Name:  "name",
+									Index: 0,
+									Type:  "string",
+								},
+							},
+						},
+						Enclosing: CallingContext{
+							Package: "package-name",
+							Method:  "method",
+						},
+					},
+					{
+						Target: Target{
+							Kind:    CallKind,
+							Package: "os",
+							Method:  "MkdirAll",
+							Objects: []TargetObject{
+								{
+									Kind:  ArgumentKind,
+									Name:  "path",
+									Index: 0,
+									Type:  "string",
+								},
+							},
+						},
+						Enclosing: CallingContext{
+							PackageRegex: "package.*",
+							MethodRegex:  ".*",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testLoadOneFile(t, "config-new.yaml", *want)
 }

--- a/analysis/config/dataflow_config.go
+++ b/analysis/config/dataflow_config.go
@@ -200,7 +200,7 @@ func (c Config) IsSomeValidator(cid CodeIdentifier) bool {
 // IsSomeBacktracePoint returns true if the code identifier matches any backtrace point in the slicing problems
 func (c Config) IsSomeBacktracePoint(cid CodeIdentifier) bool {
 	for _, ss := range c.DataflowProblems.SlicingProblems {
-		if ss.IsBacktracePoint(cid) {
+		if _, ok := ss.IsBacktracePoint(cid); ok {
 			return true
 		}
 	}
@@ -234,8 +234,12 @@ func (scs StaticCommandsSpec) IsStaticCommand(cid CodeIdentifier) bool {
 }
 
 // IsBacktracePoint returns true if the code identifier matches a backtrace point according to the SlicingSpec
-func (ss SlicingSpec) IsBacktracePoint(cid CodeIdentifier) bool {
-	return ExistsCid(ss.BacktracePoints, cid.equalOnNonEmptyFields)
+func (ss SlicingSpec) IsBacktracePoint(cid CodeIdentifier) (CodeIdentifier, bool) {
+	if ExistsCid(ss.BacktracePoints, cid.equalOnNonEmptyFields) {
+		return cid, true
+	}
+
+	return CodeIdentifier{}, false
 }
 
 // TargetIncludes returns true if the list of targets includes the targets or has the "all" target, or the target

--- a/analysis/config/testdata/config-new.yaml
+++ b/analysis/config/testdata/config-new.yaml
@@ -1,0 +1,29 @@
+dataflow-problems:
+  slicing:
+    - tag: "tag-name"
+      description: "Sample description"
+      backtracepoints:
+        - target:
+            kind: "call"
+            package: "os"
+            method: "Mkdir"
+            objects:
+              - kind: "argument"
+                name: "name"
+                index: 0
+                type: "string"
+          enclosing:
+            package: "package-name"
+            method: "method"
+        - target:
+            kind: "call"
+            package: "os"
+            method: "MkdirAll"
+            objects:
+              - kind: "argument"
+                name: "path"
+                index: 0
+                type: "string"
+          enclosing:
+            package~: "package.*"
+            method~: ".*"

--- a/analysis/dataflow/code_identifiers.go
+++ b/analysis/dataflow/code_identifiers.go
@@ -34,39 +34,59 @@ import (
 // - reading from channels marked as source
 // - writing in struct fields that are marked as sinks.
 func IsNodeOfInterest(state *State, n ssa.Node) bool {
-	return analysisutil.IsEntrypointNode(state.PointerAnalysis, n, state.Config.IsSomeSource) ||
-		analysisutil.IsEntrypointNode(state.PointerAnalysis, n, state.Config.IsSomeSink) ||
-		analysisutil.IsEntrypointNode(state.PointerAnalysis, n, state.Config.IsSomeBacktracePoint) ||
-		state.ResolveSsaNode(annotations.Source, "_", n) ||
-		state.ResolveSsaNode(annotations.Sink, "_", n)
+	if _, ok := analysisutil.IsEntrypointNode(state.PointerAnalysis, n, state.Config.IsSomeSource); ok {
+		return true
+	}
+	if _, ok := analysisutil.IsEntrypointNode(state.PointerAnalysis, n, state.Config.IsSomeSink); ok {
+		return true
+	}
+	if _, ok := analysisutil.IsEntrypointNode(state.PointerAnalysis, n, state.Config.IsSomeBacktracePoint); ok {
+		return true
+	}
+
+	return state.ResolveSsaNode(annotations.Source, "_", n) || state.ResolveSsaNode(annotations.Sink, "_", n)
 }
 
 // IsSourceNode returns true if n matches the code identifier of a source node in the taint specification.
 // If the taint specification is nil, then it will look whether the node can be any source node in the
 // config.
-func IsSourceNode(state *State, ts *config.TaintSpec, n ssa.Node) bool {
+func IsSourceNode(state *State, ts *config.TaintSpec, n ssa.Node) (config.CodeIdentifier, bool) {
 	if ts == nil {
-		return analysisutil.IsEntrypointNode(state.PointerAnalysis, n, state.Config.IsSomeSource) ||
-			state.ResolveSsaNode(annotations.Source, "_", n)
+		if cid, ok := analysisutil.IsEntrypointNode(state.PointerAnalysis, n, state.Config.IsSomeSource); ok {
+			return cid, true
+		}
+		return config.CodeIdentifier{}, state.ResolveSsaNode(annotations.Source, "_", n)
 	}
-	return analysisutil.IsEntrypointNode(state.PointerAnalysis, n, ts.IsSource) ||
-		state.ResolveSsaNode(annotations.Source, ts.Tag, n)
+	if cid, ok := analysisutil.IsEntrypointNode(state.PointerAnalysis, n, ts.IsSource); ok {
+		return cid, true
+	}
+	return config.CodeIdentifier{}, state.ResolveSsaNode(annotations.Source, ts.Tag, n)
 }
 
 // IsBacktraceNode returns true if slicing spec identifies n as a backtrace entrypoint. If the backtrace specification
 // is nil, then it will look at whether the node can be any backtrace point in the config.
-func IsBacktraceNode(state *State, ss *config.SlicingSpec, n ssa.Node) bool {
+func IsBacktraceNode(state *State, ss *config.SlicingSpec, n ssa.Node) (config.CodeIdentifier, bool) {
 	if f, ok := n.(*ssa.Function); ok {
 		pkg := lang.PackageNameFromFunction(f)
 		return ss.IsBacktracePoint(config.CodeIdentifier{Package: pkg, Method: f.Name()})
 	}
 
 	if ss == nil {
-		return analysisutil.IsEntrypointNode(state.PointerAnalysis, n, state.Config.IsSomeBacktracePoint) ||
-			state.ResolveSsaNode(annotations.BacktracePoint, "_", n)
+		if cid, ok := analysisutil.IsEntrypointNode(state.PointerAnalysis, n, state.Config.IsSomeBacktracePoint); ok {
+			return cid, true
+		}
+		return config.CodeIdentifier{}, state.ResolveSsaNode(annotations.BacktracePoint, "_", n)
 	}
-	return analysisutil.IsEntrypointNode(state.PointerAnalysis, n, ss.IsBacktracePoint) ||
-		state.ResolveSsaNode(annotations.BacktracePoint, ss.Tag, n)
+	f := func(cid config.CodeIdentifier) bool {
+		if _, ok := ss.IsBacktracePoint(cid); ok {
+			return true
+		}
+		return false
+	}
+	if cid, ok := analysisutil.IsEntrypointNode(state.PointerAnalysis, n, f); ok {
+		return cid, true
+	}
+	return config.CodeIdentifier{}, state.ResolveSsaNode(annotations.BacktracePoint, ss.Tag, n)
 }
 
 // IsSink returns true if the taint spec identifies n as a sink.
@@ -170,7 +190,10 @@ func isMatchingCodeID(codeIDOracle func(config.CodeIdentifier) bool, n GraphNode
 	case *BuiltinCallNode:
 		return codeIDOracle(config.CodeIdentifier{Context: n.parent.Parent.String(), Method: n.name})
 	case *SyntheticNode:
-		return analysisutil.IsEntrypointNode(nil, n.Instr().(ssa.Node), codeIDOracle)
+		if _, ok := analysisutil.IsEntrypointNode(nil, n.Instr().(ssa.Node), codeIDOracle); ok {
+			return true
+		}
+		return false
 	case *ReturnValNode, *ClosureNode, *BoundVarNode:
 		return false
 	default:

--- a/analysis/dataflow/function_summary_graph.go
+++ b/analysis/dataflow/function_summary_graph.go
@@ -373,7 +373,7 @@ func (g *SummaryGraph) addCallInstr(c *State, instr ssa.CallInstruction) {
 				argPos:    pos,
 				out:       make(map[GraphNode][]EdgeInfo),
 				in:        make(map[GraphNode]EdgeInfo),
-				paramName: params[pos].Name(),
+				paramName: params[pos].Var.Name(),
 			}
 			node.args[pos] = argNode
 		}

--- a/analysis/dataflow/function_summary_graph.go
+++ b/analysis/dataflow/function_summary_graph.go
@@ -335,6 +335,10 @@ func (g *SummaryGraph) addCallInstr(c *State, instr ssa.CallInstruction) {
 	}
 
 	args := lang.GetArgs(instr)
+	params := lang.GetParams(instr)
+	if len(params) != len(args) {
+		panic(fmt.Errorf("param len %d != arg len %d: params: %v, args: %v", len(params), len(args), params, args))
+	}
 	callees, err := c.ResolveCallee(instr, true)
 	if err != nil {
 		c.Logger.Errorf("missing information in state (%s), could not resolve callee in instruction %s", err,
@@ -363,12 +367,13 @@ func (g *SummaryGraph) addCallInstr(c *State, instr ssa.CallInstruction) {
 
 		for pos, arg := range args {
 			argNode := &CallNodeArg{
-				id:       g.newNodeID(),
-				parent:   node,
-				ssaValue: arg,
-				argPos:   pos,
-				out:      make(map[GraphNode][]EdgeInfo),
-				in:       make(map[GraphNode]EdgeInfo),
+				id:        g.newNodeID(),
+				parent:    node,
+				ssaValue:  arg,
+				argPos:    pos,
+				out:       make(map[GraphNode][]EdgeInfo),
+				in:        make(map[GraphNode]EdgeInfo),
+				paramName: params[pos].Name(),
 			}
 			node.args[pos] = argNode
 		}
@@ -384,7 +389,7 @@ func (g *SummaryGraph) addBuiltinCallInstr(instr ssa.CallInstruction) {
 		return
 	}
 
-	//_args := lang.GetArgs(instr)
+	// _args := lang.GetArgs(instr)
 
 	node := &BuiltinCallNode{
 		id:       g.newNodeID(),
@@ -861,7 +866,7 @@ func (g *SummaryGraph) addGlobalEdge(mark MarkWithAccessPath, cond *ConditionInf
 
 	if node == nil {
 		// TODO: debug this
-		//g.addError(fmt.Errorf("attempting to set global edge but no global node"))
+		// g.addError(fmt.Errorf("attempting to set global edge but no global node"))
 		return
 	}
 	// Set node to written

--- a/analysis/dataflow/function_summary_graph_nodes.go
+++ b/analysis/dataflow/function_summary_graph_nodes.go
@@ -378,13 +378,14 @@ func (a *FreeVarNode) LongID() string {
 
 // CallNodeArg is a node that represents the argument of a function call
 type CallNodeArg struct {
-	id       uint32
-	parent   *CallNode
-	ssaValue ssa.Value
-	argPos   int
-	out      map[GraphNode][]EdgeInfo
-	in       map[GraphNode]EdgeInfo
-	marks    LocSet
+	id        uint32
+	parent    *CallNode
+	ssaValue  ssa.Value
+	argPos    int
+	out       map[GraphNode][]EdgeInfo
+	in        map[GraphNode]EdgeInfo
+	marks     LocSet
+	paramName string // paramName is the name of the callee's parameter.
 }
 
 // ID returns the integer id of the node in its parent graph
@@ -451,6 +452,11 @@ func (a *CallNodeArg) LongID() string {
 // Value returns the ssa value of the call argument
 func (a *CallNodeArg) Value() ssa.Value {
 	return a.ssaValue
+}
+
+// ParamName returns the name of the callee's corresponding parameter.
+func (a *CallNodeArg) ParamName() string {
+	return a.paramName
 }
 
 // CallNode is a node that represents a function call. It represents the Value returned by the function call

--- a/analysis/dataflow/inter_procedural.go
+++ b/analysis/dataflow/inter_procedural.go
@@ -20,9 +20,11 @@ import (
 	"io"
 	"os"
 
+	"github.com/awslabs/ar-go-tools/analysis/config"
 	"github.com/awslabs/ar-go-tools/analysis/lang"
 	"github.com/awslabs/ar-go-tools/analysis/summaries"
 	"github.com/awslabs/ar-go-tools/internal/formatutil"
+	"github.com/awslabs/ar-go-tools/internal/funcutil"
 	"golang.org/x/tools/go/ssa"
 )
 
@@ -259,14 +261,20 @@ func (g *InterProceduralFlowGraph) Sync() {
 // predicates to identify graph nodes that are the entry points of the analysis.
 type ScanningSpec struct {
 	// IsEntryPointSsa identifies graph nodes by the ssa node they represent.
-	IsEntryPointSsa func(node ssa.Node) bool
+	// It returns the code identifier from the config file if there was a match.
+	IsEntryPointSsa func(node ssa.Node) (config.CodeIdentifier, bool)
 
 	// IsEntryPointGraph identifies graph nodes directly as entry points.
-	IsEntryPointGraph func(node GraphNode) bool
+	// It returns the code identifier from the config file if there was a match.
+	IsEntryPointGraph func(node GraphNode) (config.CodeIdentifier, bool)
 
 	// MarkCallArgsLikeCall specifies whether call arguments should be considered entry points when the call is
 	// an entry point.
 	MarkCallArgsLikeCall bool
+
+	// ScanCallArgsOnly specifies whether only call arguments should be
+	// considered entry points - not the call itself.
+	ScanCallArgsOnly bool
 }
 
 // BuildAndRunVisitor runs the pass on the inter-procedural flow graph. First, it calls the BuildGraph function to
@@ -335,18 +343,35 @@ func (g *InterProceduralFlowGraph) RunVisitorOnEntryPoints(visitor Visitor, spec
 	}
 }
 
+// TODO this will likely get refactored in the future anyways
+//
+//gocyclo:ignore
 func scanEntryPoints(
 	g *InterProceduralFlowGraph,
 	spec ScanningSpec,
 	entryPoints map[KeyType]NodeWithTrace) func(n GraphNode) {
 	return func(n GraphNode) {
-		if spec.IsEntryPointGraph != nil && spec.IsEntryPointGraph(n) {
-			for _, callnode := range n.Graph().Callsites {
-				contexts := GetAllCallingContexts(g.AnalyzerState, callnode)
-				addWithContexts(contexts, n, entryPoints)
+		if spec.IsEntryPointGraph != nil {
+			if _, ok := spec.IsEntryPointGraph(n); ok {
+				switch node := n.(type) {
+				case *CallNodeArg:
+					contexts := GetAllCallingContexts(g.AnalyzerState, node.ParentNode())
+					nodes := addContexts(contexts, node)
+					for _, nt := range nodes {
+						entryPoints[nt.Key()] = nt
+					}
+					return
+				}
+
+				for _, callnode := range n.Graph().Callsites {
+					contexts := GetAllCallingContexts(g.AnalyzerState, callnode)
+					nodes := addContexts(contexts, n)
+					for _, node := range nodes {
+						entryPoints[node.Key()] = node
+					}
+				}
 			}
 		}
-
 		// if the isEntryPointSsa function is not specified, skip the special casing
 		if spec.IsEntryPointSsa == nil {
 			return
@@ -358,15 +383,30 @@ func scanEntryPoints(
 		case *SyntheticNode:
 			addSyntheticNodeEntryPoints(spec, entryPoints, node)
 		case *CallNodeArg:
-			if spec.MarkCallArgsLikeCall &&
-				spec.IsEntryPointSsa(node.parent.CallSite().Value()) {
-				entry := NodeWithTrace{Node: node, Trace: nil, ClosureTrace: nil}
-				entryPoints[entry.Key()] = entry
+			if spec.MarkCallArgsLikeCall {
+				if _, ok := spec.IsEntryPointSsa(node.parent.CallSite().Value()); ok {
+					entry := NodeWithTrace{Node: node, Trace: nil, ClosureTrace: nil}
+					entryPoints[entry.Key()] = entry
+				}
 			}
 		case *CallNode:
-			if node.callSite != nil && spec.IsEntryPointSsa(node.callSite.Value()) {
+			if node.callSite == nil {
+				return
+			}
+
+			if cid, ok := spec.IsEntryPointSsa(node.callSite.Value()); ok {
+				if funcutil.Exists(cid.Target.Objects, func(obj config.TargetObject) bool {
+					return obj.Kind == config.ArgumentKind
+				}) {
+					// Matching cid has an argument object which means the call itself is not an entrypoint
+					return
+				}
+
 				contexts := GetAllCallingContexts(g.AnalyzerState, node)
-				addWithContexts(contexts, node, entryPoints)
+				nodes := addContexts(contexts, node)
+				for _, node := range nodes {
+					entryPoints[node.Key()] = node
+				}
 
 				if spec.MarkCallArgsLikeCall {
 					for _, arg := range node.args {
@@ -390,19 +430,20 @@ func addSyntheticNodeEntryPoints(
 	if !isValue {
 		return
 	}
-	if spec.IsEntryPointSsa(asValue) {
+	if _, ok := spec.IsEntryPointSsa(asValue); ok {
 		entry := NodeWithTrace{Node: node}
 		entryPoints[entry.Key()] = entry
 	}
 }
 
-// addWithContexts adds an entry corresponding to node in each of the contexts to the entryPoints
-// if contexts is empty or nil, then the node is added without context
-func addWithContexts(contexts []*CallStack, node GraphNode, entryPoints map[KeyType]NodeWithTrace) {
+// addContexts returns a new NodeWithTrace for each calling context of node.
+// If contexts is empty or nil, then the node is returned without context.
+func addContexts(contexts []*CallStack, node GraphNode) []NodeWithTrace {
+	var res []NodeWithTrace
 	if len(contexts) == 0 {
 		// Default behaviour is to start without context (trace is nil)
-		entry := NodeWithTrace{Node: node, Trace: nil, ClosureTrace: nil}
-		entryPoints[entry.Key()] = entry
+		node := NodeWithTrace{Node: node, Trace: nil, ClosureTrace: nil}
+		res = append(res, node)
 	} else {
 		for _, ctxt := range contexts {
 			n := NodeWithTrace{
@@ -410,9 +451,11 @@ func addWithContexts(contexts []*CallStack, node GraphNode, entryPoints map[KeyT
 				Trace:        ctxt,
 				ClosureTrace: nil,
 			}
-			entryPoints[n.Key()] = n
+			res = append(res, n)
 		}
 	}
+
+	return res
 }
 
 // resolveCalleeSummary fetches the summary of node's callee, using all possible summary resolution methods. It also

--- a/analysis/lang/instructions.go
+++ b/analysis/lang/instructions.go
@@ -171,16 +171,35 @@ func GetArgs(instr ssa.CallInstruction) []ssa.Value {
 	return args
 }
 
+// Param is a parameter of a function.
+type Param struct {
+	Var        *types.Var
+	IsVariadic bool
+}
+
 // GetParams returns the callee params of instr.
-func GetParams(instr ssa.CallInstruction) []*types.Var {
-	var params []*types.Var
+func GetParams(instr ssa.CallInstruction) []Param {
+	var params []Param
 	sig := instr.Common().Signature()
 	if sig.Recv() != nil {
 		// The first parameter of a method call is the receiver
-		params = append(params, sig.Recv())
+		param := Param{
+			Var:        sig.Recv(),
+			IsVariadic: false,
+		}
+		params = append(params, param)
 	}
 	for i := 0; i < sig.Params().Len(); i++ {
-		params = append(params, sig.Params().At(i))
+		p := sig.Params().At(i)
+		isVariadic := false
+		if sig.Variadic() && i == sig.Params().Len()-1 {
+			isVariadic = true
+		}
+		param := Param{
+			Var:        p,
+			IsVariadic: isVariadic,
+		}
+		params = append(params, param)
 	}
 
 	return params

--- a/analysis/lang/instructions.go
+++ b/analysis/lang/instructions.go
@@ -17,6 +17,8 @@
 package lang
 
 import (
+	"go/types"
+
 	fn "github.com/awslabs/ar-go-tools/internal/funcutil"
 	"golang.org/x/tools/go/ssa"
 )
@@ -167,6 +169,21 @@ func GetArgs(instr ssa.CallInstruction) []ssa.Value {
 	}
 	args = append(args, instr.Common().Args...)
 	return args
+}
+
+// GetParams returns the callee params of instr.
+func GetParams(instr ssa.CallInstruction) []*types.Var {
+	var params []*types.Var
+	sig := instr.Common().Signature()
+	if sig.Recv() != nil {
+		// The first parameter of a method call is the receiver
+		params = append(params, sig.Recv())
+	}
+	for i := 0; i < sig.Params().Len(); i++ {
+		params = append(params, sig.Params().At(i))
+	}
+
+	return params
 }
 
 // InstrMethodKey return a method key (as used in the analyzer state for indexing interface methods) if the instruction

--- a/analysis/render/render.go
+++ b/analysis/render/render.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/awslabs/ar-go-tools/analysis/config"
 	"github.com/awslabs/ar-go-tools/analysis/dataflow"
 	"github.com/awslabs/ar-go-tools/internal/formatutil"
 	"golang.org/x/tools/go/ssa"
@@ -34,7 +35,7 @@ func BuildCrossFunctionGraph(state *dataflow.State) (*dataflow.State, error) {
 	state.Logger.Infof("Building full-program inter-procedural dataflow graph...")
 	start := time.Now()
 	dataflow.RunInterProcedural(state, CrossFunctionGraphVisitor{}, dataflow.ScanningSpec{
-		IsEntryPointSsa: func(ssa.Node) bool { return true },
+		IsEntryPointSsa: func(ssa.Node) (config.CodeIdentifier, bool) { return config.CodeIdentifier{}, true },
 	})
 
 	state.Logger.Infof("Full-program inter-procedural dataflow graph done (%.2f s).", time.Since(start).Seconds())

--- a/analysis/syntactic/structinit/structinit.go
+++ b/analysis/syntactic/structinit/structinit.go
@@ -230,11 +230,12 @@ func initInfos(
 	allocs []alloced,
 	specs []config.StructInitSpec) (map[*types.Named]InitInfo, error) {
 	infos := make(map[*types.Named]InitInfo)
-	initialized := make(map[config.CodeIdentifier]bool)
+	initialized := make(map[structId]bool)
 
 	for _, alloc := range allocs {
 		for _, spec := range specs {
-			if initialized[spec.Struct] {
+			id := newStructId(spec.Struct)
+			if initialized[id] {
 				continue
 			}
 
@@ -263,11 +264,23 @@ func initInfos(
 			}
 
 			infos[structTyps.named] = info
-			initialized[spec.Struct] = true
+			initialized[id] = true
 		}
 	}
 
 	return infos, nil
+}
+
+type structId struct {
+	pkg  string
+	name string
+}
+
+func newStructId(cid config.CodeIdentifier) structId {
+	return structId{
+		pkg:  cid.Package,
+		name: cid.Type,
+	}
 }
 
 func newInitInfo(state *ptr.State, spec config.StructInitSpec, structType *types.Struct) (InitInfo, error) {

--- a/analysis/taint/taint.go
+++ b/analysis/taint/taint.go
@@ -163,7 +163,9 @@ func runSpec(state *dataflow.State, reqs AnalysisReqs, taintSpec config.TaintSpe
 	visitor := NewVisitor(&taintSpec)
 	dataflow.RunInterProcedural(state, visitor, dataflow.ScanningSpec{
 		// The entry points are specific to each taint tracking problem (unlike in the intra-procedural pass)
-		IsEntryPointSsa:      func(node ssa.Node) bool { return dataflow.IsSourceNode(state, &taintSpec, node) },
+		IsEntryPointSsa: func(node ssa.Node) (config.CodeIdentifier, bool) {
+			return dataflow.IsSourceNode(state, &taintSpec, node)
+		},
 		MarkCallArgsLikeCall: taintSpec.SourceTaintsArgs,
 	})
 	taintFlows.Merge(visitor.taints)

--- a/cmd/argot/cli/analysis.go
+++ b/cmd/argot/cli/analysis.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/awslabs/ar-go-tools/analysis/backtrace"
+	"github.com/awslabs/ar-go-tools/analysis/config"
 	"github.com/awslabs/ar-go-tools/analysis/dataflow"
 	"github.com/awslabs/ar-go-tools/analysis/escape"
 	"github.com/awslabs/ar-go-tools/analysis/render"
@@ -458,7 +459,7 @@ func cmdTaint(tt *term.Terminal, c *dataflow.State, _ Command, _ bool) bool {
 			taint.NewVisitor(&ts),
 			dataflow.ScanningSpec{
 				MarkCallArgsLikeCall: ts.SourceTaintsArgs,
-				IsEntryPointSsa: func(node ssa.Node) bool {
+				IsEntryPointSsa: func(node ssa.Node) (config.CodeIdentifier, bool) {
 					return dataflow.IsSourceNode(c, &ts, node)
 				},
 			},
@@ -488,7 +489,7 @@ func cmdBacktrace(tt *term.Terminal, c *dataflow.State, _ Command, _ bool) bool 
 		c.FlowGraph.RunVisitorOnEntryPoints(
 			visitor,
 			dataflow.ScanningSpec{
-				IsEntryPointSsa: func(node ssa.Node) bool {
+				IsEntryPointSsa: func(node ssa.Node) (config.CodeIdentifier, bool) {
 					return dataflow.IsBacktraceNode(c, &ps, node)
 				}})
 		for _, tr := range visitor.Traces {

--- a/cmd/argot/cli/dataflowreachability.go
+++ b/cmd/argot/cli/dataflowreachability.go
@@ -56,7 +56,9 @@ func cmdTrace(tt *term.Terminal, c *dataflow.State, command Command, _ bool) boo
 	}
 	dummyTaintSpec := &config.TaintSpec{}
 	scanningSpec := dataflow.ScanningSpec{
-		IsEntryPointGraph: func(g dataflow.GraphNode) bool { return r.MatchString(g.LongID()) },
+		IsEntryPointGraph: func(g dataflow.GraphNode) (config.CodeIdentifier, bool) {
+			return config.CodeIdentifier{}, r.MatchString(g.LongID())
+		},
 	}
 	c.FlowGraph.RunVisitorOnEntryPoints(taint.NewVisitor(dummyTaintSpec), scanningSpec)
 

--- a/internal/analysisutil/analysisutil.go
+++ b/internal/analysisutil/analysisutil.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/awslabs/ar-go-tools/analysis/config"
+	"github.com/awslabs/ar-go-tools/analysis/lang"
 	fn "github.com/awslabs/ar-go-tools/internal/funcutil"
 	"github.com/awslabs/ar-go-tools/internal/pointer"
 	"golang.org/x/tools/go/ssa"
@@ -145,17 +146,23 @@ func GetFieldInfoFromType(t types.Type, i int) (string, bool) {
 //
 //gocyclo:ignore
 func IsEntrypointNode(pointer *pointer.Result, n ssa.Node,
-	f func(config.CodeIdentifier) bool) bool {
+	f func(config.CodeIdentifier) bool) (config.CodeIdentifier, bool) {
 	switch node := (n).(type) {
 	// Look for callees to functions that are considered entry points
 	case *ssa.Call:
 		if node == nil {
-			return false // inits cannot be entry points
+			return config.CodeIdentifier{}, false // inits cannot be entry points
 		}
 
 		parent := node.Parent()
 		if !node.Call.IsInvoke() {
-			return isFuncEntrypoint(node, parent, f) || isAliasEntrypoint(pointer, node, f)
+			if cid, ok := isFuncEntrypoint(node, parent, f); ok {
+				return cid, true
+			}
+			if cid, ok := isAliasEntrypoint(pointer, node, f); ok {
+				return cid, true
+			}
+			return config.CodeIdentifier{}, false
 		}
 
 		// For invoke also populate the receiver
@@ -163,54 +170,80 @@ func IsEntrypointNode(pointer *pointer.Result, n ssa.Node,
 		methodName := node.Call.Method.Name()
 		calleePkg := FindSafeCalleePkg(node.Common())
 		if calleePkg.IsSome() {
-			return f(
-				config.CodeIdentifier{
-					Context:    parent.String(),
-					Package:    calleePkg.Value(),
-					Method:     methodName,
-					Receiver:   receiver,
-					ValueMatch: n.String()})
+			cid := config.CodeIdentifier{
+				Context:    parent.String(),
+				Package:    calleePkg.Value(),
+				Method:     methodName,
+				Receiver:   receiver,
+				ValueMatch: n.String(),
+			}
+			if f(cid) {
+				return cid, true
+			}
+
+			// Entrypoint could be one of the arguments: use the new code identifier format
+			cids := newCodeIdentifierCall(node, calleePkg.Value(), methodName, parent)
+			for _, cid := range cids {
+				if f(cid) {
+					return cid, true
+				}
+			}
 		}
-		return false
+		return config.CodeIdentifier{}, false
 
 	// Field accesses that are considered as entry points
 	case *ssa.Field:
 		fieldName, _ := FieldFieldInfo(node)
 		packageName, typeName, err := FindEltTypePackage(node.X.Type(), "%s")
 		if err != nil {
-			return false
+			return config.CodeIdentifier{}, false
 		}
-		return f(config.CodeIdentifier{
+		cid := config.CodeIdentifier{
 			Context:    node.Parent().String(),
 			Package:    packageName,
 			Field:      fieldName,
 			Type:       typeName,
-			ValueMatch: n.String()})
+			ValueMatch: n.String(),
+		}
+		if f(cid) {
+			return cid, true
+		}
+		return config.CodeIdentifier{}, false
 
 	case *ssa.FieldAddr:
 		fieldName, _ := FieldAddrFieldInfo(node)
 		packageName, typeName, err := FindEltTypePackage(node.X.Type(), "%s")
 		if err != nil {
-			return false
+			return config.CodeIdentifier{}, false
 		}
-		return f(config.CodeIdentifier{
+		cid := config.CodeIdentifier{
 			Context:    node.Parent().String(),
 			Package:    packageName,
 			Field:      fieldName,
 			Type:       typeName,
-			ValueMatch: n.String()})
+			ValueMatch: n.String(),
+		}
+		if f(cid) {
+			return cid, true
+		}
+		return config.CodeIdentifier{}, false
 
 	// Allocations of data of a type that is an entry point
 	case *ssa.Alloc:
 		packageName, typeName, err := FindEltTypePackage(node.Type(), "%s")
 		if err != nil {
-			return false
+			return config.CodeIdentifier{}, false
 		}
-		return f(config.CodeIdentifier{
+		cid := config.CodeIdentifier{
 			Context:    node.Parent().String(),
 			Package:    packageName,
 			Type:       typeName,
-			ValueMatch: n.String()})
+			ValueMatch: n.String(),
+		}
+		if f(cid) {
+			return cid, true
+		}
+		return config.CodeIdentifier{}, false
 
 	// Storing into a specific struct field
 	case *ssa.Store:
@@ -218,37 +251,82 @@ func IsEntrypointNode(pointer *pointer.Result, n ssa.Node,
 			fieldName, _ := FieldAddrFieldInfo(fieldAddr)
 			packageName, typeName, err := FindEltTypePackage(fieldAddr.X.Type(), "%s")
 			if err != nil {
-				return false
+				return config.CodeIdentifier{}, false
 			}
-			return f(config.CodeIdentifier{
+			cid := config.CodeIdentifier{
 				Context:    node.Parent().String(),
 				Package:    packageName,
 				Field:      fieldName,
 				Type:       typeName,
 				Kind:       "store",
-				ValueMatch: n.String()})
+				ValueMatch: n.String(),
+			}
+			if f(cid) {
+				return cid, true
+			}
+			return config.CodeIdentifier{}, false
 		}
-		return false
+		return config.CodeIdentifier{}, false
 
 	// Channel receives can be sources
 	case *ssa.UnOp:
 		if node.Op == token.ARROW {
 			packageName, typeName, err := FindEltTypePackage(node.X.Type(), "%s")
 			if err != nil {
-				return false
+				return config.CodeIdentifier{}, false
 			}
-			return f(config.CodeIdentifier{
+			cid := config.CodeIdentifier{
 				Context:    node.Parent().String(),
 				Package:    packageName,
 				Type:       typeName,
 				Kind:       "channel receive",
-				ValueMatch: n.String()})
+				ValueMatch: n.String(),
+			}
+			if f(cid) {
+				return cid, true
+			}
+			return config.CodeIdentifier{}, false
 		}
-		return false
+		return config.CodeIdentifier{}, false
 
 	default:
-		return false
+		return config.CodeIdentifier{}, false
 	}
+}
+
+// newCodeIdentifierCall returns a code identifier for each possible object in the call.
+func newCodeIdentifierCall(node *ssa.Call, calleePkg string, methodName string, parent *ssa.Function) []config.CodeIdentifier {
+	if parent == nil || parent.Package() == nil {
+		return nil
+	}
+
+	var res []config.CodeIdentifier
+	args := lang.GetArgs(node)
+	params := lang.GetParams(node)
+	for i, arg := range args {
+		cid := config.CodeIdentifier{
+			Target: config.Target{
+				Kind:    config.CallKind,
+				Package: calleePkg,
+				Method:  methodName,
+				Objects: []config.TargetObject{
+					{
+						Kind:  config.ArgumentKind,
+						Name:  params[i].Name(),
+						Index: uint(i),
+						Type:  arg.Type().String(),
+					},
+				},
+			},
+			Enclosing: config.CallingContext{
+				Package: parent.Package().Pkg.Path(),
+				Method:  parent.Name(),
+			},
+		}
+		res = append(res, cid)
+	}
+
+	return res
 }
 
 // ReceiverStr returns the string receiver name of t.
@@ -263,30 +341,50 @@ func ReceiverStr(t types.Type) string {
 }
 
 // isFuncEntrypoint returns true if the actual function called matches an entrypoint.
-func isFuncEntrypoint(node *ssa.Call, parent *ssa.Function, f func(config.CodeIdentifier) bool) bool {
+func isFuncEntrypoint(node *ssa.Call, parent *ssa.Function, f func(config.CodeIdentifier) bool) (config.CodeIdentifier, bool) {
 	funcValue := node.Call.Value.Name()
 	calleePkg := FindSafeCalleePkg(node.Common())
 	if calleePkg.IsSome() {
-		return f(config.CodeIdentifier{Context: parent.String(), Package: calleePkg.Value(), Method: funcValue})
+		cid := config.CodeIdentifier{Context: parent.String(), Package: calleePkg.Value(), Method: funcValue}
+		if f(cid) {
+			return cid, true
+		}
+		// Entrypoint could be one of the arguments: use the new code identifier format
+		cids := newCodeIdentifierCall(node, calleePkg.Value(), funcValue, parent)
+		for _, cid := range cids {
+			if f(cid) {
+				return cid, true
+			}
+		}
 	}
-	return false
+	return config.CodeIdentifier{}, false
 }
 
 // isAliasEntrypoint returns true if any alias to node matches an entrypoint.
-func isAliasEntrypoint(pointer *pointer.Result, node *ssa.Call, f func(config.CodeIdentifier) bool) bool {
+func isAliasEntrypoint(pointer *pointer.Result, node *ssa.Call, f func(config.CodeIdentifier) bool) (config.CodeIdentifier, bool) {
 	if pointer == nil {
-		return false
+		return config.CodeIdentifier{}, false
 	}
 	ptr, hasAliases := pointer.Queries[node.Call.Value]
 	if !hasAliases {
-		return false
+		return config.CodeIdentifier{}, false
 	}
 	for _, label := range ptr.PointsTo().Labels() {
 		funcValue := label.Value().Name()
 		funcPackage := FindValuePackage(label.Value())
-		if funcPackage.IsSome() && f(config.CodeIdentifier{Package: funcPackage.Value(), Method: funcValue}) {
-			return true
+		if funcPackage.IsSome() {
+			cid := config.CodeIdentifier{Package: funcPackage.Value(), Method: funcValue}
+			if f(cid) {
+				return cid, true
+			}
+			// Entrypoint could be one of the arguments: use the new code identifier format
+			cids := newCodeIdentifierCall(node, funcPackage.Value(), funcValue, label.Value().Parent())
+			for _, cid := range cids {
+				if f(cid) {
+					return cid, true
+				}
+			}
 		}
 	}
-	return false
+	return config.CodeIdentifier{}, false
 }

--- a/internal/analysisutil/analysisutil.go
+++ b/internal/analysisutil/analysisutil.go
@@ -310,12 +310,7 @@ func newCodeIdentifierCall(node *ssa.Call, calleePkg string, methodName string, 
 				Package: calleePkg,
 				Method:  methodName,
 				Objects: []config.TargetObject{
-					{
-						Kind:  config.ArgumentKind,
-						Name:  params[i].Name(),
-						Index: uint(i),
-						Type:  arg.Type().String(),
-					},
+					NewParamTargetObject(params[i], i, arg),
 				},
 			},
 			Enclosing: config.CallingContext{
@@ -327,6 +322,24 @@ func newCodeIdentifierCall(node *ssa.Call, calleePkg string, methodName string, 
 	}
 
 	return res
+}
+
+// NewParamTargetObject returns the config.TargetObject corresponding to the parameter for arg at
+// index idx.
+func NewParamTargetObject(param lang.Param, idx int, arg ssa.Value) config.TargetObject {
+	typ := arg.Type().String()
+	if param.IsVariadic {
+		// If the parameter type is variadic, the SSA form of the argument will be a slice
+		// (`[]type`) instead of the `...type` form.
+		typ = strings.TrimPrefix(typ, "[]")
+		typ = "..." + typ
+	}
+	return config.TargetObject{
+		Kind:  config.ArgumentKind,
+		Name:  param.Var.Name(),
+		Index: uint(idx),
+		Type:  typ,
+	}
 }
 
 // ReceiverStr returns the string receiver name of t.


### PR DESCRIPTION
Adds a new code identifier format.

There's a lot of special-casing in the implementation so we need to refactor this soon - especially if we want to support other types of code identifiers in the future.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
