### PR TITLE
Cleaning up staticcheck messages and new summaries.

### DIFF
--- a/analysis/config/logging.go
+++ b/analysis/config/logging.go
@@ -178,6 +178,41 @@ func (l *LogGroup) Errorf(format string, v ...any) {
 	}
 }
 
+// Trace calls Trace.Print to print to the trace logger. Arguments are handled in the manner of Print
+func (l *LogGroup) Trace(msg string) {
+	if l.Level >= TraceLevel {
+		l.trace.Print(msg)
+	}
+}
+
+// Debug calls Debug.Print to print to the trace logger. Arguments are handled in the manner of Print
+func (l *LogGroup) Debug(msg string) {
+	if l.Level >= DebugLevel {
+		l.debug.Print(msg)
+	}
+}
+
+// Info calls Info.Print to print to the trace logger. Arguments are handled in the manner of Print
+func (l *LogGroup) Info(msg string) {
+	if l.Level >= InfoLevel {
+		l.info.Print(msg)
+	}
+}
+
+// Warn calls Warn.Print to print to the trace logger. Arguments are handled in the manner of Print
+func (l *LogGroup) Warn(msg string) {
+	if l.Level >= WarnLevel && !l.suppressWarn {
+		l.warn.Print(msg)
+	}
+}
+
+// Error calls Error.Print to print to the trace logger. Arguments are handled in the manner of Print
+func (l *LogGroup) Error(msg string) {
+	if l.Level >= ErrLevel {
+		l.err.Print(msg)
+	}
+}
+
 // GetDebug returns the debug level logger, for applications that need a logger as input
 func (l *LogGroup) GetDebug() *log.Logger {
 	return l.debug

--- a/analysis/dataflow/analyzers.go
+++ b/analysis/dataflow/analyzers.go
@@ -127,9 +127,6 @@ type singleFunctionJob struct {
 	// postBlockCallback will be called after every block during the intra-procedural analysis, with the state of
 	// the intra-procedural analysis at that point
 	postBlockCallback func(*IntraAnalysisState)
-
-	// output is the channel for the summary generated
-	output chan *SummaryGraph
 }
 
 // runSingleFunctionJob runs the intra-procedural analysis with the information in job

--- a/analysis/dataflow/builtins.go
+++ b/analysis/dataflow/builtins.go
@@ -166,5 +166,4 @@ func doBuiltinCall(t *IntraAnalysisState, callValue ssa.Value, callCommon *ssa.C
 			}
 		}
 	}
-	return
 }

--- a/analysis/dataflow/checks.go
+++ b/analysis/dataflow/checks.go
@@ -47,7 +47,7 @@ func CheckNoGoRoutine(s *State, reportedLocs map[*ssa.Go]bool, node *CallNode) {
 	if goroutine, isGo := node.CallSite().(*ssa.Go); isGo {
 		if !reportedLocs[goroutine] {
 			reportedLocs[goroutine] = true
-			s.Logger.Warnf(formatutil.Yellow("Data flows to Go call."))
+			s.Logger.Warn(formatutil.Yellow("Data flows to Go call."))
 			s.Logger.Warnf("-> Position: %s", node.Position(s))
 		}
 	}

--- a/analysis/dataflow/contracts.go
+++ b/analysis/dataflow/contracts.go
@@ -87,10 +87,10 @@ func LoadDefinitions(fileName string) ([]Contract, error) {
 	for _, contract := range data {
 		// only one of InterfaceID and DataflowEdge should be given
 		if contract.InterfaceID == "" && contract.ObjectPath == "" {
-			return data, fmt.Errorf("InterfaceID and DataflowEdge should not be both empty")
+			return data, fmt.Errorf("InterfaceID and ObjectPath should not be both empty")
 		}
 		if contract.InterfaceID != "" && contract.ObjectPath != "" {
-			return data, fmt.Errorf("InterfaceID and DataflowEdge should not be both specified")
+			return data, fmt.Errorf("InterfaceID and ObjectPath should not be both specified")
 		}
 	}
 

--- a/analysis/dataflow/function_summary_graph.go
+++ b/analysis/dataflow/function_summary_graph.go
@@ -123,8 +123,7 @@ func NewSummaryGraph(s *State, f *ssa.Function, id uint32,
 		return nil
 	}
 
-	var lastNodeID uint32
-	lastNodeID = 0
+	var lastNodeID uint32 = 0
 
 	g := &SummaryGraph{
 		ID:                    id,

--- a/analysis/dataflow/function_summary_graph_nodes.go
+++ b/analysis/dataflow/function_summary_graph_nodes.go
@@ -146,11 +146,11 @@ func NodeSummary(g GraphNode) string {
 			x.Type().String(),
 			x.ParentName())
 	case *ClosureNode:
-		return fmt.Sprintf("Closure")
+		return "Closure"
 	case *BoundLabelNode:
 		return fmt.Sprintf("Bound label of type %s", x.targetInfo.Type().String())
 	case *SyntheticNode:
-		return fmt.Sprintf("Synthetic node")
+		return "Synthetic node"
 	case *BoundVarNode:
 		return "Bound variable"
 	case *FreeVarNode:
@@ -187,11 +187,11 @@ func TermNodeSummary(g GraphNode) string {
 			formatutil.Italic(x.Type().String()),
 			formatutil.Magenta(x.ParentName()))
 	case *ClosureNode:
-		return fmt.Sprintf("Closure")
+		return "Closure"
 	case *BoundLabelNode:
 		return fmt.Sprintf("Bound label of type %s", formatutil.Italic(x.targetInfo.Type().String()))
 	case *SyntheticNode:
-		return fmt.Sprintf("Synthetic node")
+		return "Synthetic node"
 	case *BoundVarNode:
 		return "Bound variable"
 	case *FreeVarNode:

--- a/analysis/dataflow/intra_procedural_monotone_analysis.go
+++ b/analysis/dataflow/intra_procedural_monotone_analysis.go
@@ -191,7 +191,7 @@ func populateInstrPrevMap(intraState *IntraAnalysisState, firstInstr ssa.Instruc
 				for _, pred := range block.Preds {
 					if pred != nil && len(pred.Instrs) > 0 {
 						last := pred.Instrs[len(pred.Instrs)-1]
-						lastID, _ := intraState.flowInfo.InstrID[last]
+						lastID := intraState.flowInfo.InstrID[last]
 						intraState.instrPrev[instrID][lastID] = true
 					}
 				}
@@ -272,13 +272,9 @@ func (state *IntraAnalysisState) getMarks(i ssa.Instruction, v ssa.Value, path s
 		return origins
 	}
 	if ignorePath {
-		for _, mark := range state.flowInfo.MarkedValues[aliasPos].AllMarks() {
-			origins = append(origins, mark)
-		}
+		origins = append(origins, state.flowInfo.MarkedValues[aliasPos].AllMarks()...)
 	} else {
-		for _, mark := range state.flowInfo.MarkedValues[aliasPos].MarksAt(path) {
-			origins = append(origins, mark)
-		}
+		origins = append(origins, state.flowInfo.MarkedValues[aliasPos].MarksAt(path)...)
 	}
 	return origins
 }

--- a/analysis/dataflow/report.go
+++ b/analysis/dataflow/report.go
@@ -56,14 +56,14 @@ func (s *State) ReportMissingOrNotConstructedSummary(callSite *CallNode) {
 		typeString = formatutil.SanitizeRepr(callSite.Callee().Type())
 	}
 	if callSite.CalleeSummary == nil {
-		s.Logger.Debugf(formatutil.Red(fmt.Sprintf("| %q has not been summarized (call %q).",
+		s.Logger.Debug(formatutil.Red(fmt.Sprintf("| %q has not been summarized (call %q).",
 			callSite.String(), typeString)))
 	} else if !callSite.CalleeSummary.Constructed {
-		s.Logger.Debugf(formatutil.Red(fmt.Sprintf("| %q has not been constructed (call %q).",
+		s.Logger.Debug(formatutil.Red(fmt.Sprintf("| %q has not been constructed (call %q).",
 			callSite.String(), typeString)))
 	}
 	if callSite.Callee() != nil && callSite.CallSite() != nil {
-		s.Logger.Debugf(fmt.Sprintf("| Please add %s to summaries",
+		s.Logger.Debug(fmt.Sprintf("| Please add %s to summaries",
 			formatutil.Sanitize(callSite.Callee().String())))
 
 		pos := callSite.Position(s)
@@ -94,7 +94,7 @@ func (s *State) ReportMissingClosureNode(closureNode *ClosureNode) {
 	} else {
 		instrStr = closureNode.Instr().String()
 	}
-	s.Logger.Debugf(formatutil.Red(fmt.Sprintf("| %s has not been summarized (closure %s).",
+	s.Logger.Debug(formatutil.Red(fmt.Sprintf("| %s has not been summarized (closure %s).",
 		closureNode.String(), formatutil.Sanitize(instrStr))))
 	if closureNode.Instr() != nil {
 		s.Logger.Debugf("| Please add closure %s to summaries",
@@ -114,17 +114,17 @@ func (s *State) ReportSummaryNotConstructed(callSite *CallNode) {
 		formatutil.Yellow(callSite.Graph().Parent.Name()))
 	pos := callSite.Position(s)
 	if pos != lang.DummyPos {
-		s.Logger.Debugf(fmt.Sprintf("|_ See call site: %s", pos))
+		s.Logger.Debugf("|_ See call site: %s", pos)
 	} else {
 		opos := lang.SafeFunctionPos(callSite.Graph().Parent)
-		s.Logger.Debugf(fmt.Sprintf("|_ See call site in %s", opos.ValueOr(lang.DummyPos)))
+		s.Logger.Debugf("|_ See call site in %s", opos.ValueOr(lang.DummyPos))
 	}
 
 	if callSite.CallSite() != nil {
 		methodKey := lang.InstrMethodKey(callSite.CallSite())
 		if methodKey.IsSome() {
-			s.Logger.Debugf(fmt.Sprintf("| Or add %s to dataflow contracts",
-				formatutil.Sanitize(methodKey.ValueOr("?"))))
+			s.Logger.Debugf("| Or add %s to dataflow contracts",
+				formatutil.Sanitize(methodKey.ValueOr("?")))
 		}
 	}
 }
@@ -180,7 +180,7 @@ func reportUnsoundFeatures(state *State, f *ssa.Function) {
 		}
 		msg += "    Adding a predefined summary might help avoid soundness issues.\n"
 
-		state.Logger.Warnf(msg)
+		state.Logger.Warn(msg)
 	}
 }
 
@@ -258,5 +258,4 @@ func detectUnsafeBuiltinUsage(callVal *ssa.Builtin, unsafeUsages map[token.Posit
 	// It's not a handled builting, but we're not sure it's safe
 	// Report it in the unsafe usages without calling it a function
 	unsafeUsages[iPos] = fmt.Sprintf("Calling builtin %s.", callVal.Name())
-	return
 }

--- a/analysis/dataflow/state.go
+++ b/analysis/dataflow/state.go
@@ -299,7 +299,7 @@ func (s *State) ResolveCallee(instr ssa.CallInstruction, useContracts bool) (map
 	}
 
 	// Last option is to use the map from type string to implementation
-	if s.ImplementationsByType == nil || len(s.ImplementationsByType) == 0 {
+	if len(s.ImplementationsByType) == 0 {
 		return nil, fmt.Errorf("cannot resolve callee without information about possible implementations")
 	}
 

--- a/analysis/lang/instructions_test.go
+++ b/analysis/lang/instructions_test.go
@@ -51,7 +51,7 @@ func (v *InstructionCountingOp) DoSlice(*ssa.Slice)                             
 // Only the DoReturn reports something in the pass.
 func (v *InstructionCountingOp) DoReturn(ret *ssa.Return) {
 	if v.report && ret.Pos() != 0 {
-		v.pass.Reportf(ret.Pos(), fmt.Sprintf("count %d instructions at return", v.count))
+		v.pass.Reportf(ret.Pos(), "count %d instructions at return", v.count)
 	}
 	v.count++
 }

--- a/analysis/summaries/standard_library.go
+++ b/analysis/summaries/standard_library.go
@@ -153,7 +153,53 @@ var stdPackages = map[string]map[string]Summarizer{
 	"internal/unsafeheader":    summaryInternal,
 }
 
-var summaryArchiveTar = map[string]Summarizer{}
+var summaryArchiveTar = map[string]Summarizer{
+	//  === Reader ===
+
+	// func NewReader(r io.Reader) *Reader
+	"archive/tar.NewReader": RawSummary{
+		Flows: map[string][]string{
+			"!arg 0": {"!ret 0"},
+		},
+	}.MustCompile(),
+	// func (tr *Reader) Next() (*Header, error)
+	"(*archive/tar.Reader).Next": RawSummary{
+		Flows: map[string][]string{"!receiver": {"!ret 0", "!ret 1"}},
+	}.MustCompile(),
+	// func (tr *Reader) Read(b []byte) (int, error)
+	"(*archive/tar.Reader).Read": RawSummary{
+		Flows: map[string][]string{
+			"!receiver": {"!arg 0", "!ret 0", "!ret 1"},
+		},
+	}.MustCompile(),
+
+	// === Writer ===
+
+	// func NewWriter(w io.Writer) *Writer
+	"archive/tar.NewWriter": RawSummary{
+		Flows: map[string][]string{"!arg 0": {"!ret 0"}},
+	}.MustCompile(),
+	// func (tw *Writer) AddFS(fsys fs.FS) error
+	"(*archive/tar.Writer).AddFS": RawSummary{
+		Flows: map[string][]string{"!arg 0": {"!receiver", "!ret 0"}},
+	}.MustCompile(),
+	// func (tw *Writer) Close() error
+	"(*archive/tar.Writer).Close": RawSummary{
+		Flows: map[string][]string{"!receiver": {"!ret 0"}},
+	}.MustCompile(),
+	// func (tw *Writer) Flush() error
+	"(*archive/tar.Writer).Flush": RawSummary{
+		Flows: map[string][]string{"!receiver": {"!ret 0"}},
+	}.MustCompile(),
+	// func (tw *Writer) Write(b []byte) (int, error)
+	"(*archive/tar.Writer).Writer": RawSummary{
+		Flows: map[string][]string{"!arg 0": {"!receiver", "!ret 0", "!ret 1"}},
+	}.MustCompile(),
+	// func (tw *Writer) WriteHeader(hdr *Header) error
+	"(*archive/tar.Writer).WriteHeader": RawSummary{
+		Flows: map[string][]string{"!arg 0": {"!receiver", "!ret 0"}},
+	}.MustCompile(),
+}
 
 var summaryArchiveZip = map[string]Summarizer{}
 

--- a/analysis/taint/taint_utils_test.go
+++ b/analysis/taint/taint_utils_test.go
@@ -99,11 +99,11 @@ func checkTaint(t *testing.T, prog *ssa.Program, expect analysistest.TargetToSou
 				msg := fmt.Sprintf("false positive:\n%s\nwith trace: %s\nflows to\n%s\n",
 					actualSource.Pos, actualSource.Trace, actualSink.Pos)
 				if !hasMeta {
-					t.Errorf(msg)
+					t.Error(msg)
 				} else {
 					// TODO false positives are logs for now for tests with metadata until context-sensitivity is
 					// improved
-					t.Logf(msg)
+					t.Log(msg)
 				}
 			}
 		}
@@ -287,7 +287,7 @@ func runTestWithoutCheck(t *testing.T, dirName string, files []string, summarize
 	ptrState := result.Bind(lp, ptr.NewState)
 	state, err := result.Bind(ptrState, dataflow.NewState).Value()
 	if err != nil {
-		t.Fatalf("failed to initialize state")
+		t.Fatalf("failed to initialize state: %s", err)
 	}
 	res, err := taint.Analyze(state, taint.AnalysisReqs{})
 	if err != nil {

--- a/analysis/taint/testdata/stdlib/main.go
+++ b/analysis/taint/testdata/stdlib/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"archive/tar"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -54,6 +55,23 @@ func TestCsvReadFromTaintedReader() {
 	sink2(r.Read()) // @Sink(TestCsvReadFromTaintedReader)
 }
 
+func TestArchiveTarReadFromTaintedReader() {
+	x := source1() // @Source(TestArchiveTarReadFromTaintedReader)
+	reader := strings.NewReader(x.Data)
+	r := tar.NewReader(reader)
+	h, err := r.Next()
+	if err != nil {
+		return
+	}
+	sink2(h.Name) // @Sink(TestArchiveTarReadFromTaintedReader)
+	buf := make([]byte, 1024)
+	_, err = r.Read(buf)
+	if err != nil {
+		return
+	}
+	sink2(string(buf)) // @Sink(TestArchiveTarReadFromTaintedReader)
+}
+
 func TestFmtErrorf() {
 	x := source3() // @Source(TestFmtErrorf)
 	eTainted := fmt.Errorf("error: %s", x)
@@ -70,4 +88,5 @@ func main() {
 	TestSyncDoOnce()
 	TestFmtErrorf()
 	TestCsvReadFromTaintedReader()
+	TestArchiveTarReadFromTaintedReader()
 }


### PR DESCRIPTION
This PR does minor code cleanup: removing non-necessary formatting directive, one unused struct field, and extra returns.
Adds a few standard library summaries.