### PR TITLE
Implementing must-reinit check

### DIFF
--- a/analysis/config/config.go
+++ b/analysis/config/config.go
@@ -213,6 +213,9 @@ type StructInitSpec struct {
 	FieldsSet []FieldsSetSpec `yaml:"fields-set" json:"fields-set"`
 	// Filters is the list of values that the analysis does not track.
 	Filters []CodeIdentifier
+	// MustReinits is the list of function calls resulting in the struct that must be
+	// folllowed by a statement reinitializing the struct value
+	MustReinits []CodeIdentifier `yaml:"must-reinit" json:"must-reinit"`
 }
 
 // SpecTag returns the struct init specification's tag
@@ -568,6 +571,7 @@ func Load(filename string, configBytes []byte, cmdLineOverrides *CmdLineOverride
 			siSpec.FieldsSet[j].Value = compileRegexes(fSpec.Value)
 		}
 		funcutil.MapInPlace(siSpec.Filters, compileRegexes)
+		funcutil.MapInPlace(siSpec.MustReinits, compileRegexes)
 	}
 
 	for i, ccSpec := range cfg.SyntacticProblems.CondCheckSpecs {

--- a/analysis/lang/instructions.go
+++ b/analysis/lang/instructions.go
@@ -151,10 +151,10 @@ func InstrSwitch(visitor InstrOp, instr ssa.Instruction) {
 
 // Utilities for working with blocks and instructions
 
-// ParentBlockIndex returns the parent block of an instruction with the index of the instruction in it.
+// IndexInEnclosingBlock returns the parent block of an instruction with the index of the instruction in it.
 //
 //	If the instruction is nil, or the parent function is nil, then it returns nil.
-func ParentBlockIndex(instr ssa.Instruction) (*ssa.BasicBlock, int) {
+func IndexInEnclosingBlock(instr ssa.Instruction) (*ssa.BasicBlock, int) {
 	if instr == nil || instr.Block() == nil {
 		return nil, 0
 	}

--- a/analysis/lang/instructions.go
+++ b/analysis/lang/instructions.go
@@ -151,6 +151,23 @@ func InstrSwitch(visitor InstrOp, instr ssa.Instruction) {
 
 // Utilities for working with blocks and instructions
 
+// ParentBlockIndex returns the parent block of an instruction with the index of the instruction in it.
+//
+//	If the instruction is nil, or the parent function is nil, then it returns nil.
+func ParentBlockIndex(instr ssa.Instruction) (*ssa.BasicBlock, int) {
+	if instr == nil || instr.Block() == nil {
+		return nil, 0
+	}
+	block := instr.Block()
+	for i, blockInstr := range block.Instrs {
+		if blockInstr == instr {
+			return block, i
+		}
+	}
+	// Not found in own parent?
+	panic("internal SSA representation broken.")
+}
+
 // LastInstr returns the last instruction in a block. There is always a last instruction for a reachable block.
 // Returns nil for an empty block (a block can be empty if it is non-reachable)
 func LastInstr(block *ssa.BasicBlock) ssa.Instruction {

--- a/analysis/syntactic/preconditions/precond_check.go
+++ b/analysis/syntactic/preconditions/precond_check.go
@@ -68,8 +68,8 @@ func Analyze(state *ptr.State, reqs AnalysisReqs) (AnalysisResult, error) {
 	return AnalysisResult{NumSpecs: analyzed, UncheckedLocs: locs}, nil
 }
 
-// ReportResults writes res to a string and returns true if the analysis has findings.
-func ReportResults(res AnalysisResult) (string, bool) {
+// FormattedReport writes res to a string and returns true if the analysis has findings.
+func FormattedReport(res AnalysisResult) (string, bool) {
 	if res.NumSpecs == 0 {
 		return "precondition analysis didn't run; check the tags if you expected a result", false
 	}

--- a/analysis/syntactic/structinit/structinit.go
+++ b/analysis/syntactic/structinit/structinit.go
@@ -25,6 +25,7 @@ import (
 	"github.com/awslabs/ar-go-tools/analysis/lang"
 	"github.com/awslabs/ar-go-tools/analysis/ptr"
 	"github.com/awslabs/ar-go-tools/analysis/summaries"
+	"github.com/awslabs/ar-go-tools/internal/analysisutil"
 	"github.com/awslabs/ar-go-tools/internal/formatutil"
 	"github.com/awslabs/ar-go-tools/internal/funcutil"
 	"golang.org/x/tools/go/ssa"
@@ -52,6 +53,8 @@ type InitInfo struct {
 	// InvalidWrites is a mapping of the struct field to all the invalid writes
 	// to that field.
 	InvalidWrites map[*types.Var][]InvalidWrite
+	// BadReinits is a list of bad reinitializations
+	BadReinits []BadReinit
 	// fieldExpectedValue is a mapping of the struct field to the concrete value it
 	// should be initialized to according to the spec.
 	//
@@ -78,6 +81,15 @@ type InvalidWrite struct {
 	Want ssa.Value
 	// Instr is the instruction performing the write.
 	Instr ssa.Instruction
+	// Pos is the position of the instruction.
+	Pos token.Position
+}
+
+// BadReinit is a function call resulting in a struct that should have specific
+// fields reinitialized, but it hasn't.
+type BadReinit struct {
+	// Call is the function call instruction.
+	Call ssa.Instruction
 	// Pos is the position of the instruction.
 	Pos token.Position
 }
@@ -118,6 +130,16 @@ func Analyze(state *ptr.State, reqs AnalysisReqs) (AnalysisResult, error) {
 
 	runZeroAllocAnalysis(state, allocs, res, structToNamed)
 
+	// Run the must-reinit checks
+	for sType, findings := range runMustReinitChecks(state, specs, state.ReachableFunctions(), structToNamed) {
+		if iInfo, ok := res.InitInfos[sType]; ok {
+			iInfo.BadReinits = findings
+			res.InitInfos[sType] = iInfo
+		} else {
+			res.InitInfos[sType] = InitInfo{Tag: reqs.Tag, BadReinits: findings}
+		}
+	}
+
 	runInvalidWritesAnalysis(state, fns, res, structToNamed)
 
 	return res, nil
@@ -139,18 +161,17 @@ func runInvalidWritesAnalysis(
 				return
 			}
 
-			switch instr := instr.(type) {
-			case *ssa.Store:
-				pos := program.Fset.Position(instr.Pos())
-				if write, ok := isInvalidWrite(res, structToNamed, instr, pos); ok {
+			if storeInstr, ok := instr.(*ssa.Store); ok {
+				pos := program.Fset.Position(storeInstr.Pos())
+				if write, ok := isInvalidWrite(res, structToNamed, storeInstr, pos); ok {
 					namedType := write.structTypes.named
 					is := res.InitInfos[namedType]
 
 					if state.Annotations.IsIgnoredPos(pos, is.Tag) {
-						logger.Infof("annotation found, ignored %s: invalid write to struct field %v.%v at %s\n",
+						logger.Infof("annotation found, ignored %s: invalid write to struct field %v.%s at %s\n",
 							is.Tag, namedType, write.fieldType.Name(), pos)
 					} else {
-						logger.Infof("%s: found invalid write of value %v (wanted %v) to struct field %v.%v at %v\n",
+						logger.Warnf("%s: found invalid write of value %v (wanted %v) to struct field %v.%v at %v\n",
 							is.Tag, write.write.Got, write.write.Want, namedType, write.fieldType.Name(), pos)
 						writes := res.InitInfos[namedType].InvalidWrites[write.fieldType]
 						res.InitInfos[namedType].InvalidWrites[write.fieldType] = append(writes, write.write)
@@ -762,8 +783,8 @@ func findMethod(program *ssa.Program, valCi config.CodeIdentifier) (*ssa.Functio
 	return nil, false
 }
 
-// ReportResults writes res to a string and returns true if the analysis should fail.
-func ReportResults(res AnalysisResult) (string, bool) {
+// FormattedReport writes res to a string and returns true if the analysis should fail.
+func FormattedReport(res AnalysisResult) (string, bool) {
 	failed := false
 
 	w := &strings.Builder{}
@@ -789,6 +810,16 @@ func ReportResults(res AnalysisResult) (string, bool) {
 				w.WriteString(fmt.Sprintf("\t\t%v (got %v, want %v) at %v\n", write.Instr, write.Got, write.Want, write.Pos))
 				failed = true
 			}
+		}
+
+		if len(info.BadReinits) == 0 {
+			w.WriteString(fmt.Sprintf("\t%v\n", formatutil.Green("all must-reinit constraints satisfied")))
+		} else {
+			w.WriteString(fmt.Sprintf("\t%s\n", formatutil.Red("missing reinitializations (must-reinit not satisfied):")))
+		}
+		for _, badReinit := range info.BadReinits {
+			w.WriteString(fmt.Sprintf("\t   after call %s at %v\n", badReinit.Call.String(), badReinit.Pos))
+			failed = true
 		}
 	}
 
@@ -820,5 +851,141 @@ func isFiltered(spec config.StructInitSpec, f *ssa.Function) bool {
 		}
 	}
 
+	return false
+}
+
+// runMustReinitChecks runs all the must-reinit checks and returns a map from named struct type to
+// a possibly empty list of problems of bad reinitialization of that struct.
+func runMustReinitChecks(
+	state *ptr.State,
+	specs []config.StructInitSpec,
+	fns map[*ssa.Function]bool,
+	structToNamed map[*types.Struct]*types.Named) map[*types.Named][]BadReinit {
+	state.Logger.Infof("Run must-reinit checks.")
+	badReinits := map[*types.Named][]BadReinit{}
+	for fn := range fns {
+		if summaries.IsStdPackageName(lang.PackageNameFromFunction(fn)) {
+			continue
+		}
+		lang.IterateInstructions(fn, func(_ int, instr ssa.Instruction) {
+			if instr == nil || instr.Parent() == nil || !instr.Pos().IsValid() {
+				return
+			}
+
+			if call, isCall := instr.(*ssa.Call); isCall {
+				if !lang.CanType(call) {
+					return
+				}
+				namedType := checkStructTyp(call.Type(), structToNamed)
+				if namedType == nil {
+					return
+				}
+				if maybeBadReinit := checkMustReinitCall(state, specs, call); maybeBadReinit.IsSome() {
+					if _, ok := badReinits[namedType]; !ok {
+						badReinits[namedType] = []BadReinit{}
+					}
+					badReinits[namedType] = append(badReinits[namedType],
+						maybeBadReinit.Value())
+				}
+			}
+		})
+	}
+	return badReinits
+}
+
+// checkStructTyp extracts the types.Named type of a struct type or a pointer to a struct type.
+// This is for checking reintiializations: we only check them for function that returns the proper
+// named struct type.
+func checkStructTyp(typ types.Type, structToNamed map[*types.Struct]*types.Named) *types.Named {
+	var namedType *types.Named
+	if structTyp, ok := typ.(*types.Struct); ok {
+		namedType = structToNamed[structTyp]
+	} else if namedTyp, ok := typ.(*types.Named); ok {
+		namedType = namedTyp
+	} else if ptrTyp, ok := typ.(*types.Pointer); ok {
+		return checkStructTyp(ptrTyp.Elem(), structToNamed)
+	}
+	return namedType
+}
+
+// checkMustReinitCall checks whether the call instructions that are marked as having to
+// reinitialize the fields of their output are actually doing the reinitialization.
+func checkMustReinitCall(
+	state *ptr.State,
+	specs []config.StructInitSpec,
+	callInstr *ssa.Call) funcutil.Optional[BadReinit] {
+	callees, _ := state.ResolveCallee(callInstr)
+	// Does this call need to be checked?
+	mustCheckFor := []config.StructInitSpec{}
+	for _, spec := range specs {
+		for _, callSpec := range spec.MustReinits {
+			for _, callee := range callees {
+				if callSpec.MatchPackageAndMethod(callee.Callee) {
+					mustCheckFor = append(mustCheckFor, spec)
+				}
+			}
+		}
+	}
+
+	if len(mustCheckFor) == 0 {
+		return funcutil.None[BadReinit]() /* Nothing to do */
+	}
+	// For each spec, the statements following directly the call MUST write the fields
+	// that are specified in the spec.
+	block, index := lang.ParentBlockIndex(callInstr)
+	fieldsToReinit := map[string]bool{}
+	for _, spec := range mustCheckFor {
+		for _, fieldSpec := range spec.FieldsSet {
+			fieldsToReinit[fieldSpec.Field] = true
+		}
+	}
+	var callVal ssa.Value
+	callVal = callInstr
+	for i := index + 1; i < len(block.Instrs); i++ {
+		instr := block.Instrs[i]
+		switch instr := instr.(type) {
+		case *ssa.Store:
+			// Check that this is a store to a field that is tracked by the struct-init problem.
+			if checkStore(instr, callVal, fieldsToReinit) {
+				continue
+			}
+			// It can also be a store of the call returned value into another var, in which case we
+			// change the callVal being tracked to properly reflect on the stores
+			if instr.Val == callInstr {
+				callVal = instr.Addr
+				continue
+			}
+		case *ssa.FieldAddr:
+			fieldName, _ := analysisutil.FieldAddrFieldInfo(instr)
+			// Check that this is taking the address of a field that is tracked by the struct-init problem.
+			if _, ok := fieldsToReinit[fieldName]; ok {
+				continue
+			}
+		}
+		// At this point, we have an instr that is not a recognized store or field addr.
+		// Exit the loop to check whether it's ok because we have already reinitialized everything.
+		break
+	}
+	if len(fieldsToReinit) == 0 {
+		state.Logger.Infof("Result of %s properly reinitialized", callInstr)
+		return funcutil.None[BadReinit]() /* All checked! */
+	}
+	// We haven't reinit all fields. This is bad!
+	return funcutil.Some(BadReinit{
+		Call: callInstr,
+		Pos:  state.Program.Fset.Position(callInstr.Pos()),
+	})
+}
+
+func checkStore(instr *ssa.Store, callVal ssa.Value, fieldsToReinit map[string]bool) bool {
+	if field, ok := instr.Addr.(*ssa.FieldAddr); ok {
+		if field.X == callVal {
+			fieldName, _ := analysisutil.FieldAddrFieldInfo(field)
+			if fieldsToReinit[fieldName] {
+				delete(fieldsToReinit, fieldName)
+				return true
+			}
+		}
+	}
 	return false
 }

--- a/analysis/syntactic/structinit/structinit.go
+++ b/analysis/syntactic/structinit/structinit.go
@@ -876,7 +876,7 @@ func runMustReinitChecks(
 				if !lang.CanType(call) {
 					return
 				}
-				namedType := checkStructTyp(call.Type(), structToNamed)
+				namedType := namedStructTyp(call.Type(), structToNamed)
 				if namedType == nil {
 					return
 				}
@@ -893,17 +893,17 @@ func runMustReinitChecks(
 	return badReinits
 }
 
-// checkStructTyp extracts the types.Named type of a struct type or a pointer to a struct type.
+// namedStructTyp extracts the types.Named type of a struct type or a pointer to a struct type.
 // This is for checking reintiializations: we only check them for function that returns the proper
 // named struct type.
-func checkStructTyp(typ types.Type, structToNamed map[*types.Struct]*types.Named) *types.Named {
+func namedStructTyp(typ types.Type, structToNamed map[*types.Struct]*types.Named) *types.Named {
 	var namedType *types.Named
 	if structTyp, ok := typ.(*types.Struct); ok {
 		namedType = structToNamed[structTyp]
 	} else if namedTyp, ok := typ.(*types.Named); ok {
 		namedType = namedTyp
 	} else if ptrTyp, ok := typ.(*types.Pointer); ok {
-		return checkStructTyp(ptrTyp.Elem(), structToNamed)
+		return namedStructTyp(ptrTyp.Elem(), structToNamed)
 	}
 	return namedType
 }
@@ -931,8 +931,9 @@ func checkMustReinitCall(
 		return funcutil.None[BadReinit]() /* Nothing to do */
 	}
 	// For each spec, the statements following directly the call MUST write the fields
-	// that are specified in the spec.
-	block, index := lang.ParentBlockIndex(callInstr)
+	// that are specified in the spec. The write statements are in the same block as the
+	// call statement.
+	block, index := lang.IndexInEnclosingBlock(callInstr)
 	fieldsToReinit := map[string]bool{}
 	for _, spec := range mustCheckFor {
 		for _, fieldSpec := range spec.FieldsSet {

--- a/analysis/syntactic/structinit/structinit_test.go
+++ b/analysis/syntactic/structinit/structinit_test.go
@@ -52,12 +52,13 @@ func TestZeroAllocs(t *testing.T) {
 			t.Parallel()
 			lp, got := runAnalysis(t, tt.dirName)
 			want := expectedZeroAllocs(lp)
+			checkHasResults(t, got, want)
 			checkAllocs(t, got, want)
 		})
 	}
 }
 
-func TestInvalidWrites(t *testing.T) {
+func TestInvalidWriteAndBadReinits(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
@@ -78,8 +79,8 @@ func TestInvalidWrites(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			lp, got := runAnalysis(t, tt.dirName)
-			want := expectedInvalidWrites(lp)
-			checkInvalidWrites(t, got, want)
+			checkInvalidWrites(t, got, expectedInvalidWrites(lp))
+			checkBadReinit(t, got, expectedBadReinits(lp))
 		})
 	}
 }
@@ -89,7 +90,7 @@ func runAnalysis(t *testing.T, dirName string) (*loadprogram.State, structinit.A
 	lpState := analysistest.LoadTest(testfsys, dirName, []string{}, analysistest.LoadTestOptions{ApplyRewrite: false})
 	lp, err := lpState.Value()
 	if err != nil {
-		t.Fatalf("failedo load test: %s", err)
+		t.Fatalf("failed to load test: %s", err)
 	}
 	setupConfig(lp.Config)
 	state, err := resultMonad.Bind(lpState, ptr.NewState).Value()
@@ -104,13 +105,6 @@ func runAnalysis(t *testing.T, dirName string) (*loadprogram.State, structinit.A
 }
 
 func checkAllocs(t *testing.T, res structinit.AnalysisResult, want map[string][]analysistest.LPos) {
-	if len(res.InitInfos) == 0 {
-		t.Fatalf("no analysis results")
-	}
-	if len(want) == 0 {
-		t.Fatalf("no expected test results")
-	}
-
 	got := make(map[string][]analysistest.LPos)
 	for structType, info := range res.InitInfos {
 		name := structType.Obj().Name()
@@ -120,48 +114,24 @@ func checkAllocs(t *testing.T, res structinit.AnalysisResult, want map[string][]
 		}
 	}
 
+	compareGotWant(t, got, want, "zero-allocs")
+}
+
+func checkBadReinit(t *testing.T, res structinit.AnalysisResult, want map[string][]analysistest.LPos) {
+	got := make(map[string][]analysistest.LPos)
+	for structType, info := range res.InitInfos {
+		name := structType.Obj().Name()
+		for _, badReinit := range info.BadReinits {
+			gotPos := analysistest.NewLPos(badReinit.Pos)
+			got[name] = append(got[name], gotPos)
+		}
+	}
+
 	// make sure got has all the structs and positions in want
-	for wantName, wantPosns := range want {
-		if _, ok := got[wantName]; !ok {
-			t.Errorf("failed to find struct name in analysis results: %v", wantName)
-			continue
-		}
-
-		for _, wantPos := range wantPosns {
-			if !funcutil.Contains(got[wantName], wantPos) {
-				t.Errorf("failed to find zero-allocation position for struct %v in analysis results: %v", wantName, wantPos)
-			}
-		}
-	}
-
-	// make sure want has all the structs and positions in got
-	for gotName, gotPosns := range got {
-		if _, ok := want[gotName]; !ok {
-			t.Errorf("failed to find struct name in test annotations: %v", gotName)
-			continue
-		}
-
-		for _, gotPos := range gotPosns {
-			if !funcutil.Contains(want[gotName], gotPos) {
-				t.Errorf("failed to find zero-allocation position for struct %v in test annotations: %v", gotName, gotPos)
-			}
-		}
-	}
-
-	if t.Failed() {
-		t.Logf("want: %+v\n", want)
-		t.Logf("got: %+v\n", got)
-	}
+	compareGotWant(t, got, want, "bad reinit")
 }
 
 func checkInvalidWrites(t *testing.T, res structinit.AnalysisResult, want map[string][]analysistest.LPos) {
-	if len(res.InitInfos) == 0 {
-		t.Fatalf("no analysis results")
-	}
-	if len(want) == 0 {
-		t.Fatalf("no expected test results")
-	}
-
 	got := make(map[string][]analysistest.LPos)
 	for structType, info := range res.InitInfos {
 		name := structType.Obj().Name()
@@ -173,7 +143,19 @@ func checkInvalidWrites(t *testing.T, res structinit.AnalysisResult, want map[st
 		}
 	}
 
-	// make sure got has all the structs and positions in want
+	compareGotWant(t, got, want, "invalid write")
+}
+
+func checkHasResults(t *testing.T, res structinit.AnalysisResult, want map[string][]analysistest.LPos) {
+	if len(res.InitInfos) == 0 {
+		t.Fatalf("no analysis results")
+	}
+	if len(want) == 0 {
+		t.Fatalf("no expected test results")
+	}
+}
+
+func compareGotWant(t *testing.T, got map[string][]analysistest.LPos, want map[string][]analysistest.LPos, what string) {
 	for wantName, wantPosns := range want {
 		if _, ok := got[wantName]; !ok {
 			t.Errorf("failed to find struct name in analysis results: %v", wantName)
@@ -182,7 +164,7 @@ func checkInvalidWrites(t *testing.T, res structinit.AnalysisResult, want map[st
 
 		for _, wantPos := range wantPosns {
 			if !funcutil.Contains(got[wantName], wantPos) {
-				t.Errorf("failed to find invalid write position for struct %v in analysis results: %v", wantName, wantPos)
+				t.Errorf("failed to find %s position for struct %v in analysis results: %v", what, wantName, wantPos)
 			}
 		}
 	}
@@ -196,7 +178,7 @@ func checkInvalidWrites(t *testing.T, res structinit.AnalysisResult, want map[st
 
 		for _, gotPos := range gotPosns {
 			if !funcutil.Contains(want[gotName], gotPos) {
-				t.Errorf("failed to find invalid write position for struct %v in test annotations: %v", gotName, gotPos)
+				t.Errorf("failed to find %s position for struct %v in test annotations: %v", what, gotName, gotPos)
 			}
 		}
 	}
@@ -219,6 +201,9 @@ var zeroAllocRegex = regexp.MustCompile(`//.*@ZeroAlloc\(((?:\s*\w\s*,?)+)\)`)
 // invalidWriteRegex matches annotations of the form "@InvalidWrite(id1, id2, id3)"
 var invalidWriteRegex = regexp.MustCompile(`//.*@InvalidWrite\(((?:\s*\w\s*,?)+)\)`)
 
+// invalidWriteRegex matches annotations of the form "@InvalidWrite(id1, id2, id3)"
+var badReinitRegex = regexp.MustCompile(`//.*@BadReinit\(((?:\s*\w\s*,?)+)\)`)
+
 // expectedZeroAllocs analyzes the files in astFiles and looks for comments
 // @ZeroAlloc(id1, id2, ...) to construct the expected positions of the zero-allocations of
 // a struct.
@@ -239,6 +224,17 @@ func expectedZeroAllocs(lp *loadprogram.State) map[string][]analysistest.LPos {
 // invalid write operations' positions.
 func expectedInvalidWrites(lp *loadprogram.State) map[string][]analysistest.LPos {
 	return expectedAnnotations(invalidWriteRegex, lp)
+}
+
+// expectedBadReinits analyzes the files in astFiles and looks for comments
+// @BadReinit(id1, id2, ...) to construct the expected positions of the invalid writes to
+// a struct field.
+// Each id must be the name of the struct whose field is written to. There may be
+// multiple.
+// These positions are represented as a map from the struct name to all the
+// invalid write operations' positions.
+func expectedBadReinits(lp *loadprogram.State) map[string][]analysistest.LPos {
+	return expectedAnnotations(badReinitRegex, lp)
 }
 
 func expectedAnnotations(regex *regexp.Regexp, lp *loadprogram.State) map[string][]analysistest.LPos {

--- a/analysis/syntactic/structinit/testdata/field-func/config.yaml
+++ b/analysis/syntactic/structinit/testdata/field-func/config.yaml
@@ -7,3 +7,9 @@ syntactic-problems:
           value:
             package: "(field-func)|(main)|(command-line-arguments)"
             method: "^Func"
+      filters:
+        - method: "^allowedBadInit$"
+          package: "(field-func)|(main)|(command-line-arguments)"
+      must-reinit:
+        - method: "^allowedBadInit$"
+          package: ".*"

--- a/analysis/syntactic/structinit/testdata/field-func/main.go
+++ b/analysis/syntactic/structinit/testdata/field-func/main.go
@@ -16,10 +16,12 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 )
 
 type target struct {
-	f func() int
+	f    func() int
+	Flag int
 }
 
 type nested struct {
@@ -36,6 +38,11 @@ func Func() int {
 
 func invalid() int {
 	return 1
+}
+
+func allowedBadInit() target {
+	ex1 := target{f: nil} // ok: this is filtered out
+	return ex1
 }
 
 func testWrites() {
@@ -56,10 +63,10 @@ func testWrites() {
 	fmt.Println(ex5)
 
 	g := invalid
-	ex6 := target{g} // @InvalidWrite(target)
+	ex6 := target{g, 1} // @InvalidWrite(target)
 	fmt.Println(ex6)
 
-	ex7 := target{func() int { return Func() }} // @InvalidWrite(target)
+	ex7 := target{func() int { return Func() }, 1} // @InvalidWrite(target)
 	fmt.Println(ex7)
 }
 
@@ -89,7 +96,51 @@ func testNestedWrites() {
 	fmt.Println(ex8)
 }
 
+func testMustReinit() {
+	// Reinitialized
+	reinitializeMe := allowedBadInit()
+	reinitializeMe.f = Func // ok
+	fmt.Println(reinitializeMe)
+	// Not reinitialized
+	fmt.Print("Some stuff!")
+	badInit := allowedBadInit() // @BadReinit(target)
+	fmt.Println(badInit)
+	if rand.Int() > 0 {
+		// Not reinitialized 2
+		fmt.Print("Some stuff!")
+		badInit2 := allowedBadInit() // @BadReinit(target)
+		badInit2.Flag = 42
+		fmt.Println(badInit2)
+	}
+	if rand.Int() > 0 {
+		fmt.Print("Some stuff!")
+		okInit := allowedBadInit()
+		okInit.f = Func // ok : in same block
+		fmt.Println(okInit)
+	}
+}
+
+func testMustReinit2() {
+	// Reinitialized
+	reinitializeMe := allowedBadInit() // @BadReinit(target)
+	if rand.Float32() > 1.0 {
+		reinitializeMe.f = Func // reinitialized in a different block
+		fmt.Println(reinitializeMe)
+	}
+}
+
+func testMustReinit3() {
+	// Reinitialized
+	reinitializeMe := allowedBadInit() // @BadReinit(target)
+	reinitializeMe.Flag = 0
+	reinitializeMe.f = Func // field that must be reinitialized initialized after another field
+	fmt.Println(reinitializeMe)
+}
+
 func main() {
 	testWrites()
 	testNestedWrites()
+	testMustReinit()
+	testMustReinit2()
+	testMustReinit3()
 }

--- a/analysis/version.go
+++ b/analysis/version.go
@@ -15,4 +15,4 @@
 package analysis
 
 // Version is the last tagged version of the analysis tool
-const Version = "v0.4.5-alpha"
+const Version = "v0.4.6-alpha"

--- a/cmd/argot/syntactic/syntactic.go
+++ b/cmd/argot/syntactic/syntactic.go
@@ -121,7 +121,7 @@ func runTarget(
 			return false, nil, fmt.Errorf("struct init analysis error: %v", err)
 		}
 		var s string
-		s, structAnalysisFailed = structinit.ReportResults(structInitRes)
+		s, structAnalysisFailed = structinit.FormattedReport(structInitRes)
 		c.Logger.Infof("Struct analysis done (%.3f s)", time.Since(start).Seconds())
 		c.Logger.Infof(s)
 	}
@@ -135,7 +135,7 @@ func runTarget(
 			return false, nil, fmt.Errorf("precondition analysis error: %v", err)
 		}
 		var s string
-		s, preconditionAnalysisFailed = preconditions.ReportResults(precondCheckRes)
+		s, preconditionAnalysisFailed = preconditions.FormattedReport(precondCheckRes)
 		c.Logger.Infof("Precondition analysis done (%.3f s)", time.Since(start).Seconds())
 		c.Logger.Infof(s)
 	}

--- a/doc/12_syntactic.md
+++ b/doc/12_syntactic.md
@@ -12,17 +12,17 @@ syntactic-problems:
     - tag: "check-min-version-is-1.2"
       description: "This checks that the MinVersion in the tls.Config is always 1.2"
       struct: # Defines the struct of interest
-        type: "crypto/tls.Config" # specify the struct type 
+        type: "crypto/tls.Config" # specify the struct type
       fields-set: # Defines the fields of interest, and the value they should be set to
-        - field: "MinVersion" # The field 
+        - field: "MinVersion" # The field
           value: # The value, a code identifier: package + const or package + method
-            package: "crypto/tls" 
+            package: "crypto/tls"
             const: "VersionTLS12"
       filters: # Some function where we don't want reports, typically dependencies
         - package: "some-dep/*"
           method: ".*"
 ```
-Once you have a configuration file, you can run `argot syntactic -config config.yaml ...`. 
+Once you have a configuration file, you can run `argot syntactic -config config.yaml ...`.
 If there are no improper initializations, or improper values being assigned to the fields you are checking, the output should look like:
 ```shell
 [INFO]  Loaded ? annotations from program
@@ -30,7 +30,7 @@ If there are no improper initializations, or improper values being assigned to t
 [INFO]  Pointer analysis terminated (?? s)
 [INFO]  starting struct init analysis...
 [INFO]  Analyzing ???? unfiltered reachable functions...
-[INFO]  
+[INFO]
 struct-init analysis results:
 -----------------------------
 initialization information for crypto/tls.Config:
@@ -40,6 +40,41 @@ initialization information for crypto/tls.Config:
 ```
 The analyzer reports that 1) the struct was always allocated with the appropriate setting for the field `MinVersion` and 2) there were no writes that changed the value of that field to some value that is not capture by the constraints in the config file.
 
+### Must-reinits
+
+Sometimes the bad struct initialization is in a dependency that you cannot modify. To silence the alert, you need to add the dependency's function where the struct is badly initialized to the `filters` of the struct-init problem. However, you have to remember to reinitialize the struct: while Argot would check that all field assignment are correct with respect to the config above, it would not check that the fields have been reassigned. To perform that check, you need to add a `must-reinit` specification:
+```yaml
+syntactic-problems:
+  struct-inits:
+    - tag: "check-min-version-is-1.2"
+      description: "This checks that the MinVersion in the tls.Config is always 1.2"
+      struct: # Defines the struct of interest
+        type: "crypto/tls.Config" # specify the struct type
+      fields-set: # Defines the fields of interest, and the value they should be set to
+        - field: "MinVersion" # The field
+          value: # The value, a code identifier: package + const or package + method
+            package: "crypto/tls"
+            const: "VersionTLS12"
+      filters: # Some function where we don't want reports, typically dependencies
+        - package: "some-dep/.*"
+          method: "generateTlsConfig"
+      must-reinit: # Findings in some function bodies are silenced, but we must check the results are reinitialized
+        - package: "some-dep/.*"
+          method: "generateTlsConfig" # enforce fields of the struct returned by this call are reinitialized
+```
+In the example above, provided `generateTlsConfig` is a function that outputs a struct of type `crypto/tls.Config` (or a pointer to it), then Argot will check that when `generateTlsConfig` is called, then the field `MinVersion` is reassigned immediately after the function is called.
+For example, this code snippet will pass the check:
+```go
+config := dependency.generateTlsConfig()
+config.MinVersion = tls.VersionTLS12
+```
+but this will not pass:
+```go
+config := dependency.generateTlsConfig()
+handleConfig(config)
+config.MinVersion = tls.VersionTLS12
+```
+because the fields MUST be reinitialized in the same block as the call to the function, and immediately after. If any other instruction precedes the field assignment, Argot will generate a finding. In particular, assigning other fields should be done after having assigned the fields that are tracked by the `struct-init` problem for which `must-reinit` is specified.
 
 ## Precondition Checks
 Users may want to check that some specific functions are called only when some precondition is satisfied. You can specify a `cond-check` constraint in the config file in the `syntactic-problems` to check for those properties. Currently, the analysis is limited to checking that specific functions are called only when some simple precondition on the output of another function is called. The function calls in the preconditions must be static calls: we currently do not support interfaces.
@@ -65,13 +100,13 @@ When some call does not satisfy the preconditions, an error message is printed:
 ```
 [ERROR] Preconditions not satisfied in call FooFunc(struct{x int}{}:G)
 [ERROR] Preconditions is: !(FooPreCheck(...))
-[ERROR] Position: /<>/analysis/syntactic/preconditions/testdata/func-cond/main.go:56:9 
+[ERROR] Position: /<>/analysis/syntactic/preconditions/testdata/func-cond/main.go:56:9
 ```
 The positions are also printed when the analysis terminates.
 
 If the analysis doesn't detect any invalid calls, you should see the message:
 ```
-[INFO]  
+[INFO]
 precondition analysis results:
 -----------------------------
 all calls have valid preconditions!


### PR DESCRIPTION
This PR adds functionality to the `struct-init` syntactic check problem. Now, users can add a `must-reinit` specification that instructs Argot to check the results of some specified function call has its field reinitialized. The fields that must be reinitialized are the same fields that are constrained in the `struct-init` problem the `must-reinit` specification belongs to.

See doc/12_syntactic.md for an example and more information.