### PR TITLE
Bugfix: mark aliases of call args

### DIFF
--- a/analysis/dataflow/intra_procedural_monotone_analysis.go
+++ b/analysis/dataflow/intra_procedural_monotone_analysis.go
@@ -361,8 +361,8 @@ func (state *IntraAnalysisState) callCommonMark(value ssa.Value, instr ssa.CallI
 		// Mark call argument
 		if state.flowInfo.pathSensitivityFilter[state.flowInfo.ValueID[arg]] {
 			for _, path := range AccessPathsOfType(arg.Type()) {
-				state.flowInfo.AddMark(instr, arg, path,
-					state.flowInfo.GetNewLabelledMark(instr.(ssa.Node), CallSiteArg, arg, NonIndexMark, path))
+				newMark := state.flowInfo.GetNewLabelledMark(instr.(ssa.Node), CallSiteArg, arg, NonIndexMark, path)
+				state.markValue(instr, arg, path, newMark)
 			}
 		}
 		newMark := state.flowInfo.GetNewMark(instr.(ssa.Node), CallSiteArg, arg, NonIndexMark)

--- a/analysis/taint/taint_test.go
+++ b/analysis/taint/taint_test.go
@@ -193,6 +193,10 @@ func TestTaint(t *testing.T) {
 			name: "annotations",
 			args: args{"annotations", []string{}, noErrorExpected},
 		},
+		{
+			name: "pointers",
+			args: args{"pointers", []string{}, noErrorExpected},
+		},
 	}
 
 	for _, tt := range tests {

--- a/analysis/taint/testdata/pointers/config.yaml
+++ b/analysis/taint/testdata/pointers/config.yaml
@@ -1,0 +1,13 @@
+options:
+  silence-warn: true
+
+dataflow-problems:
+  field-sensitive-funcs:
+    - .*
+  taint-tracking:
+    - sources:
+        - package: "(pointers)|(command-line-arguments)|(main)"
+          method: "source"
+      sinks:
+        - package: fmt
+          method: Println

--- a/analysis/taint/testdata/pointers/pointers.go
+++ b/analysis/taint/testdata/pointers/pointers.go
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	dc := outer{in: &inner{secrets: secrets{}}}
+	in := dc.in
+	in.setSecret()
+	// dc.in = in
+	fmt.Println(string(dc.in.secrets.secret)) // @Sink(ex1)
+}
+
+type outer struct {
+	in *inner
+}
+
+type inner struct {
+	secrets secrets
+}
+
+func (i *inner) setSecret() {
+	i.secrets.secret = source() // @Source(ex1)
+}
+
+type secrets struct {
+	secret []byte
+}
+
+func source() []byte {
+	return []byte("secret")
+}


### PR DESCRIPTION
Fixes a soundness issue reproduced via the "pointers" taint analysis test.

The issue was that we were using a lower level function to mark arguments to calls that only adds the value, instead of the higher level function which also marks aliases.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
