### PR TITLE
Use Go 1.23.10 in CI

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: ['1.23.6']
+        go-version: ['1.23.10']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes the os package vulnerability that govulncheck was flagging: https://github.com/golang/go/issues?q=milestone%3AGo1.23.10+label%3ACherryPickApproved

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
