### PR TITLE
Minor fixes

### DIFF
--- a/analysis/backtrace/backtrace.go
+++ b/analysis/backtrace/backtrace.go
@@ -481,7 +481,7 @@ func (v *Visitor) visit(s *df.State, entrypoint df.NodeWithTrace) error {
 			// We pop the call from the trace (callstack) when exiting the callee and returning to the caller
 			var tr *df.NodeTree[*df.CallNode]
 			if cur.Trace != nil {
-				tr = cur.Trace.Parent
+				tr = cur.Trace.Parent()
 			}
 
 			// Check if the previous node was a parameter coming from the same function (recursive call)
@@ -706,7 +706,7 @@ func (v *Visitor) visit(s *df.State, entrypoint df.NodeWithTrace) error {
 					nextNodeWithTrace := df.NodeWithTrace{
 						Node:         bv,
 						Trace:        cur.Trace,
-						ClosureTrace: cur.ClosureTrace.Parent,
+						ClosureTrace: cur.ClosureTrace.Parent(),
 					}
 					status := df.VisitorNodeStatus{
 						Kind:        df.ClosureTracing,

--- a/analysis/dataflow/callctx.go
+++ b/analysis/dataflow/callctx.go
@@ -96,7 +96,7 @@ func isRecursive(stack *CallStack, call *CallNode) bool {
 		if stack.Label == call {
 			return true
 		}
-		stack = stack.Parent
+		stack = stack.Parent()
 	}
 	return false
 }
@@ -112,7 +112,7 @@ func hasReachedContextLimit(stack *CallStack, limit int) bool {
 		if counter >= limit {
 			return true
 		}
-		stack = stack.Parent
+		stack = stack.Parent()
 	}
 	return false
 }
@@ -122,7 +122,7 @@ func reverseCallStack(s *reversedCallStack) *CallStack {
 		return nil
 	}
 	res := NewNodeTree(s.Label)
-	for cur := s.Parent; cur != nil; cur = cur.Parent {
+	for cur := s.Parent(); cur != nil; cur = cur.Parent() {
 		res = res.Add(cur.Label)
 	}
 	return res

--- a/analysis/dataflow/inter_procedural.go
+++ b/analysis/dataflow/inter_procedural.go
@@ -645,7 +645,7 @@ func UnwindCallStackToFunc(stack *CallStack, f *ssa.Function) *CallStack {
 		if cur.Label.Callee() == f {
 			return cur
 		}
-		cur = cur.Parent
+		cur = cur.Parent()
 	}
 	return nil
 }

--- a/analysis/dataflow/trace.go
+++ b/analysis/dataflow/trace.go
@@ -50,8 +50,8 @@ type NodeTree[T GraphNode] struct {
 	// Origin is the root of the node tree
 	Origin *NodeTree[T]
 
-	// Parent is the parent of the current node
-	Parent *NodeTree[T]
+	// parent is the parent of the current node
+	parent *NodeTree[T]
 
 	Children []*NodeTree[T]
 
@@ -64,13 +64,24 @@ type NodeTree[T GraphNode] struct {
 // NewNodeTree returns a new node tree with the initial node label provided
 func NewNodeTree[T GraphNode](initNode T) *NodeTree[T] {
 	origin := &NodeTree[T]{
-		Label:  initNode,
-		Parent: nil, Children: []*NodeTree[T]{},
-		height: 1,
-		key:    initNode.LongID(),
+		Label:    initNode,
+		parent:   nil,
+		Children: []*NodeTree[T]{},
+		height:   1,
+		key:      initNode.LongID(),
 	}
 	origin.Origin = origin
 	return origin
+}
+
+// Parent returns the parent of the node. If the node is nil, returns nil.
+//
+// (nil-safe)
+func (n *NodeTree[T]) Parent() *NodeTree[T] {
+	if n == nil {
+		return nil
+	}
+	return n.parent
 }
 
 // Key returns the key of the node. If the node has been constructed only using NewNodeTree and Add, the key will be
@@ -89,7 +100,7 @@ func (n *NodeTree[T]) String() string {
 		return ""
 	}
 	s := make([]string, n.height)
-	for cur := n; cur != nil; cur = cur.Parent {
+	for cur := n; cur != nil; cur = cur.Parent() {
 		if cur.height >= 1 {
 			s[cur.height-1] = cur.Label.String()
 		}
@@ -103,7 +114,7 @@ func (n *NodeTree[T]) SummaryString() string {
 		return ""
 	}
 	s := make([]string, n.height)
-	for cur := n; cur != nil; cur = cur.Parent {
+	for cur := n; cur != nil; cur = cur.Parent() {
 		if cur.height >= 1 {
 			s[cur.height-1] = shortNodeSummary(cur.Label)
 		}
@@ -127,7 +138,7 @@ func (n *NodeTree[T]) ToSlice() []T {
 	}
 	s := make([]T, n.height)
 	pos := n.height - 1
-	for cur := n; cur != nil; cur = cur.Parent {
+	for cur := n; cur != nil; cur = cur.Parent() {
 		s[pos] = cur.Label
 		pos--
 	}
@@ -144,7 +155,7 @@ func (n *NodeTree[T]) GetLassoHandle() *NodeTree[T] {
 		return nil
 	}
 	last := n
-	for cur := last.Parent; cur != nil; cur = cur.Parent {
+	for cur := last.Parent(); cur != nil; cur = cur.Parent() {
 		if cur.Label.String() == last.Label.String() {
 			return cur
 		}
@@ -167,7 +178,7 @@ func (n *NodeTree[T]) Add(node T) *NodeTree[T] {
 	// A new node needs to be allocated
 	newNode := &NodeTree[T]{
 		Label:    node,
-		Parent:   n,
+		parent:   n,
 		Children: []*NodeTree[T]{},
 		Origin:   n.Origin,
 		height:   n.height + 1,
@@ -201,7 +212,7 @@ func FuncNames(n *NodeTree[*CallNode], debug bool) string {
 		return ""
 	}
 	s := make([]string, n.height)
-	for cur := n; cur != nil; cur = cur.Parent {
+	for cur := n; cur != nil; cur = cur.Parent() {
 		if cur.height >= 1 {
 			// if debug is set, add the internal id
 			if debug {

--- a/analysis/ptr/pointer_test.go
+++ b/analysis/ptr/pointer_test.go
@@ -1,0 +1,92 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ptr_test
+
+import (
+	"embed"
+	"path/filepath"
+	"testing"
+
+	"github.com/awslabs/ar-go-tools/analysis/config"
+	"github.com/awslabs/ar-go-tools/analysis/loadprogram"
+	"github.com/awslabs/ar-go-tools/analysis/ptr"
+	"github.com/awslabs/ar-go-tools/internal/analysistest"
+	"github.com/awslabs/ar-go-tools/internal/funcutil/result"
+)
+
+//go:embed testdata
+var testfsys embed.FS
+
+func TestPointer(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		dirName     string
+		extraFiles  []string
+		expectError func(error) bool
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "ptr-no-panic-tests",
+			args: args{"ptr-no-panic-tests", []string{}, noErrorExpected},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runTest(t, tt.args.dirName, tt.args.extraFiles, tt.args.expectError)
+		})
+	}
+}
+
+func runTest(t *testing.T, dirName string, files []string, errorExpected func(e error) bool) {
+	dirName = filepath.Join("./testdata", dirName)
+	lp := analysistest.LoadTest(testfsys, dirName, files, analysistest.LoadTestOptions{ApplyRewrite: false})
+	if lp.IsErr() {
+		t.Fatalf("failed to load test: %v", lp)
+	}
+	result.Do(lp, func(lp *loadprogram.State) { setupConfig(lp) })
+	ptrState, err := result.Bind(lp, ptr.NewState).Value()
+	if err != nil {
+		if !errorExpected(err) {
+			t.Errorf("pointer analysis returned error: %v", err)
+		}
+		return
+	}
+
+	// Verify pointer analysis completed successfully
+	if ptrState.PointerAnalysis == nil {
+		t.Error("pointer analysis result is nil")
+	}
+}
+
+func setupConfig(lp *loadprogram.State) {
+	cfg := lp.Config
+	cfg.Options.ReportCoverage = false
+	cfg.Options.ReportPaths = false
+	cfg.Options.ReportSummaries = false
+	cfg.Options.ReportsDir = ""
+	cfg.LogLevel = int(config.ErrLevel)
+
+	lp.Logger = config.NewLogGroup(cfg)
+}
+
+func noErrorExpected(_ error) bool {
+	return false
+}

--- a/analysis/ptr/testdata/ptr-no-panic-tests/config.yaml
+++ b/analysis/ptr/testdata/ptr-no-panic-tests/config.yaml
@@ -1,0 +1,3 @@
+options:
+  analysis-options:
+    max-entrypoint-context-size: 5

--- a/analysis/ptr/testdata/ptr-no-panic-tests/main.go
+++ b/analysis/ptr/testdata/ptr-no-panic-tests/main.go
@@ -1,0 +1,412 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "unsafe"
+
+// Basic types
+
+type MyInt int
+type MyString string
+type MyBool bool
+
+// Array types
+
+type IntArray [5]int
+type StringArray [3]string
+
+// Slice types
+
+type IntSlice []int
+type StringSlice []string
+
+// Map types
+
+type StringIntMap map[string]int
+type IntStringMap map[int]string
+
+// Channel types
+
+type IntChan chan int
+type SendOnlyChan chan<- string
+type RecvOnlyChan <-chan bool
+
+// Pointer types
+
+type IntPtr *int
+type StringPtr *string
+
+// Function types
+
+type SimpleFunc func()
+type FuncWithArgs func(int, string) bool
+type FuncWithVariadic func(string, ...int) error
+
+// Struct types
+
+type SimpleStruct struct {
+	Field1 int
+	Field2 string
+}
+
+type EmbeddedStruct struct {
+	SimpleStruct
+	Field3 bool
+}
+
+type StructWithTags struct {
+	Field1 int    `json:"field1"`
+	Field2 string `json:"field2,omitempty"`
+}
+
+// Interface types
+
+type SimpleInterface interface {
+	Method1()
+}
+
+type ComplexInterface interface {
+	Method1() int
+	Method2(string) error
+	Method3(int, ...string) (bool, error)
+}
+
+type EmbeddedInterface interface {
+	SimpleInterface
+	Method4() string
+}
+
+// Type aliases
+
+type MyIntAlias = int
+type MyStructAlias = SimpleStruct
+
+// Unsafe pointer
+
+type UnsafePtr unsafe.Pointer
+
+// Generic types (Go 1.18+)
+
+type GenericStruct[T any] struct {
+	Value T
+}
+
+type GenericInterface[T comparable] interface {
+	Compare(T) bool
+}
+
+type GenericMap[K comparable, V any] map[K]V
+
+// SimpleInterface implementations
+
+type SimpleImpl1 struct{}
+
+func (s SimpleImpl1) Method1() {}
+
+type SimpleImpl2 struct {
+	data int
+}
+
+func (s SimpleImpl2) Method1() {}
+
+// ComplexInterface implementations
+
+type ComplexImpl1 struct {
+	value int
+}
+
+func (c ComplexImpl1) Method1() int {
+	return c.value
+}
+
+func (c ComplexImpl1) Method2(string) error {
+	return nil
+}
+
+func (c ComplexImpl1) Method3(int, ...string) (bool, error) {
+	return true, nil
+}
+
+type ComplexImpl2 struct {
+	name string
+}
+
+func (c ComplexImpl2) Method1() int {
+	return len(c.name)
+}
+
+func (c ComplexImpl2) Method2(string) error {
+	return nil
+}
+
+func (c ComplexImpl2) Method3(int, ...string) (bool, error) {
+	return false, nil
+}
+
+// EmbeddedInterface implementations
+
+type EmbeddedImpl1 struct {
+	id int
+}
+
+func (e EmbeddedImpl1) Method1() {}
+
+func (e EmbeddedImpl1) Method4() string {
+	return "embedded1"
+}
+
+type EmbeddedImpl2 struct {
+	tag string
+}
+
+func (e EmbeddedImpl2) Method1() {}
+
+func (e EmbeddedImpl2) Method4() string {
+	return e.tag
+}
+
+// GenericInterface implementations
+
+type GenericImpl1[T comparable] struct {
+	value T
+}
+
+func (g GenericImpl1[T]) Compare(other T) bool {
+	return g.value == other
+}
+
+type GenericImpl2[T comparable] struct {
+	items []T
+}
+
+func (g GenericImpl2[T]) Compare(other T) bool {
+	for _, item := range g.items {
+		if item == other {
+			return true
+		}
+	}
+	return false
+}
+
+func fooChans() {
+	// Use channel types
+	var intCh IntChan = make(chan int, 1)
+	var sendCh SendOnlyChan = make(chan string, 1)
+	var recvCh RecvOnlyChan = make(chan bool, 1)
+
+	intCh <- 42
+	<-intCh
+
+	sendCh <- "hello"
+
+	select {
+	case <-recvCh:
+	default:
+	}
+}
+
+func fooMaps() {
+	// Use map types
+	var stringIntMap StringIntMap = make(map[string]int)
+	var intStringMap IntStringMap = make(map[int]string)
+	var genericMap GenericMap[string, int] = make(map[string]int)
+
+	stringIntMap["key"] = 42
+	intStringMap[1] = "value"
+	genericMap["generic"] = 100
+
+	_ = stringIntMap["key"]
+	_ = intStringMap[1]
+	_ = genericMap["generic"]
+}
+
+func fooUnsafe() {
+	// Use pointer types
+	s := "hello"
+	var strPtr StringPtr = &s
+
+	arr := StringArray{"a", "b", "c"}
+
+	// Unsafe pointer operations
+	var unsafePtr = UnsafePtr(strPtr)
+	var backToStrPtr StringPtr = (*string)(unsafePtr)
+
+	// Array to slice conversion with unsafe
+	arrPtr := unsafe.Pointer(&arr[0])
+	slicePtr := (*string)(arrPtr)
+
+	// Pointer arithmetic (unsafe)
+	nextPtr := unsafe.Pointer(uintptr(arrPtr) + unsafe.Sizeof(arr[0]))
+	nextStr := (*string)(nextPtr)
+
+	// Use the values
+	_ = *strPtr
+	_ = *backToStrPtr
+	_ = *slicePtr
+	_ = *nextStr
+	_ = unsafe.Sizeof(arr)
+	_ = uintptr(unsafePtr)
+}
+
+func fooStructs() {
+	// Use struct types
+	var simple = SimpleStruct{Field1: 10, Field2: "simple"}
+	var embedded = EmbeddedStruct{
+		SimpleStruct: SimpleStruct{Field1: 20, Field2: "embedded"},
+		Field3:       true,
+	}
+	var tagged = StructWithTags{Field1: 30, Field2: "tagged"}
+	var generic = GenericStruct[int]{Value: 40}
+
+	// Use type aliases
+	var aliasStruct = MyStructAlias{Field1: 50, Field2: "alias"}
+	var aliasInt MyIntAlias
+	aliasInt = simple.Field1
+
+	// Access fields
+	_ = simple.Field2
+	_ = embedded.Field1
+	_ = embedded.Field2
+	_ = embedded.Field3
+	_ = tagged.Field1
+	_ = tagged.Field2
+	_ = generic.Value
+	_ = aliasStruct.Field1
+	_ = aliasStruct.Field2
+	_ = aliasInt
+}
+
+func fooFuncs() {
+	// Use function types
+	var simple SimpleFunc = func() {}
+	var withArgs FuncWithArgs = func(i int, s string) bool { return i > 0 }
+	var variadic FuncWithVariadic = func(s string, nums ...int) error { return nil }
+
+	simple()
+	result := withArgs(42, "test")
+	err := variadic("hello", 1, 2, 3)
+
+	_ = result
+	_ = err
+}
+
+func fooSlices() {
+	// Use slice types
+	var intSlice IntSlice = []int{1, 2, 3}
+	var stringSlice StringSlice = []string{"a", "b", "c"}
+
+	intSlice = append(intSlice, 4)
+	stringSlice = append(stringSlice, "d")
+
+	for _, v := range intSlice {
+		_ = v
+	}
+
+	for _, v := range stringSlice {
+		_ = v
+	}
+}
+
+func foo() {
+	// Use SimpleInterface implementations
+	var simple1 SimpleInterface = SimpleImpl1{}
+	var simple2 SimpleInterface = SimpleImpl2{data: 10}
+	simple1.Method1()
+	simple2.Method1()
+
+	// Use ComplexInterface implementations
+	var complex1 ComplexInterface = ComplexImpl1{value: 5}
+	var complex2 ComplexInterface = ComplexImpl2{name: "test"}
+	complex1.Method1()
+	err := complex1.Method2("hello")
+	if err != nil {
+		return
+	}
+	_, err = complex1.Method3(1, "a", "b")
+	if err != nil {
+		return
+	}
+	complex2.Method1()
+	err2 := complex2.Method2("world")
+	if err2 != nil {
+		return
+	}
+	_, err4 := complex2.Method3(2, "c", "d")
+	if err4 != nil {
+		return
+	}
+
+	// Use EmbeddedInterface implementations
+	var embedded1 EmbeddedInterface = EmbeddedImpl1{id: 1}
+	var embedded2 EmbeddedInterface = EmbeddedImpl2{tag: "tag1"}
+	embedded1.Method1()
+	embedded1.Method4()
+	embedded2.Method1()
+	embedded2.Method4()
+
+	// Use GenericInterface implementations
+	var generic1 GenericInterface[int] = GenericImpl1[int]{value: 42}
+	var generic2 GenericInterface[string] = GenericImpl2[string]{items: []string{"a", "b"}}
+	generic1.Compare(42)
+	generic2.Compare("a")
+}
+
+func main() {
+	foo()
+	fooFuncs()
+	fooChans()
+	fooMaps()
+	fooSlices()
+	fooStructs()
+	fooUnsafe()
+
+	// Use the types to ensure they're analyzed
+	var i MyInt = 42
+	var s MyString = "hello"
+	var b MyBool = true
+
+	var arr IntArray = [5]int{1, 2, 3, 4, 5}
+	var slice IntSlice = []int{1, 2, 3}
+	var m StringIntMap = make(map[string]int)
+	var ch IntChan = make(chan int)
+
+	var j = 100
+	var ptr IntPtr = &j
+	var fn SimpleFunc = func() {}
+
+	var st = SimpleStruct{Field1: 1, Field2: "test"}
+	var embedded = EmbeddedStruct{
+		SimpleStruct: st,
+		Field3:       true,
+	}
+
+	var generic = GenericStruct[int]{Value: 42}
+	var genericMap GenericMap[string, int] = make(map[string]int)
+
+	// Use variables to prevent optimization
+	_ = i
+	_ = s
+	_ = b
+	_ = arr
+	_ = slice
+	_ = m
+	_ = ch
+	_ = ptr
+	_ = fn
+	_ = st
+	_ = embedded
+	_ = generic
+	_ = genericMap
+}

--- a/analysis/render/render.go
+++ b/analysis/render/render.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package render provides functions to build a inter-procedural dataflow graph.
+// Package render provides functions to build an inter-procedural dataflow graph.
 // This is used to render the graph in a GraphViz format.
 package render
 
@@ -104,7 +104,7 @@ func (v CrossFunctionGraphVisitor) Visit(c *dataflow.State, entrypoint dataflow.
 					// Follow taint on matching argument at call site
 					arg := callSite.Args()[graphNode.Index()]
 					if arg != nil {
-						que = addNext(c, que, seen, elt, arg, elt.Trace.Parent, elt.ClosureTrace)
+						que = addNext(c, que, seen, elt, arg, elt.Trace.Parent(), elt.ClosureTrace)
 						addEdge(c.FlowGraph, arg, graphNode)
 					}
 				}
@@ -174,12 +174,12 @@ func (v CrossFunctionGraphVisitor) Visit(c *dataflow.State, entrypoint dataflow.
 				// This function was called: the value flows back to the call site only
 				addEdge(c.FlowGraph, graphNode, caller)
 				for x := range caller.Out() {
-					que = addNext(c, que, seen, elt, x, elt.Trace.Parent, elt.ClosureTrace)
+					que = addNext(c, que, seen, elt, x, elt.Trace.Parent(), elt.ClosureTrace)
 				}
 			} else if elt.ClosureTrace != nil && dataflow.CheckClosureReturns(graphNode, elt.ClosureTrace.Label) {
 				addEdge(c.FlowGraph, graphNode, elt.ClosureTrace.Label)
 				for cCall := range elt.ClosureTrace.Label.Out() {
-					que = addNext(c, que, seen, elt, cCall, elt.Trace, elt.ClosureTrace.Parent)
+					que = addNext(c, que, seen, elt, cCall, elt.Trace, elt.ClosureTrace.Parent())
 				}
 			} else if len(graphNode.Graph().Callsites) > 0 {
 				// The value must always flow back to all call sites: we got here without context
@@ -199,7 +199,7 @@ func (v CrossFunctionGraphVisitor) Visit(c *dataflow.State, entrypoint dataflow.
 			// We pop the call from the stack and continue inside the caller
 			var trace *dataflow.NodeTree[*dataflow.CallNode]
 			if elt.Trace != nil {
-				trace = elt.Trace.Parent
+				trace = elt.Trace.Parent()
 			}
 			for x := range graphNode.Out() {
 				que = addNext(c, que, seen, elt, x, trace, elt.ClosureTrace)
@@ -252,7 +252,7 @@ func (v CrossFunctionGraphVisitor) Visit(c *dataflow.State, entrypoint dataflow.
 				bvs := elt.ClosureTrace.Label.BoundVars()
 				if graphNode.Index() < len(bvs) {
 					bv := bvs[graphNode.Index()]
-					que = addNext(c, que, seen, elt, bv, elt.Trace, elt.ClosureTrace.Parent)
+					que = addNext(c, que, seen, elt, bv, elt.Trace, elt.ClosureTrace.Parent())
 				} else {
 					c.Report.AddError(
 						fmt.Sprintf("no bound variable matching free variable in %s",

--- a/analysis/taint/dataflow_visitor.go
+++ b/analysis/taint/dataflow_visitor.go
@@ -237,7 +237,7 @@ func (v *Visitor) Visit(s *df.State, source df.NodeWithTrace) {
 					if nextNodeArg != nil {
 						nextNodeWithTrace := df.NodeWithTrace{
 							Node:         nextNodeArg,
-							Trace:        cur.Trace.Parent,
+							Trace:        cur.Trace.Parent(),
 							ClosureTrace: cur.ClosureTrace,
 						}
 						que = v.addNext(s, que, cur, nil, nextNodeWithTrace, cur.Status, df.EdgeInfo{})
@@ -358,7 +358,7 @@ func (v *Visitor) Visit(s *df.State, source df.NodeWithTrace) {
 						if !(graphNode.Index() >= 0 && edgeInfo.Index >= 0 && graphNode.Index() != edgeInfo.Index) {
 							nextNodeWithTrace := df.NodeWithTrace{
 								Node:         nextNode,
-								Trace:        cur.Trace.Parent,
+								Trace:        cur.Trace.Parent(),
 								ClosureTrace: cur.ClosureTrace,
 							}
 							que = v.addNext(s, que, cur, callSiteFromCallStack, nextNodeWithTrace, cur.Status, edgeInfo)
@@ -374,7 +374,7 @@ func (v *Visitor) Visit(s *df.State, source df.NodeWithTrace) {
 						nextNodeWithTrace := df.NodeWithTrace{
 							Node:         nextNode,
 							Trace:        cur.Trace,
-							ClosureTrace: cur.ClosureTrace.Parent,
+							ClosureTrace: cur.ClosureTrace.Parent(),
 						}
 						que = v.addNext(s, que, cur, cur.ClosureTrace.Label, nextNodeWithTrace, cur.Status, edgeInfo)
 					}
@@ -430,7 +430,7 @@ func (v *Visitor) Visit(s *df.State, source df.NodeWithTrace) {
 			// We pop the call from the stack and continue inside the caller
 			var trace *df.NodeTree[*df.CallNode]
 			if cur.Trace != nil {
-				trace = cur.Trace.Parent
+				trace = cur.Trace.Parent()
 			}
 			for nextNode, edgeInfos := range graphNode.Out() {
 				for _, edgeInfo := range edgeInfos {
@@ -535,8 +535,8 @@ func (v *Visitor) Visit(s *df.State, source df.NodeWithTrace) {
 					bv := bvs[graphNode.Index()]
 					nextNodeWithTrace := df.NodeWithTrace{
 						Node:         bv,
-						Trace:        cur.Trace.Parent,
-						ClosureTrace: cur.ClosureTrace.Parent,
+						Trace:        cur.Trace.Parent(),
+						ClosureTrace: cur.ClosureTrace.Parent(),
 					}
 					que = v.addNext(s, que, cur, nil, nextNodeWithTrace, cur.Status, df.EdgeInfo{})
 				} else {
@@ -716,7 +716,7 @@ func (v *Visitor) initEscapeAnalysisInfo(s *df.State, source df.NodeWithTrace) {
 	var rootKey df.KeyType
 	// Resolve the context
 	if source.Trace != nil {
-		rootKey = source.Trace.Parent.Key()
+		rootKey = source.Trace.Parent().Key()
 	} else {
 		rootKey = ""
 	}
@@ -934,9 +934,7 @@ func (v *Visitor) storeEscapeGraph(s *df.State, stack *df.CallStack, callNode *d
 
 	key := "" // key corresponding to no context if the function is a root
 	if stack != nil {
-		if stack.Parent != nil {
-			key = stack.Parent.Key()
-		}
+		key = stack.Parent().Key()
 		escapeContext = v.escapeGraphs[callNode.Graph().Parent][key]
 	}
 

--- a/internal/pointer/analysis.go
+++ b/internal/pointer/analysis.go
@@ -230,6 +230,8 @@ func Analyze(config *Config) (result *Result, err error) {
 		if p := recover(); p != nil {
 			err = fmt.Errorf("internal error in pointer analysis: %v (please report this bug)", p)
 			fmt.Fprintln(os.Stderr, "Internal panic in pointer analysis:")
+			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+			fmt.Fprintln(os.Stderr, "Stack:")
 			debug.PrintStack()
 		}
 	}()

--- a/internal/pointer/util.go
+++ b/internal/pointer/util.go
@@ -120,7 +120,7 @@ func (a *analysis) flatten(t types.Type) []*fieldInfo {
 	fl, ok := a.flattenMemo[t]
 	if !ok {
 		switch t := t.(type) {
-		case *types.Named:
+		case *types.Named, *types.Alias:
 			u := t.Underlying()
 			if isInterface(u) {
 				// Debuggability hack: don't remove
@@ -171,6 +171,10 @@ func (a *analysis) flatten(t types.Type) []*fieldInfo {
 				}
 			}
 
+		case *types.Union:
+			panic(fmt.Sprintf("union type %T not supported", t))
+		case *types.TypeParam:
+			panic(fmt.Sprintf("unexpected type param %T", t))
 		default:
 			panic(fmt.Sprintf("cannot flatten unsupported type %T", t))
 		}


### PR DESCRIPTION
This PR fixes two potential panic locations:
- a nil panic when trying to extract the parent node of a trace. `Parent` is now a nil-safe method.
- a missed type case when flattening in the pointer analysis. Now the flattening also works for aliases, and the panic messages are more descriptive. 
Also added a pointer analysis test testing for absence of panics.