### PR TITLE
Removing 1.23 for CI: vulnerability in latest 1.23 version.

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: ['1.23', '1.24', '1.25']
+        go-version: ['1.24', '1.25']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
