### PR TITLE
Global as entrypoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ lint: **/*.go
 	gocyclo -ignore "test|internal/pointer|internal/typeparams" -over 15 .
 	ineffassign ./...
 	nilaway --test=false ./cmd/argot/... \
+                         ./cmd/argot-mcp-server/... \
                          ./analysis/annotations/... \
                          ./analysis/backtrace/... \
                          ./analysis/concurrency/... \

--- a/analysis/backtrace/backtrace.go
+++ b/analysis/backtrace/backtrace.go
@@ -414,7 +414,7 @@ func (v *Visitor) visit(s *df.State, entrypoint df.NodeWithTrace) error {
 						}
 
 						// the callee summary may not have been created yet
-						if callSite.CalleeSummary == nil {
+						if callSite.CalleeSummary == nil && callSite.Callee() != nil {
 							logger.Tracef("Callee summary has not been created")
 							callSite.CalleeSummary = df.NewSummaryGraph(s,
 								callSite.Callee(),
@@ -426,6 +426,9 @@ func (v *Visitor) visit(s *df.State, entrypoint df.NodeWithTrace) error {
 									return false
 								},
 								nil)
+							if callSite.CalleeSummary == nil {
+								panic(fmt.Errorf("summary of %v is nil, this should never happen", callSite.Callee()))
+							}
 							v.onDemandIntraProcedural(s, callSite.CalleeSummary)
 						}
 					} else {

--- a/analysis/backtrace/backtrace_taint_test.go
+++ b/analysis/backtrace/backtrace_taint_test.go
@@ -244,6 +244,8 @@ func sourceNode(source dataflow.GraphNode) ssa.Node {
 		return node.ParentNode().CallSite().Value()
 	case *dataflow.SyntheticNode:
 		return node.Instr().(ssa.Node)
+	case *dataflow.AccessGlobalNode:
+		return node.Instr().(ssa.Node)
 	default:
 		panic(fmt.Errorf("invalid source: %T", source))
 	}

--- a/analysis/config/code_identifier.go
+++ b/analysis/config/code_identifier.go
@@ -56,6 +56,10 @@ type CodeIdentifier struct {
 	// The Package field must be set as well.
 	Const string `xml:"const,attr"`
 
+	// Global identifies a global variable.
+	// The Package field must be set as well
+	Global string `xml:"global,attr"`
+
 	// Label can be used to store user-defined information about the code identifier.
 	Label string `xml:"label,attr"`
 
@@ -185,6 +189,7 @@ type codeIdentifierRegex struct {
 	receiverRegex   *regexp.Regexp
 	valueMatchRegex *regexp.Regexp
 	constRegex      *regexp.Regexp
+	globalRegex     *regexp.Regexp
 }
 
 // compileRegexes compiles the strings in the code identifier into regexes. It compiles all identifiers into regexes
@@ -193,24 +198,7 @@ type codeIdentifierRegex struct {
 // TODO improve error handling
 func compileRegexes(cid CodeIdentifier) CodeIdentifier {
 	if isNewFormat(cid) {
-		// Enclosing is the only object that may contain regexes (for now)
-		cid.Enclosing.computedRegexs = &callingContextRegex{}
-		if cid.Enclosing.PackageRegex != "" {
-			packageRegex, err := regexp.Compile(cid.Enclosing.PackageRegex)
-			if err != nil {
-				fmt.Printf("[WARN] failed to compile enclosing package regex %v: %v\n", cid.Enclosing.PackageRegex, err)
-			}
-			cid.Enclosing.computedRegexs.packageRegex = packageRegex
-		}
-		if cid.Enclosing.MethodRegex != "" {
-			methodRegex, err := regexp.Compile(cid.Enclosing.MethodRegex)
-			if err != nil {
-				fmt.Printf("[WARN] failed to compile enclosing method regex %v: %v\n", cid.Enclosing.MethodRegex, err)
-			}
-			cid.Enclosing.computedRegexs.methodRegex = methodRegex
-		}
-
-		return cid
+		return compileRegexesNewFormat(cid)
 	}
 
 	contextRegex, err := regexp.Compile(cid.Context)
@@ -249,6 +237,10 @@ func compileRegexes(cid CodeIdentifier) CodeIdentifier {
 	if err != nil {
 		fmt.Printf("[WARN] failed to compile const regex %v: %v\n", cid.Const, err)
 	}
+	globalRegex, err := regexp.Compile(cid.Global)
+	if err != nil {
+		fmt.Printf("[WARN] failed to compile global regex %v: %v\n", cid.Global, err)
+	}
 	cid.computedRegexs = &codeIdentifierRegex{
 		contextRegex,
 		packageRegex,
@@ -259,6 +251,27 @@ func compileRegexes(cid CodeIdentifier) CodeIdentifier {
 		receiverRegex,
 		valueMatchRegex,
 		constRegex,
+		globalRegex,
+	}
+	return cid
+}
+
+func compileRegexesNewFormat(cid CodeIdentifier) CodeIdentifier {
+	// Enclosing is the only object that may contain regexes (for now)
+	cid.Enclosing.computedRegexs = &callingContextRegex{}
+	if cid.Enclosing.PackageRegex != "" {
+		packageRegex, err := regexp.Compile(cid.Enclosing.PackageRegex)
+		if err != nil {
+			fmt.Printf("[WARN] failed to compile enclosing package regex %v: %v\n", cid.Enclosing.PackageRegex, err)
+		}
+		cid.Enclosing.computedRegexs.packageRegex = packageRegex
+	}
+	if cid.Enclosing.MethodRegex != "" {
+		methodRegex, err := regexp.Compile(cid.Enclosing.MethodRegex)
+		if err != nil {
+			fmt.Printf("[WARN] failed to compile enclosing method regex %v: %v\n", cid.Enclosing.MethodRegex, err)
+		}
+		cid.Enclosing.computedRegexs.methodRegex = methodRegex
 	}
 	return cid
 }
@@ -280,6 +293,7 @@ func (cid *CodeIdentifier) equalOnNonEmptyFields(cidRef CodeIdentifier) bool {
 			((cidRef.computedRegexs.methodRegex.MatchString(cid.Method)) || (cidRef.Method == "")) &&
 			((cidRef.computedRegexs.receiverRegex.MatchString(cid.Receiver)) || (cidRef.Receiver == "")) &&
 			((cidRef.computedRegexs.constRegex.MatchString(cid.Const)) || (cidRef.Const == "")) &&
+			((cidRef.computedRegexs.globalRegex.MatchString(cid.Global)) || (cidRef.Global == "")) &&
 			((cidRef.computedRegexs.fieldRegex.MatchString(cid.Field)) || (cidRef.Field == "")) &&
 			(cidRef.computedRegexs.typeRegex.MatchString(cid.Type) || cidRef.Type == "") &&
 			(cidRef.computedRegexs.valueMatchRegex.MatchString(cid.ValueMatch) || cidRef.ValueMatch == "") &&
@@ -291,6 +305,7 @@ func (cid *CodeIdentifier) equalOnNonEmptyFields(cidRef CodeIdentifier) bool {
 		((cid.Method == cidRef.Method) || (cidRef.Method == "")) &&
 		((cid.Receiver == cidRef.Receiver) || (cidRef.Receiver == "")) &&
 		((cid.Const == cidRef.Const) || (cidRef.Const == "")) &&
+		((cid.Global == cidRef.Global) || (cidRef.Global == "")) &&
 		((cid.Field == cidRef.Field) || (cidRef.Field == "")) &&
 		((cid.Type == cidRef.Type) || (cidRef.Type == "")) &&
 		((cid.ValueMatch == cidRef.ValueMatch) || (cidRef.ValueMatch == "")) &&
@@ -468,6 +483,16 @@ func (cid *CodeIdentifier) MatchInterface(f *ssa.Function) bool {
 
 // MatchConst matches a named package-level constant to a code identifier.
 func (cid *CodeIdentifier) MatchConst(c *ssa.NamedConst) bool {
+	if cid == nil || c == nil {
+		return false
+	}
+
+	pkg := c.Package().String()
+	return cid.computedRegexs.packageRegex.MatchString(pkg) && cid.computedRegexs.constRegex.MatchString(c.Name())
+}
+
+// MatchGlobal matches a named package-level constant to a code identifier.
+func (cid *CodeIdentifier) MatchGlobal(c *ssa.Global) bool {
 	if cid == nil || c == nil {
 		return false
 	}

--- a/analysis/config/config_test.go
+++ b/analysis/config/config_test.go
@@ -44,37 +44,37 @@ func checkNotEqualOnNonEmptyFields(t *testing.T, cid1 CodeIdentifier, cid2 CodeI
 }
 
 func TestCodeIdentifier_equalOnNonEmptyFields_selfEquals(t *testing.T) {
-	cid1 := CodeIdentifier{"", "a", "", "b", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid1 := CodeIdentifier{"", "a", "", "b", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
 	checkEqualOnNonEmptyFields(t, cid1, cid1)
 }
 
 func TestCodeIdentifier_equalOnNonEmptyFields_emptyMatchesAny(t *testing.T) {
-	cid1 := CodeIdentifier{"", "a", "b", "i", "c", "d", "e", "", "", "", "", nil, Target{}, CallingContext{}}
-	cid2 := CodeIdentifier{"", "de", "234jbn", "ef", "23kjb", "d", "234", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid1 := CodeIdentifier{"", "a", "b", "i", "c", "d", "e", "", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid2 := CodeIdentifier{"", "de", "234jbn", "ef", "23kjb", "d", "234", "", "", "", "", "", nil, Target{}, CallingContext{}}
 	cidEmpty := CodeIdentifier{}
 	checkEqualOnNonEmptyFields(t, cid1, cidEmpty)
 	checkEqualOnNonEmptyFields(t, cid2, cidEmpty)
 }
 
 func TestCodeIdentifier_equalOnNonEmptyFields_oneDiff(t *testing.T) {
-	cid1 := CodeIdentifier{"", "a", "b", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
-	cid2 := CodeIdentifier{"", "a", "", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid1 := CodeIdentifier{"", "a", "b", "", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid2 := CodeIdentifier{"", "a", "", "", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
 	checkEqualOnNonEmptyFields(t, cid1, cid2)
 	checkNotEqualOnNonEmptyFields(t, cid2, cid1)
 }
 
 func TestCodeIdentifier_equalOnNonEmptyFields_regexes(t *testing.T) {
-	cid1 := CodeIdentifier{"", "main", "b", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
-	cid1bis := CodeIdentifier{"", "command-line-arguments", "b", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
-	cid2 := CodeIdentifier{"", "(main)|(command-line-arguments)$", "", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid1 := CodeIdentifier{"", "main", "b", "", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid1bis := CodeIdentifier{"", "command-line-arguments", "b", "", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid2 := CodeIdentifier{"", "(main)|(command-line-arguments)$", "", "", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
 	checkEqualOnNonEmptyFields(t, cid1, cid2)
 	checkEqualOnNonEmptyFields(t, cid1bis, cid2)
 }
 
 func TestCodeIdentifier_equalOnNonEmptyFields_regexes_withContexts(t *testing.T) {
-	cid1 := CodeIdentifier{"main-package", "main", "", "b", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
-	cid1bis := CodeIdentifier{"main", "command-line-arguments", "", "b", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
-	cid2 := CodeIdentifier{"mai.*", "(main)|(command-line-arguments)$", "", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid1 := CodeIdentifier{"main-package", "main", "", "b", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid1bis := CodeIdentifier{"main", "command-line-arguments", "", "b", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
+	cid2 := CodeIdentifier{"mai.*", "(main)|(command-line-arguments)$", "", "", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
 	checkEqualOnNonEmptyFields(t, cid1, cid2)
 	checkEqualOnNonEmptyFields(t, cid1bis, cid2)
 }
@@ -447,8 +447,8 @@ func TestLoadMisc(t *testing.T) {
 		t,
 		"config.yaml",
 		mkConfig(
-			[]CodeIdentifier{{"", "a", "", "b", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
-			[]CodeIdentifier{{"", "c", "", "d", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
+			[]CodeIdentifier{{"", "a", "", "b", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
+			[]CodeIdentifier{{"", "c", "", "d", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
 			[]CodeIdentifier{},
 		),
 	)
@@ -456,20 +456,20 @@ func TestLoadMisc(t *testing.T) {
 	testLoadOneFile(t,
 		"config2.json",
 		mkConfig(
-			[]CodeIdentifier{{"", "x", "", "a", "", "b", "", "", "", "", "", nil, Target{}, CallingContext{}}},
-			[]CodeIdentifier{{"", "y", "", "b", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
-			[]CodeIdentifier{{"", "p", "", "a", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}},
-				{"", "p2", "", "a", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
+			[]CodeIdentifier{{"", "x", "", "a", "", "b", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
+			[]CodeIdentifier{{"", "y", "", "b", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
+			[]CodeIdentifier{{"", "p", "", "a", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}},
+				{"", "p2", "", "a", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
 		),
 	)
 	//
 	testLoadOneFile(t,
 		"config2.yaml",
 		mkConfig(
-			[]CodeIdentifier{{"", "x", "", "a", "", "b", "", "", "", "", "", nil, Target{}, CallingContext{}}},
-			[]CodeIdentifier{{"", "y", "", "b", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
-			[]CodeIdentifier{{"", "p", "", "a", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}},
-				{"", "p2", "", "a", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
+			[]CodeIdentifier{{"", "x", "", "a", "", "b", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
+			[]CodeIdentifier{{"", "y", "", "b", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
+			[]CodeIdentifier{{"", "p", "", "a", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}},
+				{"", "p2", "", "a", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
 		),
 	)
 	//
@@ -479,14 +479,14 @@ func TestLoadMisc(t *testing.T) {
 			DataflowProblems: DataflowProblems{
 				TaintTrackingProblems: []TaintSpec{
 					{
-						Sanitizers: []CodeIdentifier{{"", "pkg1", "", "Foo", "Obj", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
-						Sinks: []CodeIdentifier{{"", "y", "", "b", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}},
-							{"", "x", "", "", "Obj1", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
+						Sanitizers: []CodeIdentifier{{"", "pkg1", "", "Foo", "Obj", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
+						Sinks: []CodeIdentifier{{"", "y", "", "b", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}},
+							{"", "x", "", "", "Obj1", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}},
 						Sources: []CodeIdentifier{
-							{"", "some/package", "", "SuperMethod", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}},
+							{"", "some/package", "", "SuperMethod", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}},
 
-							{"", "some/other/package", "", "", "", "OneField", "ThatStruct", "", "", "", "", nil, Target{}, CallingContext{}},
-							{"", "some/other/package", "Interface", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}},
+							{"", "some/other/package", "", "", "", "OneField", "ThatStruct", "", "", "", "", "", nil, Target{}, CallingContext{}},
+							{"", "some/other/package", "Interface", "", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}},
 						},
 						FailOnImplicitFlow: false,
 					},
@@ -505,7 +505,7 @@ func TestLoadMisc(t *testing.T) {
 		},
 	)
 	// Test configuration file for static-commands
-	osExecCid := CodeIdentifier{"", "os/exec", "", "Command", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
+	osExecCid := CodeIdentifier{"", "os/exec", "", "Command", "", "", "", "", "", "", "", "", nil, Target{}, CallingContext{}}
 	cfg := NewDefault()
 	cfg.StaticCommandsProblems = []StaticCommandsSpec{{[]CodeIdentifier{osExecCid}}}
 	testLoadOneFile(t, "config-find-osexec.yaml", *cfg)

--- a/analysis/config/doc.go
+++ b/analysis/config/doc.go
@@ -65,12 +65,13 @@ The `dataflow-problems` section configures taint tracking and slicing analyses:
 	  summarize-on-demand: true
 	  field-sensitive-funcs: [".*"]
 	  user-specs: ["specifications/std-specs.json"]
-	  
+
 	  # Taint tracking problems
 	  taint-tracking:
 	    - tag: "credential-logging"
 	      description: "Checking that credentials don't get logged."
 	      targets: ["project-name-unix", "project-name-windows"]
+	      unsafe-skip-bound-labels: false
 	      severity: "HIGH"
 	      sources:
 	        - package: "credentials"
@@ -81,7 +82,7 @@ The `dataflow-problems` section configures taint tracking and slicing analyses:
 	      sanitizers:
 	        - package: ".*signer/v4"
 	          method: "Sign"
-	  
+
 	  # Slicing problems (backward dataflow)
 	  slicing:
 	    - tag: "must-compile-must-be-const"
@@ -109,7 +110,7 @@ The `syntactic-problems` section defines syntactic analysis checks:
 	          value:
 	            package: "crypto/tls"
 	            const: "VersionTLS12"
-	  
+
 	  # Conditional checks
 	  cond-checks:
 	    - tag: "resource-check-availability"
@@ -124,7 +125,7 @@ The `syntactic-problems` section defines syntactic analysis checks:
 
 The config uses [CodeIdentifier] to identify specific code entities. Code identifiers can specify:
 - `package`: Package name or regex pattern
-- `method`: Method/function name or regex pattern  
+- `method`: Method/function name or regex pattern
 - `type`: Type name or regex pattern
 - `context`: Context name or regex pattern
 - `const`: Constant name

--- a/analysis/dataflow/function_summary_graph_nodes.go
+++ b/analysis/dataflow/function_summary_graph_nodes.go
@@ -116,6 +116,8 @@ func Instr(node GraphNode) ssa.Instruction {
 		return node.Instr()
 	case *IfNode:
 		return node.SsaNode()
+	case *AccessGlobalNode:
+		return node.instr
 	}
 
 	return nil
@@ -272,7 +274,10 @@ func TermNodeSummary(g GraphNode) string {
 			formatutil.Green(x.fvPos),
 			x.ssaNode.Parent().String())
 	case *AccessGlobalNode:
-		return fmt.Sprintf("%s Global variable %s", nodeCode, formatutil.Red(x.Global.String()))
+		if x.IsWrite {
+			return fmt.Sprintf("%s Global variable write %s", nodeCode, formatutil.Yellow(x.Global.String()))
+		}
+		return fmt.Sprintf("%s Global variable read %s", nodeCode, formatutil.Red(x.Global.String()))
 	}
 	return ""
 }
@@ -299,7 +304,10 @@ func shortNodeSummary(g GraphNode) string {
 	case *FreeVarNode:
 		return "free-var"
 	case *AccessGlobalNode:
-		return fmt.Sprintf("global:%v", x.Global.Value())
+		if x.IsWrite {
+			return fmt.Sprintf("write-global:%v", x.Global.Value())
+		}
+		return fmt.Sprintf("read-global:%v", x.Global.Value())
 	}
 	return ""
 }

--- a/analysis/dataflow/inter_procedural.go
+++ b/analysis/dataflow/inter_procedural.go
@@ -382,6 +382,22 @@ func scanEntryPoints(
 		switch node := n.(type) {
 		case *SyntheticNode:
 			addSyntheticNodeEntryPoints(spec, entryPoints, node)
+		case *AccessGlobalNode:
+			// Global access is a load or store
+			ssaNode, isValue := node.Instr().(ssa.Node)
+			if !isValue {
+				return
+			}
+			if _, loads := node.Instr().(*ssa.UnOp); loads {
+				if _, ok := spec.IsEntryPointSsa(ssaNode); ok {
+					entry := NodeWithTrace{Node: node, Trace: nil, ClosureTrace: nil}
+					entryPoints[entry.Key()] = entry
+				}
+			}
+			if _, ok := spec.IsEntryPointSsa(ssaNode); ok {
+				entry := NodeWithTrace{Node: node, Trace: nil, ClosureTrace: nil}
+				entryPoints[entry.Key()] = entry
+			}
 		case *CallNodeArg:
 			if spec.MarkCallArgsLikeCall {
 				if _, ok := spec.IsEntryPointSsa(node.parent.CallSite().Value()); ok {

--- a/analysis/dataflow/inter_procedural.go
+++ b/analysis/dataflow/inter_procedural.go
@@ -388,12 +388,6 @@ func scanEntryPoints(
 			if !isValue {
 				return
 			}
-			if _, loads := node.Instr().(*ssa.UnOp); loads {
-				if _, ok := spec.IsEntryPointSsa(ssaNode); ok {
-					entry := NodeWithTrace{Node: node, Trace: nil, ClosureTrace: nil}
-					entryPoints[entry.Key()] = entry
-				}
-			}
 			if _, ok := spec.IsEntryPointSsa(ssaNode); ok {
 				entry := NodeWithTrace{Node: node, Trace: nil, ClosureTrace: nil}
 				entryPoints[entry.Key()] = entry

--- a/analysis/dataflow/intra_procedural_monotone_analysis.go
+++ b/analysis/dataflow/intra_procedural_monotone_analysis.go
@@ -155,6 +155,23 @@ func (state *IntraAnalysisState) markInstruction(i ssa.Instruction) {
 			if instr.Op == token.ARROW {
 				state.flowInfo.AddMark(i, instr, "", mark)
 			}
+			if instr.Op == token.MUL {
+				if glob, isGlob := instr.X.(*ssa.Global); isGlob {
+					gmark := state.flowInfo.GetNewMark(i.(ssa.Node), Global, glob, NonIndexMark)
+					state.flowInfo.AddMark(i, instr, "", gmark)
+				} else {
+					state.flowInfo.AddMark(i, instr, "", mark)
+				}
+			}
+		case *ssa.MakeInterface:
+			// Creating an interface can be a way to load a value
+			if glob, isGlob := instr.X.(*ssa.Global); isGlob {
+				gmark := state.flowInfo.GetNewMark(i.(ssa.Node), Global, glob, NonIndexMark)
+				state.flowInfo.AddMark(i, instr, "", gmark)
+			} else {
+				state.flowInfo.AddMark(i, instr, "", mark)
+			}
+
 		case *ssa.Alloc:
 			// Allocating a value of a certain type can be a source
 			state.flowInfo.AddMark(i, instr, "", mark)

--- a/analysis/dataflow/intra_procedural_monotone_analysis.go
+++ b/analysis/dataflow/intra_procedural_monotone_analysis.go
@@ -16,13 +16,12 @@ package dataflow
 
 import (
 	"fmt"
-	"go/token"
-	"go/types"
-
 	"github.com/awslabs/ar-go-tools/analysis/defers"
 	"github.com/awslabs/ar-go-tools/analysis/lang"
 	"github.com/awslabs/ar-go-tools/internal/analysisutil"
 	"github.com/awslabs/ar-go-tools/internal/pointer"
+	"go/token"
+	"go/types"
 	"golang.org/x/tools/go/ssa"
 )
 
@@ -140,10 +139,13 @@ func (state *IntraAnalysisState) markInstruction(i ssa.Instruction) {
 	switch instr := i.(type) {
 	case *ssa.MakeClosure:
 		state.markClosureNode(instr)
+		return
 	case *ssa.Call:
 		state.callCommonMark(instr, instr, instr.Common())
+		return
 	case *ssa.Go: // Analyze go like a function call, but a dedicated concurrency analysis should be used
 		state.callCommonMark(instr.Value(), instr, instr.Common())
+		return
 	}
 
 	// Instructions where marking is optional
@@ -155,23 +157,6 @@ func (state *IntraAnalysisState) markInstruction(i ssa.Instruction) {
 			if instr.Op == token.ARROW {
 				state.flowInfo.AddMark(i, instr, "", mark)
 			}
-			if instr.Op == token.MUL {
-				if glob, isGlob := instr.X.(*ssa.Global); isGlob {
-					gmark := state.flowInfo.GetNewMark(i.(ssa.Node), Global, glob, NonIndexMark)
-					state.flowInfo.AddMark(i, instr, "", gmark)
-				} else {
-					state.flowInfo.AddMark(i, instr, "", mark)
-				}
-			}
-		case *ssa.MakeInterface:
-			// Creating an interface can be a way to load a value
-			if glob, isGlob := instr.X.(*ssa.Global); isGlob {
-				gmark := state.flowInfo.GetNewMark(i.(ssa.Node), Global, glob, NonIndexMark)
-				state.flowInfo.AddMark(i, instr, "", gmark)
-			} else {
-				state.flowInfo.AddMark(i, instr, "", mark)
-			}
-
 		case *ssa.Alloc:
 			// Allocating a value of a certain type can be a source
 			state.flowInfo.AddMark(i, instr, "", mark)
@@ -312,9 +297,7 @@ func transfer(state *IntraAnalysisState, loc ssa.Instruction, in ssa.Value, out 
 // a value of true for pre indicates that field-sensitive value a prepended with indexing
 func transferPre(state *IntraAnalysisState, loc ssa.Instruction, in ssa.Value, out ssa.Value, path string,
 	index MarkIndex, pre bool) {
-	if glob, ok := in.(*ssa.Global); ok {
-		state.markValue(loc, out, "", state.flowInfo.GetNewMark(loc.(ssa.Node), Global, glob, index))
-	}
+	state.checkFlowFromGlobal(loc, in, out, index)
 	isFieldSensitive := state.flowInfo.pathSensitivityFilter[state.flowInfo.ValueID[out]]
 	for _, origin := range state.getMarks(loc, in, path, false) {
 		state.flowInfo.SetLoc(origin.Mark, loc)
@@ -333,6 +316,7 @@ func transferPre(state *IntraAnalysisState, loc ssa.Instruction, in ssa.Value, o
 
 // transferCopy propagates the marks for a load, which only requires copying over marks and paths
 func transferCopy(t *IntraAnalysisState, loc ssa.Instruction, in ssa.Value, out ssa.Value) {
+	t.checkFlowFromGlobal(loc, in, out, NonIndexMark)
 	pos, ok := t.flowInfo.GetPos(loc, in)
 	if !ok {
 		return
@@ -444,6 +428,12 @@ func (state *IntraAnalysisState) checkFlowIntoGlobal(loc ssa.Instruction, in, ou
 	}
 	for _, origin := range state.getMarks(loc, in, "", true) {
 		state.summary.addGlobalEdge(origin, nil, loc, glob)
+	}
+}
+
+func (state *IntraAnalysisState) checkFlowFromGlobal(loc ssa.Instruction, in ssa.Value, out ssa.Value, index MarkIndex) {
+	if glob, ok := in.(*ssa.Global); ok {
+		state.markValue(loc, out, "", state.flowInfo.GetNewMark(loc.(ssa.Node), Global, glob, index))
 	}
 }
 

--- a/analysis/taint/dataflow_visitor.go
+++ b/analysis/taint/dataflow_visitor.go
@@ -406,10 +406,12 @@ func (v *Visitor) Visit(s *df.State, source df.NodeWithTrace) {
 			df.CheckNoGoRoutine(s, goroutines, graphNode)
 
 			if cur.Status.Kind == df.ClosureTracing {
+				currentClosure := cur.Status.CurrentClosure()
 				if graphNode.CalleeSummary != nil &&
+					currentClosure != nil &&
 					// the following equality being true must imply that graphNode.CalleeSummary is a closure's summary
-					graphNode.CalleeSummary == cur.Status.CurrentClosure() {
-					fv := cur.Status.CurrentClosure().Parent.FreeVars[cur.Status.TracingInfo.Index]
+					graphNode.CalleeSummary == currentClosure {
+					fv := currentClosure.Parent.FreeVars[cur.Status.TracingInfo.Index]
 
 					if fv != nil {
 						nextNodeWithTrace := df.NodeWithTrace{

--- a/analysis/taint/testdata/globals/config.yaml
+++ b/analysis/taint/testdata/globals/config.yaml
@@ -8,7 +8,7 @@ dataflow-problems:
           # Sources can be source1, source2, etc.
           method: "source[1-9]?"
         - package: "(globals)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-          global: "globalSource[12]"
+          global: "globalSource[1-9]"
           kind: "load"
       sinks:
         - method: "sink[1-9]?"

--- a/analysis/taint/testdata/globals/config.yaml
+++ b/analysis/taint/testdata/globals/config.yaml
@@ -8,7 +8,7 @@ dataflow-problems:
           # Sources can be source1, source2, etc.
           method: "source[1-9]?"
         - package: "(globals)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
-          global: "globalSource"
+          global: "globalSource[12]"
           kind: "load"
       sinks:
         - method: "sink[1-9]?"

--- a/analysis/taint/testdata/globals/config.yaml
+++ b/analysis/taint/testdata/globals/config.yaml
@@ -7,5 +7,8 @@ dataflow-problems:
         - package: "(globals)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
           # Sources can be source1, source2, etc.
           method: "source[1-9]?"
+        - package: "(globals)|(main)|(command-line-arguments)|(git.amazon.com[[:graph:]]*)$"
+          global: "globalSource"
+          kind: "load"
       sinks:
         - method: "sink[1-9]?"

--- a/analysis/taint/testdata/globals/helpers.go
+++ b/analysis/taint/testdata/globals/helpers.go
@@ -51,3 +51,11 @@ func source2() R {
 func sink(_ ...any) {
 
 }
+
+func sinkStr(s string) {
+
+}
+
+func notSink(_ ...any) {
+
+}

--- a/analysis/taint/testdata/globals/main.go
+++ b/analysis/taint/testdata/globals/main.go
@@ -20,7 +20,8 @@ import (
 
 // TestTaintPropagatesThroughGlobal
 var x T
-var globalSource T // @Source(ex8)
+var globalSource1 T      // @Source(ex8)
+var globalSource2 string // @Source(ex9)
 
 func TestTaintPropagatesThroughGlobal() {
 	a := source1() // @Source(ex1)
@@ -90,17 +91,22 @@ func TestTaintPropagatesThroughPackageGlobal() {
 }
 
 func TestReadGlobalIsTainted() {
-	local := globalSource //@Source(ex6)
+	local := globalSource1 //@Source(ex6)
 	//local := T{}
 	sink(local.Data) // @Sink(ex6)
 }
 
 func TestGlobalAsArgIsTainted() {
-	sink(globalSource) // @Source(ex7) @Sink(ex7) global is loaded here
+	sink(globalSource1) // @Source(ex7) @Sink(ex7) global is loaded here
+	sink(globalSource2) // @Source(ex7bis) @Sink(ex7bis)
 }
 
 func TestGlobalRefAsArgIsTainted() {
-	sink(&globalSource) // @Sink(ex8)
+	sink(&globalSource1) // @Sink(ex8)
+}
+
+func TestGlobalRefAsArgIsTainted2() {
+	sink(&globalSource2) // @Sink(ex9)
 }
 
 func main() {
@@ -113,4 +119,5 @@ func main() {
 	TestReadGlobalIsTainted()
 	TestGlobalAsArgIsTainted()
 	TestGlobalRefAsArgIsTainted()
+	TestGlobalRefAsArgIsTainted2()
 }

--- a/analysis/taint/testdata/globals/main.go
+++ b/analysis/taint/testdata/globals/main.go
@@ -22,6 +22,7 @@ import (
 var x T
 var globalSource1 T      // @Source(ex8)
 var globalSource2 string // @Source(ex9)
+var globalSource3 *T
 
 func TestTaintPropagatesThroughGlobal() {
 	a := source1() // @Source(ex1)
@@ -31,6 +32,16 @@ func TestTaintPropagatesThroughGlobal() {
 
 func runX(s T) {
 	x = s
+}
+
+// Testing taint propagation through aliasing a global
+var myGlobal *T
+
+func TestTaintPropagatesThroughAliasingGlobal() {
+	myAlias := myGlobal
+	notSink(myAlias)
+	*myAlias = source1() // @Source(ex11)
+	sink(*myGlobal)      // @Sink(ex11)
 }
 
 // TestTaintDoesNotFollowDataflow
@@ -109,9 +120,17 @@ func TestGlobalRefAsArgIsTainted2() {
 	sink(&globalSource2) // @Sink(ex9)
 }
 
+func TestGlobalAliasAsArgIsTainted() {
+	local := globalSource3 // @Source(ex10)
+	notSink(local)
+	value := *local
+	sinkStr(value.Data) // @Sink(ex10)
+}
+
 func main() {
 	taintGlobalDoesNotFollowDataFlow()
 	TestTaintPropagatesThroughGlobal()
+	TestTaintPropagatesThroughAliasingGlobal()
 	TestTaintDoesNotFollowDataflow()
 	TestTaintGlobalThroughClosure()
 	TestTaintGlobalFromSlice()
@@ -120,4 +139,5 @@ func main() {
 	TestGlobalAsArgIsTainted()
 	TestGlobalRefAsArgIsTainted()
 	TestGlobalRefAsArgIsTainted2()
+	TestGlobalAliasAsArgIsTainted()
 }

--- a/analysis/taint/testdata/globals/main.go
+++ b/analysis/taint/testdata/globals/main.go
@@ -20,7 +20,7 @@ import (
 
 // TestTaintPropagatesThroughGlobal
 var x T
-var globalSource T
+var globalSource T // @Source(ex8)
 
 func TestTaintPropagatesThroughGlobal() {
 	a := source1() // @Source(ex1)
@@ -90,8 +90,17 @@ func TestTaintPropagatesThroughPackageGlobal() {
 }
 
 func TestReadGlobalIsTainted() {
-	y := globalSource //@Source(ex6)
-	sink(y.Data)      // @Sink(ex6)
+	local := globalSource //@Source(ex6)
+	//local := T{}
+	sink(local.Data) // @Sink(ex6)
+}
+
+func TestGlobalAsArgIsTainted() {
+	sink(globalSource) // @Source(ex7) @Sink(ex7) global is loaded here
+}
+
+func TestGlobalRefAsArgIsTainted() {
+	sink(&globalSource) // @Sink(ex8)
 }
 
 func main() {
@@ -102,4 +111,6 @@ func main() {
 	TestTaintGlobalFromSlice()
 	TestTaintPropagatesThroughPackageGlobal()
 	TestReadGlobalIsTainted()
+	TestGlobalAsArgIsTainted()
+	TestGlobalRefAsArgIsTainted()
 }

--- a/analysis/taint/testdata/globals/main.go
+++ b/analysis/taint/testdata/globals/main.go
@@ -20,6 +20,7 @@ import (
 
 // TestTaintPropagatesThroughGlobal
 var x T
+var globalSource T
 
 func TestTaintPropagatesThroughGlobal() {
 	a := source1() // @Source(ex1)
@@ -88,6 +89,11 @@ func TestTaintPropagatesThroughPackageGlobal() {
 	foo.CallSink() // see call to sink in foo package
 }
 
+func TestReadGlobalIsTainted() {
+	y := globalSource //@Source(ex6)
+	sink(y.Data)      // @Sink(ex6)
+}
+
 func main() {
 	taintGlobalDoesNotFollowDataFlow()
 	TestTaintPropagatesThroughGlobal()
@@ -95,4 +101,5 @@ func main() {
 	TestTaintGlobalThroughClosure()
 	TestTaintGlobalFromSlice()
 	TestTaintPropagatesThroughPackageGlobal()
+	TestReadGlobalIsTainted()
 }

--- a/analysis/taint/tracking.go
+++ b/analysis/taint/tracking.go
@@ -144,6 +144,18 @@ func Position(p *ssa.Program, instr ssa.Instruction) (token.Position, bool) {
 	if pos != token.NoPos && file != nil {
 		return file.Position(pos), true
 	}
-
+	// Sometimes the ssa creates extra instructions with no position, but the referrers might still have
+	// a position. We can try to find the position of the referrers.
+	if val, ok := instr.(ssa.Value); ok {
+		for _, i := range *val.Referrers() {
+			if i != nil {
+				pos = i.Pos()
+				file = p.Fset.File(pos)
+				if pos != token.NoPos && file != nil {
+					return file.Position(pos), true
+				}
+			}
+		}
+	}
 	return token.Position{}, false
 }

--- a/doc/01_taint.md
+++ b/doc/01_taint.md
@@ -135,6 +135,16 @@ dataflow-problems:
 ```
 This implies that any method whose receiver implements the `mypackage.interfaceName` interface will be seen as a sink.
 
+**Global Loads** are of the form:
+```yaml
+dataflow-problems:
+  - sources:
+      - package: "mypackage"
+        global: "varName"
+        kind: "load"
+```
+This implies that code that loads the global variable `varName` in `myPackage` will be considered to load tainted data.
+
 > The specifications for sources can be function calls, types, channel receives or field reads. The specifications sanitizers and validators can only be functions (method and package) or interfaces (interface name and package). The specifications for sinks can be functions calls and field writes.
 
 #### Code locations in a specific context

--- a/internal/analysisutil/analysisutil.go
+++ b/internal/analysisutil/analysisutil.go
@@ -108,6 +108,11 @@ func FindValuePackage(n ssa.Value) fn.Optional[string] {
 			return fn.Some(pkg.String())
 		}
 		return fn.None[string]()
+	case *ssa.Global:
+		if node.Pkg != nil {
+			return fn.Some(node.Pkg.String())
+		}
+		return fn.None[string]()
 	}
 	return fn.None[string]()
 }
@@ -281,24 +286,7 @@ func IsEntrypointNode(pointer *pointer.Result, n ssa.Node,
 			}
 			return config.CodeIdentifier{}, false
 		}
-		if global, isGlobal := node.Addr.(*ssa.Global); isGlobal {
-			packageName, typeName, err := FindEltTypePackage(global.Type().Underlying(), "%s")
-			if err != nil {
-				return config.CodeIdentifier{}, false
-			}
-			cid := config.CodeIdentifier{
-				Context:    node.Parent().String(),
-				Package:    packageName,
-				Type:       typeName,
-				Global:     node.Addr.Name(),
-				Kind:       "store",
-				ValueMatch: n.String(),
-			}
-			if f(cid) {
-				return cid, true
-			}
-		}
-		return config.CodeIdentifier{}, false
+		return isAccessGlobalEntryPoint(node, node.Addr, f)
 
 	// Channel receives can be sources
 	case *ssa.UnOp:
@@ -321,50 +309,42 @@ func IsEntrypointNode(pointer *pointer.Result, n ssa.Node,
 		}
 		// Reading a global variable
 		if node.Op == token.MUL {
-			if global, isGlobal := node.X.(*ssa.Global); isGlobal {
-				packageName, typeName, err := FindEltTypePackage(global.Type().Underlying(), "%s")
-				if err != nil {
-					return config.CodeIdentifier{}, false
-				}
-				cid := config.CodeIdentifier{
-					Context:    node.Parent().String(),
-					Package:    packageName,
-					Type:       typeName,
-					Global:     node.X.Name(),
-					Kind:       "load",
-					ValueMatch: n.String(),
-				}
-				if f(cid) {
-					return cid, true
-				}
-			}
+			return isAccessGlobalEntryPoint(node, node.X, f)
 		}
 		return config.CodeIdentifier{}, false
 
 	case *ssa.MakeInterface:
 		// Global is read an immediately cast to another interface type
-		if global, isGlobal := node.X.(*ssa.Global); isGlobal {
-			packageName, typeName, err := FindEltTypePackage(global.Type().Underlying(), "%s")
-			if err != nil {
-				return config.CodeIdentifier{}, false
-			}
-			cid := config.CodeIdentifier{
-				Context:    node.Parent().String(),
-				Package:    packageName,
-				Type:       typeName,
-				Global:     node.X.Name(),
-				Kind:       "load",
-				ValueMatch: n.String(),
-			}
-			if f(cid) {
-				return cid, true
-			}
-		}
-		return config.CodeIdentifier{}, false
+		return isAccessGlobalEntryPoint(node, node.X, f)
 
 	default:
 		return config.CodeIdentifier{}, false
 	}
+}
+
+func isAccessGlobalEntryPoint(
+	node ssa.Node,
+	subValue ssa.Value,
+	f func(config.CodeIdentifier) bool,
+) (config.CodeIdentifier, bool) {
+	global, isGlobal := subValue.(*ssa.Global)
+	if !isGlobal {
+		return config.CodeIdentifier{}, false
+	}
+	packageName := FindValuePackage(global).ValueOr("")
+	typeName := global.Type().String()
+	cid := config.CodeIdentifier{
+		Context:    node.Parent().String(),
+		Package:    packageName,
+		Type:       typeName,
+		Global:     global.Name(),
+		Kind:       "load",
+		ValueMatch: node.String(),
+	}
+	if f(cid) {
+		return cid, true
+	}
+	return config.CodeIdentifier{}, false
 }
 
 // newCodeIdentifierCall returns a code identifier for each possible object in the call.

--- a/internal/analysisutil/analysisutil.go
+++ b/internal/analysisutil/analysisutil.go
@@ -260,7 +260,7 @@ func IsEntrypointNode(pointer *pointer.Result, n ssa.Node,
 		}
 		return config.CodeIdentifier{}, false
 
-	// Storing into a specific struct field
+	// Storing into a specific struct field or global
 	case *ssa.Store:
 		if fieldAddr, isFieldAddr := node.Addr.(*ssa.FieldAddr); isFieldAddr {
 			fieldInfo := FieldAddrFieldInfo(fieldAddr)
@@ -280,6 +280,23 @@ func IsEntrypointNode(pointer *pointer.Result, n ssa.Node,
 				return cid, true
 			}
 			return config.CodeIdentifier{}, false
+		}
+		if global, isGlobal := node.Addr.(*ssa.Global); isGlobal {
+			packageName, typeName, err := FindEltTypePackage(global.Type().Underlying(), "%s")
+			if err != nil {
+				return config.CodeIdentifier{}, false
+			}
+			cid := config.CodeIdentifier{
+				Context:    node.Parent().String(),
+				Package:    packageName,
+				Type:       typeName,
+				Global:     node.Addr.Name(),
+				Kind:       "store",
+				ValueMatch: n.String(),
+			}
+			if f(cid) {
+				return cid, true
+			}
 		}
 		return config.CodeIdentifier{}, false
 
@@ -301,6 +318,26 @@ func IsEntrypointNode(pointer *pointer.Result, n ssa.Node,
 				return cid, true
 			}
 			return config.CodeIdentifier{}, false
+		}
+		// Reading a global variable
+		if node.Op == token.MUL {
+			if global, isGlobal := node.X.(*ssa.Global); isGlobal {
+				packageName, typeName, err := FindEltTypePackage(global.Type().Underlying(), "%s")
+				if err != nil {
+					return config.CodeIdentifier{}, false
+				}
+				cid := config.CodeIdentifier{
+					Context:    node.Parent().String(),
+					Package:    packageName,
+					Type:       typeName,
+					Global:     node.X.Name(),
+					Kind:       "load",
+					ValueMatch: n.String(),
+				}
+				if f(cid) {
+					return cid, true
+				}
+			}
 		}
 		return config.CodeIdentifier{}, false
 

--- a/internal/analysisutil/analysisutil.go
+++ b/internal/analysisutil/analysisutil.go
@@ -341,6 +341,27 @@ func IsEntrypointNode(pointer *pointer.Result, n ssa.Node,
 		}
 		return config.CodeIdentifier{}, false
 
+	case *ssa.MakeInterface:
+		// Global is read an immediately cast to another interface type
+		if global, isGlobal := node.X.(*ssa.Global); isGlobal {
+			packageName, typeName, err := FindEltTypePackage(global.Type().Underlying(), "%s")
+			if err != nil {
+				return config.CodeIdentifier{}, false
+			}
+			cid := config.CodeIdentifier{
+				Context:    node.Parent().String(),
+				Package:    packageName,
+				Type:       typeName,
+				Global:     node.X.Name(),
+				Kind:       "load",
+				ValueMatch: n.String(),
+			}
+			if f(cid) {
+				return cid, true
+			}
+		}
+		return config.CodeIdentifier{}, false
+
 	default:
 		return config.CodeIdentifier{}, false
 	}


### PR DESCRIPTION
Adds a feature: users can now specify that reading a global value can be a source of tainted data in the taint analysis.