### PR TITLE
feat: add prompt for generating a taint-tracking problem

### DIFF
--- a/cmd/argot-mcp-server/main.go
+++ b/cmd/argot-mcp-server/main.go
@@ -63,6 +63,9 @@ var dataflowPrompt string
 //go:embed config-generation-prompt.txt
 var configPrompt string
 
+//go:embed taint-tracking-definition-prompt.txt
+var taintPrompt string
+
 // jsonRPCRequest is plain struct representing a request sent to the server
 type jsonRPCRequest struct {
 	JSONRPC string      `json:"jsonrpc"`
@@ -424,6 +427,10 @@ func (s *serverState) handlePromptsList(req jsonRPCRequest) {
 			"name":        "config-generation",
 			"description": "Generate Argot configuration files with targets and analysis options",
 		},
+		{
+			"name":        "taint-tracking-definition",
+			"description": "Generate taint tracking problem definitions for Go codebases using Argot",
+		},
 	}
 	s.sendResponse(req.ID, map[string]interface{}{"prompts": prompts})
 }
@@ -470,6 +477,20 @@ func (s *serverState) handlePromptsGet(req jsonRPCRequest) {
 					"content": map[string]interface{}{
 						"type": "text",
 						"text": configPrompt,
+					},
+				},
+			},
+		}
+		s.sendResponse(req.ID, result)
+	case "taint-tracking-definition":
+		result := map[string]interface{}{
+			"description": "Generate taint tracking problem definitions for Go codebases using Argot",
+			"messages": []map[string]interface{}{
+				{
+					"role": "user",
+					"content": map[string]interface{}{
+						"type": "text",
+						"text": taintPrompt,
 					},
 				},
 			},

--- a/cmd/argot-mcp-server/mcp_test.go
+++ b/cmd/argot-mcp-server/mcp_test.go
@@ -390,6 +390,7 @@ func checkPrompts(t *testing.T, stdin io.WriteCloser, scanner *bufio.Scanner) {
 	}
 	foundDataflow := false
 	foundConfig := false
+	foundTaint := false
 	for _, prompt := range prompts {
 		promptMap, ok := prompt.(map[string]interface{})
 		if !ok {
@@ -402,6 +403,9 @@ func checkPrompts(t *testing.T, stdin io.WriteCloser, scanner *bufio.Scanner) {
 			if name == "config-generation" {
 				foundConfig = true
 			}
+			if name == "taint-tracking-definition" {
+				foundTaint = true
+			}
 		}
 	}
 	if !foundDataflow {
@@ -409,6 +413,9 @@ func checkPrompts(t *testing.T, stdin io.WriteCloser, scanner *bufio.Scanner) {
 	}
 	if !foundConfig {
 		t.Error("Expected config-generation prompt in prompts list")
+	}
+	if !foundTaint {
+		t.Error("Expected taint-tracking-definition prompt in prompts list")
 	}
 
 	// Test prompts get for dataflow-summary-generation
@@ -509,6 +516,56 @@ func checkPrompts(t *testing.T, stdin io.WriteCloser, scanner *bufio.Scanner) {
 	}
 	if !strings.Contains(configText, "targets") {
 		t.Error("Expected config prompt to contain 'targets'")
+	}
+
+	// Test prompts get for taint-tracking-definition
+	taintPromptReq := jsonRPCRequest{
+		JSONRPC: jsonRpcVersion,
+		ID:      10,
+		Method:  "prompts/get",
+		Params: map[string]interface{}{
+			"name": "taint-tracking-definition",
+		},
+	}
+	sendRequest(t, stdin, taintPromptReq)
+	response = readResponse(t, scanner)
+	var taintPromptResp jsonRPCResponse
+	if err := json.Unmarshal([]byte(response), &taintPromptResp); err != nil {
+		t.Fatal(err)
+	}
+	if taintPromptResp.Error != nil {
+		t.Fatalf("Taint prompt get failed: %v", taintPromptResp.Error)
+	}
+
+	// Check taint prompt content
+	taintResult, ok := taintPromptResp.Result.(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected taint prompt result to be a map")
+	}
+	taintMessages, ok := taintResult["messages"].([]interface{})
+	if !ok {
+		t.Fatal("Expected taint messages to be an array")
+	}
+	if len(taintMessages) == 0 {
+		t.Fatal("Expected at least one taint message")
+	}
+	taintMessage, ok := taintMessages[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected taint message to be a map")
+	}
+	taintContent, ok := taintMessage["content"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected taint content to be a map")
+	}
+	taintText, ok := taintContent["text"].(string)
+	if !ok {
+		t.Fatal("Expected taint text to be a string")
+	}
+	if !strings.Contains(taintText, "Taint Tracking Problem Definition Prompt") {
+		t.Error("Expected taint prompt to contain 'Taint Tracking Problem Definition Prompt'")
+	}
+	if !strings.Contains(taintText, "sources") {
+		t.Error("Expected taint prompt to contain 'sources'")
 	}
 }
 

--- a/cmd/argot-mcp-server/taint-tracking-definition-prompt.txt
+++ b/cmd/argot-mcp-server/taint-tracking-definition-prompt.txt
@@ -1,0 +1,274 @@
+# Taint Tracking Problem Definition Prompt
+
+You are a security-focused static analysis expert tasked with creating taint tracking problem definitions for Go codebases using the ar-go-tools (Argot) framework. Your goal is to identify potential security vulnerabilities by tracking the flow of untrusted data from sources to dangerous sinks.
+
+## Your Task
+
+Generate taint tracking problem definitions in YAML format that follow this structure:
+
+```yaml
+targets:
+  - name: <target name>
+    files: [ <list of files to load that define a main executable package> ]
+dataflow-problems:
+  summarize-on-demand: true
+  taint-tracking:
+    - tag: "problem-identifier"
+      description: "Clear description of the security issue being tracked."
+      targets:
+        - <target name defined in the targets: section of config>
+      unsafe-skip-bound-labels: false
+      severity: "HIGH|MEDIUM|LOW"
+      sources:
+        - package: "package.name"
+          method: "regex-pattern"
+      sinks:
+        - package: "package.name"
+          method: "regex-pattern"
+      sanitizers:
+        - package: "package.name"
+          method: "regex-pattern"
+```
+
+An advanced feature of the taint analysis allows you to specify dataflow summaries for the dataflow problems:
+```yaml
+dataflow-problems:
+    summarize-on-demand: true    # Whether to summarize ahead of time (false) or on-demand (true, recommended)
+    generate-unsoundness-report: true # Whether to generate a report of unsound functions/features encountered
+    user-specs:                  # A list of dataflow specification files
+        - "specs-mylib.json"     # Each element is a JSON file containing dataflow specifications
+```
+We explain in more detail how to write [dataflow specifications](#dataflow-specifications) later, and why users should write dataflow specifications in some cases.
+
+There are additional options for the outputs:
+```yaml
+options:
+  report-summaries: true    # The dataflow summaries built by the analysis
+                           # will be printed in a file in the reports directory
+
+  report-paths: true        # All paths from sources to sinks that have been
+                           # discovered will be printed in individual files
+                           # in the reports directory
+```
+
+And some other options specific to taint analysis problems:
+```yaml
+dataflow-problems:
+  taint-tracking:
+    - source-taints-args: false  # By default, the result of a call to a source
+                                # function is tainted. In some cases, you might want
+                                # to consider all arguments of a source function to be tainted
+                                # This option is set at the individual problem level
+```
+
+### Specifying Code Locations
+
+In the above example, you specify code locations for the elements that define your dataflow problem (sources, sinks, sanitizers and validators). The most common form for these *code identifiers* is shown above where a method and package are specified, e.g.:
+```yaml
+dataflow-problems:
+  taint-tracking:
+    - sources:
+        - package: "example1"
+          method: "GetSensitiveData"
+```
+This specifies that the method `GetSensitiveData` in package `example1` is a source. This means that the result of calling that function is considered tainted data (and the arguments if the `source-taints-args` option is set to true). The `method` field is used for both standalone functions and methods on types; for example, you can have a code identifier `method: "^len$"` that will exactly capture the len builtin, which could be useful if you want to specify that `len` is a sanitizer.
+
+**Important**: Regex patterns in the `method` field are scoped to the package specified in the `package` field. A pattern like `.*\\.Method.*` will only match functions/methods within that specific package.
+
+There are other possible code identifiers. For example, you can view any object of a given type as a source:
+```yaml
+dataflow-problems:
+  taint-tracking:
+    - sources:
+        - package: "mypackage"
+          type: "taintedDataType"
+```
+This implies that any object of type `taintedDataType` from package `mypackage` is a source of tainted data. Every allocation of an object of this type will be marked as a source. Other source specifications include channel receives and field reads.
+
+**Channel receives** have the following form:
+```yaml
+dataflow-problems:
+  taint-tracking:
+    - sources:
+        - package: "mypackage"
+          type: "chan A"
+          kind: "channel receive"
+```
+The difference compared to the previous specification is the `kind` attribute that explicitly specifies that only the action of receiving data from that type is considered a source. Here, any data read from a channel of type `chan A` in `mypackage` will be considered tainted (where `A` is the type within the `mypackage` package).
+
+**Field reads** have the form:
+```yaml
+dataflow-problems:
+  taint-tracking:
+    - sources:
+        - package: "mypackage"
+          type: "structA"
+          field: "taintedMember"
+```
+This implies that any access to the field `taintedMember` of a struct of type `structA` in package `mypackage` will be seen as a source of tainted data.
+
+**Field writes** have the form:
+```yaml
+dataflow-problems:
+  taint-tracking:
+    - sinks:
+        - package: "mypackage"
+          type: "structA"
+          field: "sensitiveStore"
+          kind: "store"
+```
+This implies that writing data to the field `sensitiveStore` of a struct of type `structA` defined in package `mypackage` will be seen as a sink for tainted data.
+
+**Interfaces** have the form:
+```yaml
+dataflow-problems:
+  taint-tracking:
+    - sinks:
+        - package: "mypackage"
+          interface: "interfaceName"
+          method: "MethodPattern.*"  # You must specify method patterns for interface matching
+```
+This implies that any method matching `MethodPattern.*` whose receiver implements the `mypackage.interfaceName` interface will be seen as a sink.
+
+**Global loads** have the form:
+```yaml
+dataflow-problems:
+  taint-tracking:
+    - sources:
+        - package: "mypackage"
+          global: "varName"
+          kind: "load"
+```
+This implies that code that loads the global variable `varName` in `mypackage` will be considered to load tainted data.
+
+> **Important**: Source specifications can be function calls, types, channel receives, or field reads. Sanitizer and validator specifications can only be functions (method and package) or interfaces (interface name and package). Sink specifications can be function calls or field writes.
+
+
+
+## Key Principles
+
+### 1. Identify Security-Critical Data Flows
+Focus on scenarios where untrusted input could lead to:
+- **Authentication bypass** (credentials, tokens, API keys)
+- **Injection attacks** (SQL, command, path traversal, XSS)
+- **Information disclosure** (sensitive data in logs, responses)
+- **Authorization bypass** (privilege escalation, access control)
+
+### 2. Source Identification
+Sources are entry points for untrusted data:
+- **User input**: Command-line arguments, prompts, configuration files
+- **Network input**: HTTP requests, API responses, external services
+- **File system**: User-controlled files, environment variables
+- **External processes**: Command output, subprocess results
+
+You must understand how conceptual sources of data (e.g., "HTTP requests") translate to precise functions called in the code.
+
+### 3. Sink Identification
+Sinks are dangerous operations that could be exploited:
+- **Execution sinks**: Command execution, code evaluation, file operations
+- **Output sinks**: Logging, error messages, HTTP responses, file writes
+- **Network sinks**: HTTP requests, database queries, external API calls
+- **Authentication sinks**: Login functions, token validation, session management
+
+You must understand how conceptual operations translate to real code function calls.
+
+### 4. Sanitizer Recognition
+Sanitizers are functions that clean or validate data:
+- **Validation functions**: Input validation, format checking, type conversion
+- **Encoding functions**: HTML encoding, URL encoding, escaping
+- **Filtering functions**: Allowlist/blocklist checking, pattern matching
+
+**Important**: Determining whether a function actually neutralizes a security threat versus just transforming data requires careful analysis. For example, `strings.Replace` could sanitize malicious input OR could be used to construct malicious payloads. You must evaluate the context and intended use to decide if a function should be considered a sanitizer.
+
+## Analysis Methodology
+
+### Step 1: Understand the Codebase
+1. Identify the main entry points and user interaction patterns
+2. Map out data flow from user input to critical operations
+3. Understand the security model and trust boundaries
+4. Identify existing security controls and validation mechanisms
+
+### Step 2: Threat Modeling
+1. Consider what an attacker might try to achieve
+2. Identify attack vectors and entry points
+3. Map potential impact of successful exploitation
+4. Prioritize based on likelihood and severity
+
+### Step 3: Pattern Matching
+Use regex patterns effectively:
+- **Broad patterns**: `.*\\.Method.*` to catch method variations
+- **Specific patterns**: `^ExactMethodName$` for precise matching
+- **Package wildcards**: `.*` to match any package when appropriate
+- **Method families**: `(Get|Post|Put|Delete).*` for related operations
+
+### Step 4: Validation and Testing
+1. Ensure sources actually produce untrusted data
+2. Verify sinks are genuinely dangerous without validation
+3. Confirm sanitizers actually neutralize the threat
+4. Test with realistic code examples
+
+## Common Taint Tracking Scenarios
+
+### Authentication and Authorization
+- **Token leakage**: Authentication tokens → logging/output functions
+- **Credential exposure**: Passwords/keys → error messages/responses
+- **Session hijacking**: Session data → untrusted storage/transmission
+
+### Injection Attacks
+- **Command injection**: User input → command execution functions
+- **Path traversal**: File paths → file system operations
+- **SQL injection**: User data → database query construction
+- **Template injection**: User content → template rendering
+
+### Information Disclosure
+- **Sensitive data logging**: Private data → logging frameworks
+- **Debug information**: Internal state → error responses
+- **Configuration exposure**: Secrets → configuration outputs
+
+### Network Security
+- **URL manipulation**: User URLs → HTTP client requests
+- **Header injection**: User data → HTTP headers
+- **Redirect attacks**: User URLs → redirect responses
+
+## Best Practices
+
+### Regex Patterns
+- Use `.*\\.` prefix for method patterns to match receivers
+- Include common variations: `(Print|Sprint|Fprint).*` for output functions
+- Consider case sensitivity and naming conventions
+- Test patterns against actual function names in the codebase
+
+### Severity Assessment
+- **HIGH**: Direct security impact (RCE, data breach, auth bypass)
+- **MEDIUM**: Potential security impact with additional conditions
+- **LOW**: Information disclosure or minor security concerns
+
+### Documentation
+- Write clear, actionable descriptions
+- Explain the security risk and potential impact
+- Include examples of vulnerable patterns when helpful
+- Reference relevant security standards (OWASP, CWE)
+
+## Example Template
+
+```yaml
+- tag: "descriptive-name"
+  description: "Explain what security issue this detects and why it matters."
+  targets: ["main/package/path"]
+  unsafe-skip-bound-labels: false
+  severity: "HIGH"
+  sources:
+    # Where untrusted data enters the system
+    - package: "user.input.package"
+      method: ".*Input.*"
+  sinks:
+    # Where that data could cause harm
+    - package: "dangerous.operation.package"
+      method: ".*Execute.*"
+  sanitizers:
+    # Functions that make the data safe
+    - package: "validation.package"
+      method: ".*Validate.*"
+```
+
+Remember: The goal is to find real security vulnerabilities, not just theoretical data flows. Focus on patterns that represent genuine security risks in the specific codebase you're analyzing.


### PR DESCRIPTION
Adds a new prompt in the argot MCP server. This lets LLMs work through defining a taint-tracking problem in a codebase, possibly using the other tools in the server to get information about the code. The relevant config format elements are provided in the prompt.